### PR TITLE
feat(desktop): display relative timestamps on note cards

### DIFF
--- a/crates/dirt-desktop/src/components/note_card.rs
+++ b/crates/dirt-desktop/src/components/note_card.rs
@@ -5,16 +5,63 @@ use dioxus::prelude::*;
 use super::card::{Card, CardContent};
 use crate::state::AppState;
 
+const MINUTE_MS: i64 = 60_000;
+const HOUR_MS: i64 = 60 * MINUTE_MS;
+const DAY_MS: i64 = 24 * HOUR_MS;
+const WEEK_MS: i64 = 7 * DAY_MS;
+
+fn format_relative_time(timestamp_ms: i64) -> String {
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let delta = (now_ms - timestamp_ms).max(0);
+
+    if delta < MINUTE_MS {
+        return "just now".to_string();
+    }
+    if delta < HOUR_MS {
+        let minutes = delta / MINUTE_MS;
+        return if minutes == 1 {
+            "1 minute ago".to_string()
+        } else {
+            format!("{minutes} minutes ago")
+        };
+    }
+    if delta < DAY_MS {
+        let hours = delta / HOUR_MS;
+        return if hours == 1 {
+            "1 hour ago".to_string()
+        } else {
+            format!("{hours} hours ago")
+        };
+    }
+    if delta < WEEK_MS {
+        let days = delta / DAY_MS;
+        return if days == 1 {
+            "1 day ago".to_string()
+        } else {
+            format!("{days} days ago")
+        };
+    }
+
+    let weeks = delta / WEEK_MS;
+    if weeks == 1 {
+        "1 week ago".to_string()
+    } else {
+        format!("{weeks} weeks ago")
+    }
+}
+
 /// A single note row rendered in the note list.
 #[component]
 pub fn NoteCard(
     title: String,
     preview: String,
+    updated_at_ms: i64,
     is_selected: bool,
     onclick: EventHandler<MouseEvent>,
 ) -> Element {
     let state = use_context::<AppState>();
     let colors = (state.theme)().palette();
+    let relative_time = format_relative_time(updated_at_ms);
 
     let bg = if is_selected {
         colors.bg_tertiary
@@ -76,6 +123,17 @@ pub fn NoteCard(
                             white-space: nowrap;
                         ",
                         "{preview}"
+                    }
+
+                    div {
+                        class: "note-timestamp",
+                        style: "
+                            margin-top: 4px;
+                            font-size: 11px;
+                            color: {colors.text_muted};
+                            white-space: nowrap;
+                        ",
+                        "{relative_time}"
                     }
                 }
             }

--- a/crates/dirt-desktop/src/components/note_list.rs
+++ b/crates/dirt-desktop/src/components/note_list.rs
@@ -39,12 +39,14 @@ pub fn NoteList() -> Element {
                         let is_selected = current_id == Some(note_id);
                         let title = note.title_preview(40);
                         let preview = note.title_preview(60);
+                        let updated_at_ms = note.updated_at;
 
                         rsx! {
                             NoteCard {
                                 key: "{note_id}",
                                 title,
                                 preview,
+                                updated_at_ms,
                                 is_selected,
                                 onclick: move |_| {
                                     state.current_note_id.set(Some(note_id));


### PR DESCRIPTION
## Summary
- add relative time formatting utility for note update timestamps
- pass note `updated_at` into `NoteCard` from `NoteList`
- render a human-readable timestamp in each note card (e.g. minutes/hours/days/weeks ago)

## Validation
- cargo check -p dirt-desktop
- cargo clippy --all-targets --all-features -- -D warnings

Closes #36
