### PR TITLE
feat(desktop): add sync status indicator

### DIFF
--- a/crates/dirt-desktop/assets/theme-overrides.css
+++ b/crates/dirt-desktop/assets/theme-overrides.css
@@ -117,6 +117,49 @@
   font-weight: 500;
 }
 
+.sync-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.sync-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.sync-synced {
+  color: var(--secondary-success-color);
+  background: color-mix(in srgb, var(--secondary-success-color) 15%, transparent);
+  border-color: color-mix(in srgb, var(--secondary-success-color) 40%, transparent);
+}
+
+.sync-syncing {
+  color: var(--secondary-info-color);
+  background: color-mix(in srgb, var(--secondary-info-color) 16%, transparent);
+  border-color: color-mix(in srgb, var(--secondary-info-color) 40%, transparent);
+}
+
+.sync-offline {
+  color: var(--secondary-warning-color);
+  background: color-mix(in srgb, var(--secondary-warning-color) 15%, transparent);
+  border-color: color-mix(in srgb, var(--secondary-warning-color) 35%, transparent);
+}
+
+.sync-error {
+  color: var(--secondary-error-color);
+  background: color-mix(in srgb, var(--secondary-error-color) 15%, transparent);
+  border-color: color-mix(in srgb, var(--secondary-error-color) 40%, transparent);
+}
+
 /* Search bar styling */
 .search-bar {
   padding: 12px 16px;

--- a/crates/dirt-desktop/src/components/toolbar.rs
+++ b/crates/dirt-desktop/src/components/toolbar.rs
@@ -1,17 +1,23 @@
 //! Toolbar component with actions
 
+use chrono::Utc;
 use dioxus::prelude::*;
 
 use super::button::{Button, ButtonVariant};
 use super::create_note_optimistic;
 use crate::queries::invalidate_notes_query;
-use crate::state::AppState;
+use crate::state::{AppState, SyncStatus};
 
 /// Toolbar with action buttons
 #[component]
 pub fn Toolbar() -> Element {
     let mut state = use_context::<AppState>();
     let has_selected_note = state.current_note().is_some();
+    let sync_status = (state.sync_status)();
+    let last_sync_at = (state.last_sync_at)();
+
+    let sync_status_text = format_sync_status_text(sync_status, last_sync_at);
+    let sync_status_class = sync_status_class(sync_status);
 
     let create_note = move |_| {
         create_note_optimistic(&mut state);
@@ -66,6 +72,13 @@ pub fn Toolbar() -> Element {
             // Spacer
             div { style: "flex: 1;" }
 
+            div {
+                class: "sync-indicator {sync_status_class}",
+                title: "{sync_status_text}",
+                span { class: "sync-dot" }
+                span { class: "sync-label", "{sync_status_text}" }
+            }
+
             // Settings button
             Button {
                 variant: ButtonVariant::Secondary,
@@ -73,5 +86,44 @@ pub fn Toolbar() -> Element {
                 "Settings"
             }
         }
+    }
+}
+
+const fn sync_status_class(status: SyncStatus) -> &'static str {
+    match status {
+        SyncStatus::Synced => "sync-synced",
+        SyncStatus::Syncing => "sync-syncing",
+        SyncStatus::Offline => "sync-offline",
+        SyncStatus::Error => "sync-error",
+    }
+}
+
+fn format_sync_status_text(status: SyncStatus, last_sync_at: Option<i64>) -> String {
+    match status {
+        SyncStatus::Synced => last_sync_at.map_or_else(
+            || "Synced".to_string(),
+            |timestamp| format!("Synced {}", format_relative_time(timestamp)),
+        ),
+        SyncStatus::Syncing => "Syncing...".to_string(),
+        SyncStatus::Offline => "Offline".to_string(),
+        SyncStatus::Error => "Sync error".to_string(),
+    }
+}
+
+fn format_relative_time(timestamp_ms: i64) -> String {
+    let now = Utc::now().timestamp_millis();
+    let diff = now.saturating_sub(timestamp_ms);
+    let minute = 60_000;
+    let hour = 60 * minute;
+    let day = 24 * hour;
+
+    if diff < minute {
+        "just now".to_string()
+    } else if diff < hour {
+        format!("{}m ago", diff / minute)
+    } else if diff < day {
+        format!("{}h ago", diff / hour)
+    } else {
+        format!("{}d ago", diff / day)
     }
 }

--- a/crates/dirt-desktop/src/state.rs
+++ b/crates/dirt-desktop/src/state.rs
@@ -11,6 +11,15 @@ use dirt_core::models::{Note, NoteId, Settings};
 use crate::services::DatabaseService;
 use crate::theme::ResolvedTheme;
 
+/// Current sync status for the app
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SyncStatus {
+    Synced,
+    Syncing,
+    Offline,
+    Error,
+}
+
 /// Global application state
 #[derive(Clone, Copy)]
 pub struct AppState {
@@ -28,6 +37,10 @@ pub struct AppState {
     pub theme: Signal<ResolvedTheme>,
     /// Database service (wrapped in Arc for sharing)
     pub db_service: Signal<Option<Arc<DatabaseService>>>,
+    /// Current sync status
+    pub sync_status: Signal<SyncStatus>,
+    /// Timestamp (unix ms) of the most recent successful sync
+    pub last_sync_at: Signal<Option<i64>>,
     /// Whether settings panel is open
     pub settings_open: Signal<bool>,
     /// Whether quick capture overlay is active


### PR DESCRIPTION
## Summary
- add desktop sync status state (`synced`, `syncing`, `offline`, `error`) to shared app state
- perform initial sync status detection after DB startup and update `last_sync_at` on success
- add periodic sync loop (30s) that updates status and last-sync metadata in real time
- render a sync status pill in the toolbar with relative "last synced" text
- style sync status states in `theme-overrides.css`

## Testing
- `cargo clippy -p dirt-desktop --all-targets -- -D warnings`
- `cargo test -p dirt-desktop --no-run`

Closes #28
