### PR TITLE
feat(core): implement LWW conflict resolution logging

### DIFF
--- a/crates/dirt-core/src/lib.rs
+++ b/crates/dirt-core/src/lib.rs
@@ -9,4 +9,4 @@ pub mod models;
 pub mod search;
 
 pub use error::{Error, Result};
-pub use models::{Note, NoteId};
+pub use models::{Note, NoteId, SyncConflict};

--- a/crates/dirt-core/src/models/mod.rs
+++ b/crates/dirt-core/src/models/mod.rs
@@ -2,8 +2,10 @@
 
 mod note;
 mod settings;
+mod sync_conflict;
 mod tag;
 
 pub use note::{extract_tags, Note, NoteId};
 pub use settings::{Settings, ThemeMode};
+pub use sync_conflict::SyncConflict;
 pub use tag::{Tag, TagId};

--- a/crates/dirt-core/src/models/sync_conflict.rs
+++ b/crates/dirt-core/src/models/sync_conflict.rs
@@ -1,0 +1,20 @@
+//! Sync conflict model
+
+use serde::{Deserialize, Serialize};
+
+/// Recorded sync conflict resolved by strategy (e.g., LWW)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SyncConflict {
+    /// Conflict row identifier
+    pub id: i64,
+    /// Note involved in the conflict
+    pub note_id: String,
+    /// Existing row's timestamp when conflict occurred
+    pub local_updated_at: i64,
+    /// Incoming row's timestamp that was rejected
+    pub incoming_updated_at: i64,
+    /// Resolution timestamp (unix ms)
+    pub resolved_at: i64,
+    /// Resolution strategy name
+    pub strategy: String,
+}


### PR DESCRIPTION
## Summary
- add schema migration v2 for conflict tracking (`sync_conflicts` table)
- add `notes_lww_conflict_guard` trigger to ignore stale updates (`NEW.updated_at < OLD.updated_at`) and log the conflict
- extend `NoteRepository` with `list_conflicts(limit)` and implement it in `LibSqlNoteRepository`
- add `SyncConflict` model and exports
- add tests for stale-update rejection/logging and newer-update acceptance

## Testing
- `cargo clippy -p dirt-core --all-targets -- -D warnings`
- `cargo test -p dirt-core`

Closes #27
