### PR TITLE
feat(cli): implement dirt edit command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,7 @@ dependencies = [
  "dirs",
  "dirt-core",
  "dotenvy",
+ "libsql",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/dirt-cli/Cargo.toml
+++ b/crates/dirt-cli/Cargo.toml
@@ -22,6 +22,7 @@ thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
+libsql.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- add dirt edit <id> command
- support exact UUID and unique ID-prefix resolution
- prefill editor with current note content and persist updates on save
- reject empty edited content and ambiguous/not-found IDs with clear errors
- add tests for prefix resolution and validation

## Validation
- cargo clippy -p dirt-cli --all-targets -- -D warnings
- cargo test -p dirt-cli
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #48