### PR TITLE
fix(desktop): harden Supabase auth configuration UX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,13 @@
 TURSO_DATABASE_URL=libsql://your-db-name.turso.io
 TURSO_AUTH_TOKEN=your-database-auth-token
 DIRT_ACCESS_TOKEN=
+
+# Supabase Auth (desktop sign-up/sign-in)
+# Example: https://your-project-ref.supabase.co
+SUPABASE_URL=
+# Use anon/public key (never use service_role in desktop app)
+SUPABASE_ANON_KEY=
+
+# Notes:
+# - Dev setup without SMTP: enable `mailer_autoconfirm` in Supabase Auth to bypass email delivery.
+# - Production setup: configure custom SMTP to avoid default email rate limits.

--- a/crates/dirt-desktop/src/services/mod.rs
+++ b/crates/dirt-desktop/src/services/mod.rs
@@ -5,5 +5,5 @@
 mod auth;
 mod database;
 
-pub use auth::{AuthSession, SignUpOutcome, SupabaseAuthService};
+pub use auth::{AuthConfigStatus, AuthSession, SignUpOutcome, SupabaseAuthService};
 pub use database::DatabaseService;


### PR DESCRIPTION
## Summary
- add Supabase auth configuration diagnostics API (erify_configuration) with status details
- add a Settings Verify Config action using the official Dioxus component library wrappers
- improve user-facing auth error messages for invalid email, rate-limit (429), and network issues
- update .env.example with Supabase variables and dev/prod auth setup notes (autoconfirm vs SMTP)
- add tests for auth error/config messaging behavior

## Validation
- cargo clippy -p dirt-desktop --all-targets -- -D warnings
- cargo test -p dirt-desktop
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #50