### PR TITLE
feat(cli): add shell completions command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "430b4dc2b5e3861848de79627b2bedc9f3342c7da5173a14eaa5d0f8dc18ae5d"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,6 +1492,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "clap_complete",
  "dirs",
  "dirt-core",
  "dotenvy",

--- a/crates/dirt-cli/Cargo.toml
+++ b/crates/dirt-cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 dirt-core = { path = "../dirt-core" }
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 tokio = { version = "1", features = ["full"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true


### PR DESCRIPTION
## Summary
- add dirt completions <shell> command for bash/zsh/fish generation
- support optional --output <path> (stdout by default)
- add tests to verify bash completion generation and file output
- add clap_complete dependency for script generation

## Testing
- cargo test -p dirt-cli
- cargo clippy -p dirt-cli --all-targets -- -D warnings
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

Closes #58