### PR TITLE
feat(mobile): add note list and editor UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,8 +1552,10 @@ version = "0.1.0"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
+ "dirs",
  "dirt-core",
  "dotenvy",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/dirt-mobile/Cargo.toml
+++ b/crates/dirt-mobile/Cargo.toml
@@ -15,6 +15,8 @@ dirt-core = { path = "../dirt-core" }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 dotenvy = "0.15"
+tokio.workspace = true
+dirs = "6"
 
 [target.'cfg(target_os = "android")'.dependencies]
 dioxus = { workspace = true, features = ["mobile"] }

--- a/crates/dirt-mobile/src/app.rs
+++ b/crates/dirt-mobile/src/app.rs
@@ -1,25 +1,434 @@
+use std::sync::Arc;
+
 use dioxus::prelude::*;
+use dioxus_primitives::scroll_area::{ScrollArea, ScrollDirection, ScrollType};
 use dioxus_primitives::separator::Separator;
+use dirt_core::{Note, NoteId};
+
+use crate::data::MobileNoteStore;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MobileView {
+    List,
+    Editor,
+}
 
 #[component]
 pub fn App() -> Element {
-    let placeholder = dirt_core::Note::new("Mobile shell ready #android");
-    let note_id = placeholder.id.to_string();
+    let mut store = use_signal(|| None::<Arc<MobileNoteStore>>);
+    let mut notes = use_signal(Vec::<Note>::new);
+    let mut selected_note_id = use_signal(|| None::<NoteId>);
+    let mut draft_content = use_signal(String::new);
+    let mut view = use_signal(|| MobileView::List);
+    let mut status_message = use_signal(|| None::<String>);
+    let mut loading = use_signal(|| true);
+    let mut saving = use_signal(|| false);
+    let mut deleting = use_signal(|| false);
+
+    use_future(move || async move {
+        match MobileNoteStore::open_default().await {
+            Ok(note_store) => {
+                let note_store = Arc::new(note_store);
+                match note_store.list_notes().await {
+                    Ok(loaded_notes) => {
+                        notes.set(loaded_notes);
+                        store.set(Some(note_store));
+                        status_message.set(None);
+                    }
+                    Err(error) => {
+                        status_message.set(Some(format!("Failed to load notes: {error}")));
+                    }
+                }
+            }
+            Err(error) => {
+                status_message.set(Some(format!("Failed to open database: {error}")));
+            }
+        }
+        loading.set(false);
+    });
+
+    let on_new_note = move |_| {
+        selected_note_id.set(None);
+        draft_content.set(String::new());
+        status_message.set(None);
+        view.set(MobileView::Editor);
+    };
+
+    let on_back_to_list = move |_| {
+        view.set(MobileView::List);
+    };
+
+    let on_save_note = move |_| {
+        if saving() {
+            return;
+        }
+
+        let Some(note_store) = store.read().clone() else {
+            status_message.set(Some("Database is not ready yet".to_string()));
+            return;
+        };
+
+        let content = draft_content().trim().to_string();
+        if content.is_empty() {
+            status_message.set(Some("Note content cannot be empty".to_string()));
+            return;
+        }
+
+        let current_note_id = selected_note_id();
+        saving.set(true);
+        status_message.set(Some("Saving note...".to_string()));
+
+        spawn(async move {
+            let save_result = if let Some(note_id) = current_note_id {
+                note_store.update_note(&note_id, &content).await
+            } else {
+                note_store.create_note(&content).await
+            };
+
+            match save_result {
+                Ok(saved_note) => {
+                    selected_note_id.set(Some(saved_note.id));
+                    draft_content.set(saved_note.content);
+
+                    match note_store.list_notes().await {
+                        Ok(fresh_notes) => {
+                            notes.set(fresh_notes);
+                            status_message.set(Some("Note saved".to_string()));
+                        }
+                        Err(error) => {
+                            status_message
+                                .set(Some(format!("Saved, but failed to refresh list: {error}")));
+                        }
+                    }
+                }
+                Err(error) => {
+                    status_message.set(Some(format!("Failed to save note: {error}")));
+                }
+            }
+
+            saving.set(false);
+        });
+    };
+
+    let on_delete_note = move |_| {
+        if deleting() {
+            return;
+        }
+
+        let Some(note_store) = store.read().clone() else {
+            status_message.set(Some("Database is not ready yet".to_string()));
+            return;
+        };
+        let Some(note_id) = selected_note_id() else {
+            status_message.set(Some("Select a note to delete".to_string()));
+            return;
+        };
+
+        deleting.set(true);
+        status_message.set(Some("Deleting note...".to_string()));
+
+        spawn(async move {
+            match note_store.delete_note(&note_id).await {
+                Ok(()) => {
+                    selected_note_id.set(None);
+                    draft_content.set(String::new());
+                    view.set(MobileView::List);
+
+                    match note_store.list_notes().await {
+                        Ok(fresh_notes) => {
+                            notes.set(fresh_notes);
+                            status_message.set(Some("Note deleted".to_string()));
+                        }
+                        Err(error) => {
+                            status_message.set(Some(format!(
+                                "Deleted, but failed to refresh list: {error}"
+                            )));
+                        }
+                    }
+                }
+                Err(error) => {
+                    status_message.set(Some(format!("Failed to delete note: {error}")));
+                }
+            }
+
+            deleting.set(false);
+        });
+    };
 
     rsx! {
         div {
-            style: "padding: 24px; font-family: sans-serif; line-height: 1.4;",
+            style: "
+                height: 100vh;
+                display: flex;
+                flex-direction: column;
+                background: #f6f8fb;
+                color: #111827;
+                font-family: system-ui, sans-serif;
+            ",
 
-            h1 { style: "font-size: 28px; margin: 0 0 8px 0;", "Dirt" }
-            p { style: "margin: 0;", "Android app shell initialized." }
+            div {
+                style: "
+                    padding: 14px 16px;
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                    background: #ffffff;
+                ",
+                h1 {
+                    style: "margin: 0; font-size: 22px;",
+                    "Dirt"
+                }
+                p {
+                    style: "margin: 0; color: #6b7280; font-size: 12px;",
+                    "F4.2 mobile list + editor"
+                }
+            }
 
             Separator {
                 decorative: true,
-                style: "height: 1px; background: #d4d4d8; margin: 12px 0;",
+                style: "height: 1px; background: #e5e7eb;",
             }
 
-            p { style: "margin: 0;", "dirt-core connected. Example note id: {note_id}" }
-            p { style: "margin: 8px 0 0 0;", "Next milestone: F4.2 note list + editor (mobile UI)." }
+            if let Some(message) = status_message() {
+                p {
+                    style: "margin: 0; padding: 10px 16px; font-size: 13px; color: #374151;",
+                    "{message}"
+                }
+                Separator {
+                    decorative: true,
+                    style: "height: 1px; background: #e5e7eb;",
+                }
+            }
+
+            if loading() {
+                div {
+                    style: "
+                        flex: 1;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        color: #6b7280;
+                    ",
+                    "Loading notes..."
+                }
+            } else if view() == MobileView::List {
+                div {
+                    style: "padding: 12px 16px;",
+                    button {
+                        type: "button",
+                        style: "
+                            width: 100%;
+                            border: 0;
+                            border-radius: 10px;
+                            padding: 12px;
+                            background: #111827;
+                            color: #ffffff;
+                            font-weight: 600;
+                            font-size: 14px;
+                        ",
+                        onclick: on_new_note,
+                        "New note"
+                    }
+                }
+
+                ScrollArea {
+                    direction: ScrollDirection::Vertical,
+                    scroll_type: ScrollType::Auto,
+                    tabindex: "0",
+                    style: "flex: 1; padding: 0 12px 16px 12px;",
+
+                    if notes().is_empty() {
+                        div {
+                            style: "
+                                margin-top: 24px;
+                                padding: 20px;
+                                background: #ffffff;
+                                border: 1px solid #e5e7eb;
+                                border-radius: 12px;
+                                text-align: center;
+                                color: #6b7280;
+                            ",
+                            "No notes yet. Create your first note."
+                        }
+                    } else {
+                        for note in notes() {
+                            {
+                                let note_id = note.id;
+                                let note_content = note.content.clone();
+                                let title = note_title(&note);
+                                let preview = note_preview(&note);
+                                let updated = relative_time(note.updated_at);
+                                let selected = selected_note_id() == Some(note_id);
+                                let border_color = if selected { "#2563eb" } else { "#e5e7eb" };
+                                let card_style = format!(
+                                    "margin-bottom: 10px;\
+                                     width: 100%;\
+                                     border: 1px solid {border_color};\
+                                     background: #ffffff;\
+                                     border-radius: 12px;\
+                                     padding: 12px;\
+                                     text-align: left;"
+                                );
+
+                                rsx! {
+                                    button {
+                                        key: "{note_id}",
+                                        type: "button",
+                                        style: "{card_style}",
+                                        onclick: move |_| {
+                                            selected_note_id.set(Some(note_id));
+                                            draft_content.set(note_content.clone());
+                                            status_message.set(None);
+                                            view.set(MobileView::Editor);
+                                        },
+
+                                        p {
+                                            style: "
+                                                margin: 0 0 6px 0;
+                                                font-size: 15px;
+                                                font-weight: 600;
+                                                color: #111827;
+                                            ",
+                                            "{title}"
+                                        }
+                                        p {
+                                            style: "
+                                                margin: 0 0 6px 0;
+                                                font-size: 13px;
+                                                color: #6b7280;
+                                            ",
+                                            "{preview}"
+                                        }
+                                        p {
+                                            style: "margin: 0; font-size: 12px; color: #9ca3af;",
+                                            "Updated {updated}"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                div {
+                    style: "
+                        padding: 10px 12px;
+                        display: flex;
+                        gap: 8px;
+                        background: #ffffff;
+                    ",
+                    button {
+                        type: "button",
+                        style: "
+                            border: 1px solid #d1d5db;
+                            border-radius: 8px;
+                            padding: 10px 12px;
+                            background: #ffffff;
+                            font-weight: 600;
+                        ",
+                        onclick: on_back_to_list,
+                        "Back"
+                    }
+                    button {
+                        type: "button",
+                        style: "
+                            border: 0;
+                            border-radius: 8px;
+                            padding: 10px 12px;
+                            background: #2563eb;
+                            color: #ffffff;
+                            font-weight: 600;
+                        ",
+                        disabled: saving(),
+                        onclick: on_save_note,
+                        if saving() { "Saving..." } else { "Save" }
+                    }
+                    if selected_note_id().is_some() {
+                        button {
+                            type: "button",
+                            style: "
+                                margin-left: auto;
+                                border: 1px solid #ef4444;
+                                border-radius: 8px;
+                                padding: 10px 12px;
+                                background: #ffffff;
+                                color: #b91c1c;
+                                font-weight: 600;
+                            ",
+                            disabled: deleting(),
+                            onclick: on_delete_note,
+                            if deleting() { "Deleting..." } else { "Delete" }
+                        }
+                    }
+                }
+
+                Separator {
+                    decorative: true,
+                    style: "height: 1px; background: #e5e7eb;",
+                }
+
+                textarea {
+                    style: "
+                        flex: 1;
+                        margin: 12px;
+                        border: 1px solid #d1d5db;
+                        border-radius: 12px;
+                        padding: 14px;
+                        line-height: 1.5;
+                        font-size: 15px;
+                        resize: none;
+                        background: #ffffff;
+                    ",
+                    value: "{draft_content}",
+                    placeholder: "Write your note...",
+                    oninput: move |event: Event<FormData>| {
+                        draft_content.set(event.value());
+                    },
+                }
+            }
         }
+    }
+}
+
+fn note_title(note: &Note) -> String {
+    let title = note.title_preview(48);
+    if title.trim().is_empty() {
+        "Untitled note".to_string()
+    } else {
+        title
+    }
+}
+
+fn note_preview(note: &Note) -> String {
+    let preview = note
+        .content
+        .lines()
+        .skip(1)
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or("")
+        .trim()
+        .chars()
+        .take(80)
+        .collect::<String>();
+
+    if preview.is_empty() {
+        "Tap to open".to_string()
+    } else {
+        preview
+    }
+}
+
+fn relative_time(updated_at_ms: i64) -> String {
+    let now = chrono::Utc::now().timestamp_millis();
+    let delta = (now - updated_at_ms).max(0);
+
+    if delta < 60_000 {
+        "just now".to_string()
+    } else if delta < 3_600_000 {
+        format!("{}m ago", delta / 60_000)
+    } else if delta < 86_400_000 {
+        format!("{}h ago", delta / 3_600_000)
+    } else {
+        format!("{}d ago", delta / 86_400_000)
     }
 }

--- a/crates/dirt-mobile/src/data.rs
+++ b/crates/dirt-mobile/src/data.rs
@@ -1,0 +1,128 @@
+//! Data access layer for the mobile app.
+
+#[cfg(target_os = "android")]
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use dirt_core::db::{Database, LibSqlNoteRepository, NoteRepository};
+use dirt_core::models::{Note, NoteId};
+use dirt_core::{Error, Result};
+use tokio::sync::Mutex;
+
+const DEFAULT_NOTES_LIMIT: usize = 100;
+
+/// Thin async wrapper around `dirt-core` note repository APIs.
+#[derive(Clone)]
+pub struct MobileNoteStore {
+    db: Arc<Mutex<Database>>,
+}
+
+impl MobileNoteStore {
+    /// Open the default local mobile database path.
+    #[cfg(target_os = "android")]
+    pub async fn open_default() -> Result<Self> {
+        let db_path = default_db_path();
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let db = Database::open(db_path).await?;
+        Ok(Self {
+            db: Arc::new(Mutex::new(db)),
+        })
+    }
+
+    /// Open an in-memory database for tests.
+    #[cfg(test)]
+    pub async fn open_in_memory() -> Result<Self> {
+        let db = Database::open_in_memory().await?;
+        Ok(Self {
+            db: Arc::new(Mutex::new(db)),
+        })
+    }
+
+    /// List notes newest-first.
+    pub async fn list_notes(&self) -> Result<Vec<Note>> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.list(DEFAULT_NOTES_LIMIT, 0).await
+    }
+
+    /// Create a note.
+    pub async fn create_note(&self, content: &str) -> Result<Note> {
+        let normalized = normalize_content(content)?;
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.create(&normalized).await
+    }
+
+    /// Update an existing note.
+    pub async fn update_note(&self, id: &NoteId, content: &str) -> Result<Note> {
+        let normalized = normalize_content(content)?;
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.update(id, &normalized).await
+    }
+
+    /// Soft delete a note.
+    pub async fn delete_note(&self, id: &NoteId) -> Result<()> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.delete(id).await
+    }
+}
+
+fn normalize_content(content: &str) -> Result<String> {
+    let normalized = content.trim();
+    if normalized.is_empty() {
+        return Err(Error::InvalidInput(
+            "Note content cannot be empty".to_string(),
+        ));
+    }
+    Ok(normalized.to_string())
+}
+
+/// Build a mobile-friendly local DB path.
+#[cfg(target_os = "android")]
+pub fn default_db_path() -> PathBuf {
+    dirs::data_local_dir()
+        .or_else(dirs::data_dir)
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("dirt")
+        .join("dirt-mobile.db")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn create_update_delete_roundtrip() {
+        let store = MobileNoteStore::open_in_memory().await.unwrap();
+
+        let created = store.create_note("  Hello mobile  ").await.unwrap();
+        assert_eq!(created.content, "Hello mobile");
+
+        let updated = store
+            .update_note(&created.id, "Updated #mobile")
+            .await
+            .unwrap();
+        assert_eq!(updated.content, "Updated #mobile");
+        assert_eq!(updated.id, created.id);
+
+        store.delete_note(&updated.id).await.unwrap();
+        let notes = store.list_notes().await.unwrap();
+        assert!(notes.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn create_rejects_empty_content() {
+        let store = MobileNoteStore::open_in_memory().await.unwrap();
+        let err = store.create_note("   ").await.unwrap_err();
+
+        match err {
+            Error::InvalidInput(msg) => assert!(msg.contains("cannot be empty")),
+            other => panic!("expected invalid input error, got {other:?}"),
+        }
+    }
+}

--- a/crates/dirt-mobile/src/main.rs
+++ b/crates/dirt-mobile/src/main.rs
@@ -4,6 +4,8 @@
 
 #[cfg(target_os = "android")]
 mod app;
+#[cfg(any(target_os = "android", test))]
+mod data;
 
 #[cfg(target_os = "android")]
 fn main() {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -187,8 +187,8 @@ dirt/
 
 | ID | Feature | Priority | Status | Blocks |
 |----|---------|----------|--------|--------|
-| F4.1 | Dioxus Android app shell | P0 | Todo | F1.4 |
-| F4.2 | Note list + editor (mobile UI) | P0 | Todo | F4.1 |
+| F4.1 | Dioxus Android app shell | P0 | Done | F1.4 |
+| F4.2 | Note list + editor (mobile UI) | P0 | Done | F4.1 |
 | F4.3 | Quick capture widget | P1 | Todo | F4.2 |
 | F4.4 | Share intent receiver | P1 | Todo | F4.2 |
 | F4.5 | Push notifications for sync | P2 | Todo | F2.4, F4.1 |


### PR DESCRIPTION
## Summary
- implement F4.2 mobile note list + editor in `crates/dirt-mobile`
- add `MobileNoteStore` data layer backed by `dirt-core` repository CRUD
- replace shell placeholder with real list/editor flows and mobile state/actions
- use Dioxus official primitives (`ScrollArea`, `Separator`) in the mobile UI
- add `dirt-mobile` tests for CRUD roundtrip + empty-content validation
- mark F4.1 and F4.2 as `Done` in roadmap table

Closes #62

## Validation
- cargo fmt --all
- cargo check -p dirt-mobile
- cargo test -p dirt-mobile
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

## Notes
- `cargo check -p dirt-mobile --target aarch64-linux-android` was attempted but this machine does not have the target installed (`rustup target add aarch64-linux-android` required).