### PR TITLE
feat(mobile): add app-side sync notifications

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -190,8 +190,8 @@ dirt/
 | F4.1 | Dioxus Android app shell | P0 | Done | F1.4 |
 | F4.2 | Note list + editor (mobile UI) | P0 | Done | F4.1 |
 | F4.3 | Quick capture widget | P1 | In Progress | F4.2 |
-| F4.4 | Share intent receiver | P1 | In Progress | F4.2 |
-| F4.5 | Push notifications for sync | P2 | Todo | F2.4, F4.1 |
+| F4.4 | Share intent receiver | P1 | Done | F4.2 |
+| F4.5 | Push notifications for sync | P2 | In Progress | F2.4, F4.1 |
 
 ### Phase 5: Media Support
 **Goal**: Attach images, audio, files to notes


### PR DESCRIPTION
## Summary
- add Turso sync auto-detection to MobileNoteStore via TURSO_DATABASE_URL and TURSO_AUTH_TOKEN
- add initial + periodic sync loop in mobile app with status tracking
- use official Dioxus component library (dioxus_primitives::toast) to notify sync failure/recovery
- update roadmap status for F4.4/F4.5

## Testing
- cargo fmt --all
- cargo check -p dirt-mobile
- cargo test -p dirt-mobile
- cargo clippy -p dirt-mobile --all-targets -- -D warnings
- cargo test --workspace

Closes #68