### PR TITLE
feat(core): add authenticated R2 object operations

### DIFF
--- a/crates/dirt-core/Cargo.toml
+++ b/crates/dirt-core/Cargo.toml
@@ -16,14 +16,14 @@ regex.workspace = true
 libsql.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+aws-credential-types = "1"
+aws-sdk-s3 = { version = "1", features = ["behavior-version-latest"] }
+aws-types = "1"
 
 [dev-dependencies]
 pretty_assertions.workspace = true
 tempfile = "3"
 dotenvy = "0.15"
-aws-credential-types = "1"
-aws-sdk-s3 = { version = "1", features = ["behavior-version-latest"] }
-aws-types = "1"
 
 [lints]
 workspace = true

--- a/crates/dirt-core/src/error.rs
+++ b/crates/dirt-core/src/error.rs
@@ -31,4 +31,8 @@ pub enum Error {
     /// Serialization error
     #[error("Serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
+
+    /// Media/object storage error
+    #[error("Storage error: {0}")]
+    Storage(String),
 }


### PR DESCRIPTION
## Summary
- implement authenticated R2 object operations in dirt-core
- add bucket_is_reachable, upload_bytes, object_exists, and delete_object APIs on R2Storage
- add storage-focused error mapping and input validation
- add ignored integration coverage for upload -> exists -> delete roundtrip

## Testing
- cargo fmt --all
- cargo test -p dirt-core
- cargo clippy -p dirt-core --all-targets
- cargo test -p dirt-core r2_bucket_exists_and_is_reachable -- --ignored
- cargo test -p dirt-core r2_object_roundtrip_upload_exists_delete -- --ignored

Closes #76