### PR TITLE
feat(desktop): add optional transcription service foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4030,6 +4030,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5366,6 +5376,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -5374,6 +5385,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -6834,6 +6846,12 @@ checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/dirt-desktop/Cargo.toml
+++ b/crates/dirt-desktop/Cargo.toml
@@ -26,7 +26,7 @@ dotenvy = "0.15"
 image = "0.25"
 dioxus-primitives = { git = "https://github.com/DioxusLabs/components", version = "0.0.1", default-features = false }
 dioxus-query = "0.9.2"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 keyring = "3.6.2"
 thiserror.workspace = true
 

--- a/crates/dirt-desktop/src/services/mod.rs
+++ b/crates/dirt-desktop/src/services/mod.rs
@@ -4,6 +4,9 @@
 
 mod auth;
 mod database;
+mod transcription;
 
 pub use auth::{AuthConfigStatus, AuthSession, SignUpOutcome, SupabaseAuthService};
 pub use database::DatabaseService;
+#[allow(unused_imports)] // Exported for follow-up voice memo wiring.
+pub use transcription::{TranscriptionConfigStatus, TranscriptionError, TranscriptionService};

--- a/crates/dirt-desktop/src/services/transcription.rs
+++ b/crates/dirt-desktop/src/services/transcription.rs
@@ -1,0 +1,256 @@
+//! Optional audio transcription service foundation.
+#![allow(dead_code)] // Foundation module; full wiring lands in follow-up issue.
+
+use reqwest::{multipart, Client, Request, StatusCode};
+use serde::Deserialize;
+use thiserror::Error;
+
+const ENV_OPENAI_API_KEY: &str = "OPENAI_API_KEY";
+const ENV_OPENAI_TRANSCRIPTION_MODEL: &str = "OPENAI_TRANSCRIPTION_MODEL";
+const ENV_OPENAI_BASE_URL: &str = "OPENAI_BASE_URL";
+
+const DEFAULT_MODEL: &str = "gpt-4o-mini-transcribe";
+const DEFAULT_BASE_URL: &str = "https://api.openai.com";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum TranscriptionMode {
+    Disabled,
+    OpenAi {
+        base_url: String,
+        api_key: String,
+        model: String,
+    },
+}
+
+/// Basic configuration status for transcription.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TranscriptionConfigStatus {
+    pub enabled: bool,
+    pub provider: &'static str,
+    pub model: Option<String>,
+}
+
+/// Errors from transcription service setup and requests.
+#[derive(Debug, Error)]
+pub enum TranscriptionError {
+    #[error("Transcription is not configured. Set OPENAI_API_KEY to enable it.")]
+    NotConfigured,
+    #[error("Invalid transcription configuration: {0}")]
+    InvalidConfiguration(&'static str),
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("Transcription API error: {0}")]
+    Api(String),
+}
+
+type TranscriptionResult<T> = Result<T, TranscriptionError>;
+
+#[derive(Clone)]
+pub struct TranscriptionService {
+    client: Client,
+    mode: TranscriptionMode,
+}
+
+impl TranscriptionService {
+    /// Build transcription service from environment.
+    pub fn new_from_env() -> TranscriptionResult<Self> {
+        let api_key = std::env::var(ENV_OPENAI_API_KEY)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+
+        let mode = if let Some(api_key) = api_key {
+            let base_url = std::env::var(ENV_OPENAI_BASE_URL)
+                .ok()
+                .map(|value| value.trim().trim_end_matches('/').to_string())
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| DEFAULT_BASE_URL.to_string());
+
+            if !(base_url.starts_with("https://") || base_url.starts_with("http://")) {
+                return Err(TranscriptionError::InvalidConfiguration(
+                    "OPENAI_BASE_URL must start with http:// or https://",
+                ));
+            }
+
+            let model = std::env::var(ENV_OPENAI_TRANSCRIPTION_MODEL)
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+
+            TranscriptionMode::OpenAi {
+                base_url,
+                api_key,
+                model,
+            }
+        } else {
+            TranscriptionMode::Disabled
+        };
+
+        Ok(Self {
+            client: Client::builder().build()?,
+            mode,
+        })
+    }
+
+    #[must_use]
+    pub fn config_status(&self) -> TranscriptionConfigStatus {
+        match &self.mode {
+            TranscriptionMode::Disabled => TranscriptionConfigStatus {
+                enabled: false,
+                provider: "none",
+                model: None,
+            },
+            TranscriptionMode::OpenAi { model, .. } => TranscriptionConfigStatus {
+                enabled: true,
+                provider: "openai",
+                model: Some(model.clone()),
+            },
+        }
+    }
+
+    /// Transcribe WAV bytes into text (when configured).
+    pub async fn transcribe_wav_bytes(
+        &self,
+        file_name: &str,
+        wav_bytes: Vec<u8>,
+    ) -> TranscriptionResult<String> {
+        if file_name.trim().is_empty() {
+            return Err(TranscriptionError::InvalidConfiguration(
+                "file_name must not be empty",
+            ));
+        }
+        if wav_bytes.is_empty() {
+            return Err(TranscriptionError::InvalidConfiguration(
+                "audio payload must not be empty",
+            ));
+        }
+
+        let request = self.build_transcription_request(file_name, wav_bytes)?;
+        let response = self.client.execute(request).await?;
+
+        if response.status() == StatusCode::UNAUTHORIZED {
+            return Err(TranscriptionError::Api(
+                "Unauthorized transcription request (check OPENAI_API_KEY)".to_string(),
+            ));
+        }
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(TranscriptionError::Api(format!(
+                "Transcription request failed with {status}: {body}"
+            )));
+        }
+
+        let payload: OpenAiTranscriptionResponse = response.json().await?;
+        Ok(payload.text.trim().to_string())
+    }
+
+    fn build_transcription_request(
+        &self,
+        file_name: &str,
+        wav_bytes: Vec<u8>,
+    ) -> TranscriptionResult<Request> {
+        let (base_url, api_key, model) = match &self.mode {
+            TranscriptionMode::Disabled => return Err(TranscriptionError::NotConfigured),
+            TranscriptionMode::OpenAi {
+                base_url,
+                api_key,
+                model,
+            } => (base_url, api_key, model),
+        };
+
+        let endpoint = format!("{base_url}/v1/audio/transcriptions");
+        let file_part = multipart::Part::bytes(wav_bytes)
+            .file_name(file_name.to_string())
+            .mime_str("audio/wav")
+            .map_err(TranscriptionError::Http)?;
+
+        let form = multipart::Form::new()
+            .text("model", model.clone())
+            .part("file", file_part);
+
+        self.client
+            .post(endpoint)
+            .bearer_auth(api_key)
+            .multipart(form)
+            .build()
+            .map_err(TranscriptionError::Http)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiTranscriptionResponse {
+    text: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn configured_service() -> TranscriptionService {
+        TranscriptionService {
+            client: Client::builder().build().unwrap(),
+            mode: TranscriptionMode::OpenAi {
+                base_url: "https://api.openai.com".to_string(),
+                api_key: "test-key".to_string(),
+                model: "gpt-4o-mini-transcribe".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn disabled_status_when_not_configured() {
+        let service = TranscriptionService {
+            client: Client::builder().build().unwrap(),
+            mode: TranscriptionMode::Disabled,
+        };
+
+        let status = service.config_status();
+        assert!(!status.enabled);
+        assert_eq!(status.provider, "none");
+        assert_eq!(status.model, None);
+    }
+
+    #[test]
+    fn openai_request_shape_is_correct() {
+        let service = configured_service();
+        let request = service
+            .build_transcription_request("memo.wav", vec![0, 1, 2, 3])
+            .unwrap();
+
+        assert_eq!(request.method(), reqwest::Method::POST);
+        assert_eq!(
+            request.url().as_str(),
+            "https://api.openai.com/v1/audio/transcriptions"
+        );
+
+        let auth = request
+            .headers()
+            .get(reqwest::header::AUTHORIZATION)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(auth.starts_with("Bearer "));
+    }
+
+    #[test]
+    fn request_fails_when_disabled() {
+        let service = TranscriptionService {
+            client: Client::builder().build().unwrap(),
+            mode: TranscriptionMode::Disabled,
+        };
+        let err = service
+            .build_transcription_request("memo.wav", vec![1, 2, 3])
+            .unwrap_err();
+        assert!(matches!(err, TranscriptionError::NotConfigured));
+    }
+
+    #[test]
+    fn parse_openai_response_text() {
+        let payload: OpenAiTranscriptionResponse =
+            serde_json::from_str(r#"{"text":"hello world"}"#).unwrap();
+        assert_eq!(payload.text, "hello world");
+    }
+}


### PR DESCRIPTION
## Summary
- add an optional transcription service module in desktop services
- load OpenAI transcription config from env with explicit validation errors
- add request/response shaping + unit tests for config and payload behavior

## Validation
- cargo fmt --all
- cargo test -p dirt-desktop
- cargo clippy -p dirt-desktop --all-targets

Closes #88