### PR TITLE
feat(desktop): support general file attachment drop uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,6 +1968,7 @@ dependencies = [
  "global-hotkey 0.6.4",
  "image",
  "keyring",
+ "mime_guess",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/dirt-desktop/Cargo.toml
+++ b/crates/dirt-desktop/Cargo.toml
@@ -28,6 +28,7 @@ dioxus-primitives = { git = "https://github.com/DioxusLabs/components", version 
 dioxus-query = "0.9.2"
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 keyring = "3.6.2"
+mime_guess = "2.0"
 thiserror.workspace = true
 
 [lints]


### PR DESCRIPTION
## Summary
- expand desktop note editor drop handling to support non-image file attachments
- keep image markdown insertion for image MIME types and use standard link markdown for other file types
- improve MIME inference with extension fallback for generic attachments

## Validation
- cargo fmt --all
- cargo test -p dirt-desktop
- cargo clippy -p dirt-desktop --all-targets -- -D warnings

Closes #90