### PR TITLE
feat(desktop): show attachment metadata panel in editor

### DIFF
--- a/crates/dirt-desktop/src/services/database.rs
+++ b/crates/dirt-desktop/src/services/database.rs
@@ -208,6 +208,13 @@ impl DatabaseService {
             .await
     }
 
+    /// List non-deleted attachment metadata for a note
+    pub async fn list_attachments(&self, note_id: &NoteId) -> Result<Vec<Attachment>> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.list_attachments(note_id).await
+    }
+
     /// Load settings from database
     pub async fn load_settings(&self) -> Result<Settings> {
         let db = self.db.lock().await;


### PR DESCRIPTION
## Summary
- add desktop database service support to list note attachments
- load and render an attachment panel in the note editor for the selected note
- show attachment filename, type label, and formatted size with loading/empty/error states
- refresh attachment panel after successful attachment upload
- add unit tests for attachment display helpers

## Validation
- cargo fmt --all
- cargo test -p dirt-desktop
- cargo clippy -p dirt-desktop --all-targets -- -D warnings

Closes #92