### PR TITLE
feat(desktop): add attachment delete action in editor panel

### DIFF
--- a/crates/dirt-desktop/src/services/database.rs
+++ b/crates/dirt-desktop/src/services/database.rs
@@ -10,7 +10,7 @@ use dirt_core::db::{
     SyncConfig,
 };
 use dirt_core::error::Result;
-use dirt_core::models::{Attachment, Note, Settings};
+use dirt_core::models::{Attachment, AttachmentId, Note, Settings};
 use dirt_core::NoteId;
 use tokio::sync::Mutex;
 
@@ -213,6 +213,13 @@ impl DatabaseService {
         let db = self.db.lock().await;
         let repo = LibSqlNoteRepository::new(db.connection());
         repo.list_attachments(note_id).await
+    }
+
+    /// Soft delete attachment metadata by id
+    pub async fn delete_attachment(&self, attachment_id: &AttachmentId) -> Result<()> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.delete_attachment(attachment_id).await
     }
 
     /// Load settings from database


### PR DESCRIPTION
## Summary
- add desktop database service support for deleting attachment metadata
- add per-attachment delete action in note editor panel
- refresh attachment panel after delete and surface delete errors to the user

## Validation
- cargo fmt --all
- cargo test -p dirt-desktop
- cargo clippy -p dirt-desktop --all-targets -- -D warnings

Closes #96