### PR TITLE
feat(desktop): add open action for attachment rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,6 +1977,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tray-icon 0.19.3",
+ "webbrowser",
 ]
 
 [[package]]

--- a/crates/dirt-desktop/Cargo.toml
+++ b/crates/dirt-desktop/Cargo.toml
@@ -29,6 +29,7 @@ dioxus-query = "0.9.2"
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 keyring = "3.6.2"
 mime_guess = "2.0"
+webbrowser = "1.0"
 thiserror.workspace = true
 
 [lints]


### PR DESCRIPTION
## Summary
- add an Open action to desktop attachment rows
- resolve attachment URLs via R2 public base when configured, with 2:// fallback
- surface open failures in the editor as non-fatal errors
- add helper tests for attachment URL resolution behavior

## Validation
- cargo fmt --all
- cargo test -p dirt-desktop
- cargo clippy -p dirt-desktop --all-targets -- -D warnings

Closes #103