### PR TITLE
Align desktop export with CLI and document parity matrix

### DIFF
--- a/crates/dirt-core/src/export.rs
+++ b/crates/dirt-core/src/export.rs
@@ -1,0 +1,100 @@
+//! Shared note export helpers for CLI/Desktop/Mobile parity.
+
+use std::fmt::Write as _;
+
+use serde::{Deserialize, Serialize};
+
+use crate::Note;
+
+/// Serializable note representation used in JSON and Markdown exports.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExportNote {
+    pub id: String,
+    pub content: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub tags: Vec<String>,
+}
+
+/// Convert a note into an export record with stable tag ordering.
+#[must_use]
+pub fn note_to_export_item(note: &Note) -> ExportNote {
+    let mut tags = note.tags();
+    tags.sort();
+
+    ExportNote {
+        id: note.id.to_string(),
+        content: note.content.clone(),
+        created_at: note.created_at,
+        updated_at: note.updated_at,
+        tags,
+    }
+}
+
+/// Render notes as pretty-printed JSON.
+pub fn render_json_export(notes: &[Note]) -> serde_json::Result<String> {
+    let items = notes
+        .iter()
+        .map(note_to_export_item)
+        .collect::<Vec<ExportNote>>();
+    serde_json::to_string_pretty(&items)
+}
+
+/// Render notes in Markdown with frontmatter blocks.
+#[must_use]
+pub fn render_markdown_export(notes: &[Note]) -> String {
+    let mut output = String::new();
+
+    for (index, note) in notes.iter().enumerate() {
+        if index > 0 {
+            output.push('\n');
+        }
+
+        let export_note = note_to_export_item(note);
+        let _ = writeln!(output, "---");
+        let _ = writeln!(output, "id: {}", export_note.id);
+        let _ = writeln!(output, "created_at: {}", export_note.created_at);
+        let _ = writeln!(output, "updated_at: {}", export_note.updated_at);
+        let _ = writeln!(output, "tags:");
+        for tag in export_note.tags {
+            let _ = writeln!(output, "  - {tag}");
+        }
+        let _ = writeln!(output, "---");
+        let _ = writeln!(output);
+        output.push_str(&export_note.content);
+        output.push('\n');
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn note_to_export_item_sorts_tags() {
+        let note = Note::new("#zeta test #alpha #beta");
+        let export = note_to_export_item(&note);
+
+        assert_eq!(export.tags, vec!["alpha", "beta", "zeta"]);
+    }
+
+    #[test]
+    fn render_markdown_export_includes_frontmatter_and_content() {
+        let note = Note {
+            id: "cccccccc-cccc-7ccc-8ccc-111111111111".parse().unwrap(),
+            content: "Hello export #tag".to_string(),
+            created_at: 123,
+            updated_at: 456,
+            is_deleted: false,
+        };
+
+        let rendered = render_markdown_export(&[note]);
+        assert!(rendered.contains("id: cccccccc-cccc-7ccc-8ccc-111111111111"));
+        assert!(rendered.contains("created_at: 123"));
+        assert!(rendered.contains("updated_at: 456"));
+        assert!(rendered.contains("tags:\n  - tag"));
+        assert!(rendered.contains("Hello export #tag"));
+    }
+}

--- a/crates/dirt-core/src/lib.rs
+++ b/crates/dirt-core/src/lib.rs
@@ -5,9 +5,11 @@
 
 pub mod db;
 pub mod error;
+pub mod export;
 pub mod models;
 pub mod search;
 pub mod storage;
 
 pub use error::{Error, Result};
+pub use export::ExportNote;
 pub use models::{Attachment, AttachmentId, Note, NoteId, SyncConflict};

--- a/crates/dirt-desktop/src/services/export.rs
+++ b/crates/dirt-desktop/src/services/export.rs
@@ -1,0 +1,121 @@
+//! Note export service for desktop UI parity with CLI exports.
+
+use std::path::Path;
+
+use dirt_core::export::{render_json_export, render_markdown_export};
+use dirt_core::Note;
+use thiserror::Error;
+
+use super::DatabaseService;
+
+const PAGE_SIZE: usize = 500;
+
+/// Export output format.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NotesExportFormat {
+    Json,
+    Markdown,
+}
+
+impl NotesExportFormat {
+    #[must_use]
+    pub const fn extension(self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Markdown => "md",
+        }
+    }
+}
+
+/// Errors emitted by desktop note export flows.
+#[derive(Debug, Error)]
+pub enum NotesExportError {
+    #[error(transparent)]
+    Database(#[from] dirt_core::Error),
+    #[error(transparent)]
+    Serialization(#[from] serde_json::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+/// Export all non-deleted notes to the destination path.
+pub async fn export_notes_to_path(
+    db: &DatabaseService,
+    format: NotesExportFormat,
+    output_path: &Path,
+) -> Result<usize, NotesExportError> {
+    let notes = list_all_notes(db).await?;
+    let rendered = match format {
+        NotesExportFormat::Json => render_json_export(&notes)?,
+        NotesExportFormat::Markdown => render_markdown_export(&notes),
+    };
+
+    std::fs::write(output_path, rendered)?;
+    Ok(notes.len())
+}
+
+/// Build a deterministic default file name for save dialogs.
+#[must_use]
+pub fn suggested_export_file_name(format: NotesExportFormat, timestamp_ms: i64) -> String {
+    let extension = format.extension();
+    format!("dirt-export-{timestamp_ms}.{extension}")
+}
+
+async fn list_all_notes(db: &DatabaseService) -> Result<Vec<Note>, dirt_core::Error> {
+    let mut notes = Vec::new();
+    let mut offset = 0usize;
+
+    loop {
+        let batch = db.list_notes(PAGE_SIZE, offset).await?;
+        let count = batch.len();
+        notes.extend(batch);
+
+        if count < PAGE_SIZE {
+            break;
+        }
+        offset += count;
+    }
+
+    Ok(notes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::DatabaseService;
+
+    #[test]
+    fn suggested_export_file_name_uses_format_extension() {
+        assert_eq!(
+            suggested_export_file_name(NotesExportFormat::Json, 123),
+            "dirt-export-123.json"
+        );
+        assert_eq!(
+            suggested_export_file_name(NotesExportFormat::Markdown, 456),
+            "dirt-export-456.md"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn export_notes_to_path_writes_markdown() {
+        let db = DatabaseService::in_memory().await.unwrap();
+        db.create_note("Desktop export #one").await.unwrap();
+        db.create_note("Desktop export #two").await.unwrap();
+
+        let output_path = std::env::temp_dir().join(format!(
+            "dirt-desktop-export-test-{}.md",
+            chrono::Utc::now().timestamp_millis()
+        ));
+
+        let exported_count = export_notes_to_path(&db, NotesExportFormat::Markdown, &output_path)
+            .await
+            .unwrap();
+        assert_eq!(exported_count, 2);
+
+        let exported = std::fs::read_to_string(&output_path).unwrap();
+        assert!(exported.contains("Desktop export #one"));
+        assert!(exported.contains("Desktop export #two"));
+
+        let _ = std::fs::remove_file(output_path);
+    }
+}

--- a/crates/dirt-desktop/src/services/mod.rs
+++ b/crates/dirt-desktop/src/services/mod.rs
@@ -4,9 +4,11 @@
 
 mod auth;
 mod database;
+mod export;
 mod transcription;
 
 pub use auth::{AuthConfigStatus, AuthSession, SignUpOutcome, SupabaseAuthService};
 pub use database::DatabaseService;
+pub use export::{export_notes_to_path, suggested_export_file_name, NotesExportFormat};
 #[allow(unused_imports)] // Exported for follow-up voice memo wiring.
 pub use transcription::{TranscriptionConfigStatus, TranscriptionError, TranscriptionService};

--- a/docs/feature-parity.md
+++ b/docs/feature-parity.md
@@ -1,0 +1,23 @@
+# Feature Parity Matrix
+
+Last updated: 2026-02-08
+
+This matrix tracks product parity across active Dirt clients.
+
+| Capability | Desktop (`dirt-desktop`) | CLI (`dirt-cli`) | Mobile (`dirt-mobile`) |
+| --- | --- | --- | --- |
+| Create note | Yes | Yes | Android shell only (not implemented) |
+| List/search notes | Yes | Yes | Android shell only (not implemented) |
+| Edit/delete notes | Yes | Yes | Android shell only (not implemented) |
+| Quick capture | Yes (global hotkey + tray) | Yes (single-command capture) | Android shell only (not implemented) |
+| Settings (theme/font/hotkey) | Yes | N/A | Android shell only (not implemented) |
+| Auth + sync status UI | Yes | Partial (`sync` command only) | Android shell only (not implemented) |
+| Attachments | Yes | No | Android shell only (not implemented) |
+| Export JSON | Yes | Yes | No |
+| Export Markdown | Yes | Yes | No |
+
+## Follow-up gaps
+
+- Mobile app needs baseline note CRUD/search UI before feature parity work can start.
+- CLI does not support attachments yet.
+- CLI has no interactive auth/session UX; it only runs `sync` with env-based credentials.


### PR DESCRIPTION
## Summary
- add shared export module in dirt-core for JSON + Markdown rendering (ExportNote, ender_json_export, ender_markdown_export)
- switch CLI export to shared core helpers to avoid format drift
- add desktop export service and wire export actions into Settings (Export JSON / Export Markdown)
- add feature parity matrix doc covering Desktop/CLI/Mobile capabilities and known gaps

## Validation
- cargo fmt --all
- cargo test -p dirt-core
- cargo test -p dirt-cli -- --test-threads=1
- cargo test -p dirt-desktop
- cargo clippy -p dirt-core -p dirt-cli -p dirt-desktop --all-targets -- -D warnings

Closes #108