### PR TITLE
Use button primitives for sidebar tags and note cards

### DIFF
--- a/crates/dirt-desktop/src/components/note_card.rs
+++ b/crates/dirt-desktop/src/components/note_card.rs
@@ -2,6 +2,7 @@
 
 use dioxus::prelude::*;
 
+use super::button::{Button, ButtonVariant};
 use super::card::{Card, CardContent};
 use crate::state::AppState;
 
@@ -75,14 +76,18 @@ pub fn NoteCard(
     };
 
     rsx! {
-        div {
+        Button {
+            variant: ButtonVariant::Ghost,
             class: if is_selected { "note-item selected" } else { "note-item" },
             style: "
+                width: 100%;
+                padding: 0;
                 border-bottom: 1px solid {colors.border_light};
                 border-left: {border_left};
-                cursor: pointer;
                 background: {bg};
                 transition: background 0.15s;
+                border-radius: 0;
+                text-align: left;
             ",
             onclick: move |evt| onclick.call(evt),
 

--- a/crates/dirt-desktop/src/components/sidebar.rs
+++ b/crates/dirt-desktop/src/components/sidebar.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use dioxus::prelude::*;
 
+use super::button::{Button, ButtonVariant};
 use crate::state::AppState;
 
 /// Sidebar showing tags and filters
@@ -111,11 +112,12 @@ fn TagItem(
     };
 
     rsx! {
-        div {
+        Button {
+            variant: ButtonVariant::Ghost,
             style: "
+                width: 100%;
                 padding: 8px 10px;
                 border-radius: 6px;
-                cursor: pointer;
                 margin-bottom: 4px;
                 background: {bg};
                 color: {text_color};


### PR DESCRIPTION
## Summary
- replace raw clickable div in Sidebar::TagItem with Button primitive wrapper
- replace raw clickable div in NoteCard with Button primitive wrapper
- preserve existing selection visuals and click behavior while improving primitive consistency/accessibility

## Validation
- cargo fmt --all
- cargo test -p dirt-desktop
- cargo clippy -p dirt-desktop --all-targets -- -D warnings

Closes #110