### PR TITLE
fix(mobile): recover DB init and prevent not-ready dead-end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,6 +2171,7 @@ dependencies = [
 name = "dirt-mobile"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "dioxus",
  "dioxus-primitives",
  "dirs",

--- a/crates/dirt-mobile/Cargo.toml
+++ b/crates/dirt-mobile/Cargo.toml
@@ -16,6 +16,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 dotenvy = "0.15"
 tokio.workspace = true
+chrono.workspace = true
 dirs = "6"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/crates/dirt-mobile/src/launch.rs
+++ b/crates/dirt-mobile/src/launch.rs
@@ -31,12 +31,15 @@ pub struct LaunchIntent {
 /// Detect launch intent settings from process arguments and environment.
 #[cfg(target_os = "android")]
 pub fn detect_launch_intent_from_runtime() -> LaunchIntent {
-    let args: Vec<String> = std::env::args().collect();
     let env_quick_content = std::env::var(QUICK_CAPTURE_ENV_CONTENT).ok();
     let env_quick_enabled = std::env::var(QUICK_CAPTURE_ENV_ENABLED).ok();
     let env_share_text = std::env::var(SHARE_TEXT_ENV_CONTENT).ok();
+
+    // Android NativeActivity launches do not provide reliable process argv.
+    // Reading std::env::args() can crash on some devices/emulators, so use
+    // environment-based intent metadata only.
     parse_launch_intent(
-        args.iter().map(std::string::String::as_str),
+        ["dirt-mobile"],
         env_quick_content.as_deref(),
         env_quick_enabled.as_deref(),
         env_share_text.as_deref(),


### PR DESCRIPTION
## Summary\n- add mobile local-replica recovery for libSQL bootstrap failures (including metadata/db mismatch and corrupted local file states)\n- add retryable DB initialization UX so users are not stuck with Database is not ready yet dead-end\n- gate list actions while DB is unavailable and show a dedicated retry panel\n- apply Android-safe launch intent detection (env-based only) to avoid argv crashes on NativeActivity\n- include current mobile header cleanup: remove hardcoded F4.5 sync notifications label and hide sync banner in local-only mode\n\n## Validation\n- cargo fmt --all\n- cargo test -p dirt-mobile\n- cargo clippy -p dirt-mobile --all-targets -- -D warnings\n\nCloses #115