### PR TITLE
refactor(mobile): remove in-app quick capture screen

### DIFF
--- a/crates/dirt-mobile/src/app.rs
+++ b/crates/dirt-mobile/src/app.rs
@@ -97,7 +97,7 @@ fn AppShell() -> Element {
     let mut attachments_loading = use_signal(|| false);
     let mut attachments_error = use_signal(|| None::<String>);
     let attachment_refresh_version = use_signal(|| 0u64);
-    let db_init_retry_version = use_signal(|| 0u64);
+    let mut db_init_retry_version = use_signal(|| 0u64);
     let launch: Signal<LaunchIntent> = use_signal(crate::launch::detect_launch_intent_from_runtime);
     let mut launch_applied = use_signal(|| false);
     let toasts = use_toast();


### PR DESCRIPTION
## Summary
- remove the dedicated in-app Quick Capture view and actions from dirt-mobile
- keep quick-capture launch intent support by seeding the normal note editor instead
- keep widget/share behavior focused on a single save flow in the editor

## Validation
- cargo fmt --all
- cargo test -p dirt-mobile
- cargo clippy -p dirt-mobile --all-targets -- -D warnings

Fixes #124