### PR TITLE
ci: add Android target compile check for dirt-mobile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,9 +184,10 @@ jobs:
           export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$ANDROID_HOME}"
           export ANDROID_NDK_ROOT="$ANDROID_SDK_ROOT/ndk/26.3.11579264"
           export TOOLCHAIN="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          test -x "$TOOLCHAIN/clang"
-          export CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$TOOLCHAIN/clang"
-          export CC_x86_64_linux_android="$TOOLCHAIN/clang"
-          export CXX_x86_64_linux_android="$TOOLCHAIN/clang++"
+          export ANDROID_API=24
+          test -x "$TOOLCHAIN/x86_64-linux-android${ANDROID_API}-clang"
+          export CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$TOOLCHAIN/x86_64-linux-android${ANDROID_API}-clang"
+          export CC_x86_64_linux_android="$TOOLCHAIN/x86_64-linux-android${ANDROID_API}-clang"
+          export CXX_x86_64_linux_android="$TOOLCHAIN/x86_64-linux-android${ANDROID_API}-clang++"
           export AR_x86_64_linux_android="$TOOLCHAIN/llvm-ar"
           cargo check -p dirt-mobile --target x86_64-linux-android


### PR DESCRIPTION
## Summary
- add a dedicated Android Mobile Check job to CI
- install Android SDK tools + NDK (26.3.11579264)
- add Rust Android target (x86_64-linux-android)
- run cargo check -p dirt-mobile --target x86_64-linux-android with explicit NDK toolchain env

## Why
Desktop-only CI missed an Android compile regression. This job ensures Android-target breakages fail PR checks.

Fixes #128