### PR TITLE
refactor(mobile): standardize controls on shared UI primitives

### DIFF
--- a/crates/dirt-mobile/src/app.rs
+++ b/crates/dirt-mobile/src/app.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dioxus::prelude::*;
+use dioxus_primitives::label::Label;
 use dioxus_primitives::scroll_area::{ScrollArea, ScrollDirection, ScrollType};
 use dioxus_primitives::separator::Separator;
 use dioxus_primitives::toast::{use_toast, ToastOptions, ToastProvider};
@@ -16,6 +17,7 @@ use crate::data::MobileNoteStore;
 use crate::launch::LaunchIntent;
 use crate::secret_store;
 use crate::sync_auth::{SyncToken, TursoSyncAuthClient};
+use crate::ui::{ButtonVariant, UiButton, UiInput, UiTextarea, MOBILE_UI_STYLES};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum MobileView {
@@ -857,7 +859,7 @@ fn AppShell() -> Element {
 
     rsx! {
         style {
-            "{TOAST_STYLES}"
+            "{TOAST_STYLES}{MOBILE_UI_STYLES}"
         }
 
         div {
@@ -891,32 +893,18 @@ fn AppShell() -> Element {
                         }
                     }
                     if view() == MobileView::Settings {
-                        button {
+                        UiButton {
                             type: "button",
-                            style: "
-                                border: 1px solid #d1d5db;
-                                border-radius: 8px;
-                                padding: 6px 10px;
-                                background: #ffffff;
-                                color: #111827;
-                                font-size: 12px;
-                                font-weight: 600;
-                            ",
+                            variant: ButtonVariant::Outline,
+                            style: "padding: 6px 10px; font-size: 12px;",
                             onclick: on_back_to_list,
                             "Notes"
                         }
                     } else {
-                        button {
+                        UiButton {
                             type: "button",
-                            style: "
-                                border: 1px solid #d1d5db;
-                                border-radius: 8px;
-                                padding: 6px 10px;
-                                background: #ffffff;
-                                color: #111827;
-                                font-size: 12px;
-                                font-weight: 600;
-                            ",
+                            variant: ButtonVariant::Outline,
+                            style: "padding: 6px 10px; font-size: 12px;",
                             onclick: on_open_settings,
                             "Settings"
                         }
@@ -982,16 +970,9 @@ fn AppShell() -> Element {
                                 style: "margin: 0; font-size: 12px; color: #6b7280;",
                                 "Retry initialization to continue."
                             }
-                            button {
+                            UiButton {
                                 type: "button",
-                                style: "
-                                    border: 0;
-                                    border-radius: 8px;
-                                    padding: 10px 12px;
-                                    background: #2563eb;
-                                    color: #ffffff;
-                                    font-weight: 600;
-                                ",
+                                variant: ButtonVariant::Primary,
                                 onclick: on_retry_db_init,
                                 disabled: loading(),
                                 "Retry"
@@ -1001,18 +982,11 @@ fn AppShell() -> Element {
                 } else {
                     div {
                         style: "padding: 12px 16px; display: flex; gap: 8px;",
-                        button {
+                        UiButton {
                             type: "button",
-                            style: "
-                                flex: 1;
-                                border: 0;
-                                border-radius: 10px;
-                                padding: 12px;
-                                background: #111827;
-                                color: #ffffff;
-                                font-weight: 600;
-                                font-size: 14px;
-                            ",
+                            block: true,
+                            variant: ButtonVariant::Secondary,
+                            style: "font-size: 14px; padding: 12px;",
                             onclick: on_new_note,
                             "New note"
                         }
@@ -1058,9 +1032,10 @@ fn AppShell() -> Element {
                                     );
 
                                     rsx! {
-                                        button {
+                                        UiButton {
                                             key: "{note_id}",
                                             type: "button",
+                                            variant: ButtonVariant::Ghost,
                                             style: "{card_style}",
                                             onclick: move |_| {
                                                 selected_note_id.set(Some(note_id));
@@ -1190,83 +1165,56 @@ fn AppShell() -> Element {
                             style: "margin: 0; font-size: 12px; color: #6b7280;",
                             "Auth config: {auth_config_summary_text}"
                         }
-                        input {
+                        Label {
+                            html_for: "auth-email",
+                            style: "margin: 0; font-size: 12px; color: #6b7280;",
+                            "Email"
+                        }
+                        UiInput {
+                            id: "auth-email",
                             r#type: "email",
                             placeholder: "Email",
                             value: "{auth_email_input}",
-                            style: "
-                                border: 1px solid #d1d5db;
-                                border-radius: 8px;
-                                padding: 10px;
-                                font-size: 13px;
-                            ",
                             oninput: move |event: Event<FormData>| {
                                 auth_email_input.set(event.value());
                             },
                         }
-                        input {
+                        Label {
+                            html_for: "auth-password",
+                            style: "margin: 0; font-size: 12px; color: #6b7280;",
+                            "Password"
+                        }
+                        UiInput {
+                            id: "auth-password",
                             r#type: "password",
                             placeholder: "Password",
                             value: "{auth_password_input}",
-                            style: "
-                                border: 1px solid #d1d5db;
-                                border-radius: 8px;
-                                padding: 10px;
-                                font-size: 13px;
-                            ",
                             oninput: move |event: Event<FormData>| {
                                 auth_password_input.set(event.value());
                             },
                         }
                         div {
                             style: "display: flex; gap: 8px; flex-wrap: wrap;",
-                            button {
+                            UiButton {
                                 type: "button",
-                                style: "
-                                    flex: 1;
-                                    min-width: 100px;
-                                    border: 0;
-                                    border-radius: 8px;
-                                    padding: 10px;
-                                    background: #2563eb;
-                                    color: #ffffff;
-                                    font-weight: 600;
-                                    font-size: 13px;
-                                ",
+                                variant: ButtonVariant::Primary,
+                                style: "flex: 1; min-width: 100px;",
                                 disabled: auth_loading(),
                                 onclick: on_auth_sign_in,
                                 if auth_loading() { "Working..." } else { "Sign in" }
                             }
-                            button {
+                            UiButton {
                                 type: "button",
-                                style: "
-                                    flex: 1;
-                                    min-width: 100px;
-                                    border: 1px solid #2563eb;
-                                    border-radius: 8px;
-                                    padding: 10px;
-                                    background: #ffffff;
-                                    color: #2563eb;
-                                    font-weight: 600;
-                                    font-size: 13px;
-                                ",
+                                variant: ButtonVariant::Outline,
+                                style: "flex: 1; min-width: 100px;",
                                 disabled: auth_loading(),
                                 onclick: on_auth_sign_up,
                                 "Sign up"
                             }
-                            button {
+                            UiButton {
                                 type: "button",
-                                style: "
-                                    flex: 1;
-                                    min-width: 100px;
-                                    border: 1px solid #d1d5db;
-                                    border-radius: 8px;
-                                    padding: 10px;
-                                    background: #ffffff;
-                                    color: #374151;
-                                    font-weight: 600;
-                                    font-size: 13px;
-                                ",
+                                variant: ButtonVariant::Outline,
+                                style: "flex: 1; min-width: 100px;",
                                 disabled: auth_loading() || auth_session().is_none(),
                                 onclick: on_auth_sign_out,
                                 "Sign out"
@@ -1296,16 +1244,16 @@ fn AppShell() -> Element {
                             ",
                             "Turso sync settings"
                         }
-                        input {
+                        Label {
+                            html_for: "turso-url",
+                            style: "margin: 0; font-size: 12px; color: #6b7280;",
+                            "Turso URL"
+                        }
+                        UiInput {
+                            id: "turso-url",
                             r#type: "text",
                             placeholder: "libsql://your-db.region.turso.io",
                             value: "{turso_database_url_input}",
-                            style: "
-                                border: 1px solid #d1d5db;
-                                border-radius: 8px;
-                                padding: 10px;
-                                font-size: 13px;
-                            ",
                             oninput: move |event: Event<FormData>| {
                                 turso_database_url_input.set(event.value());
                             },
@@ -1316,33 +1264,17 @@ fn AppShell() -> Element {
                         }
                         div {
                             style: "display: flex; gap: 8px;",
-                            button {
+                            UiButton {
                                 type: "button",
-                                style: "
-                                    flex: 1;
-                                    border: 0;
-                                    border-radius: 8px;
-                                    padding: 10px;
-                                    background: #2563eb;
-                                    color: #ffffff;
-                                    font-weight: 600;
-                                    font-size: 13px;
-                                ",
+                                block: true,
+                                variant: ButtonVariant::Primary,
                                 onclick: on_save_sync_settings,
                                 "Save sync config"
                             }
-                            button {
+                            UiButton {
                                 type: "button",
-                                style: "
-                                    flex: 1;
-                                    border: 1px solid #d1d5db;
-                                    border-radius: 8px;
-                                    padding: 10px;
-                                    background: #ffffff;
-                                    color: #374151;
-                                    font-weight: 600;
-                                    font-size: 13px;
-                                ",
+                                block: true,
+                                variant: ButtonVariant::Outline,
                                 onclick: on_clear_sync_settings,
                                 "Clear"
                             }
@@ -1456,44 +1388,24 @@ fn AppShell() -> Element {
                         gap: 8px;
                         background: #ffffff;
                     ",
-                    button {
+                    UiButton {
                         type: "button",
-                        style: "
-                            border: 1px solid #d1d5db;
-                            border-radius: 8px;
-                            padding: 10px 12px;
-                            background: #ffffff;
-                            font-weight: 600;
-                        ",
+                        variant: ButtonVariant::Outline,
                         onclick: on_back_to_list,
                         "Back"
                     }
-                    button {
+                    UiButton {
                         type: "button",
-                        style: "
-                            border: 0;
-                            border-radius: 8px;
-                            padding: 10px 12px;
-                            background: #2563eb;
-                            color: #ffffff;
-                            font-weight: 600;
-                        ",
+                        variant: ButtonVariant::Primary,
                         disabled: saving(),
                         onclick: on_save_note,
                         if saving() { "Saving..." } else { "Save" }
                     }
                     if selected_note_id().is_some() {
-                        button {
+                        UiButton {
                             type: "button",
-                            style: "
-                                margin-left: auto;
-                                border: 1px solid #ef4444;
-                                border-radius: 8px;
-                                padding: 10px 12px;
-                                background: #ffffff;
-                                color: #b91c1c;
-                                font-weight: 600;
-                            ",
+                            variant: ButtonVariant::Danger,
+                            style: "margin-left: auto;",
                             disabled: deleting(),
                             onclick: on_delete_note,
                             if deleting() { "Deleting..." } else { "Delete" }
@@ -1506,17 +1418,14 @@ fn AppShell() -> Element {
                     style: "height: 1px; background: #e5e7eb;",
                 }
 
-                textarea {
+                UiTextarea {
                     style: "
                         flex: 1;
                         margin: 12px;
-                        border: 1px solid #d1d5db;
                         border-radius: 12px;
                         padding: 14px;
                         line-height: 1.5;
                         font-size: 15px;
-                        resize: none;
-                        background: #ffffff;
                     ",
                     value: "{draft_content}",
                     placeholder: "Write your note...",

--- a/crates/dirt-mobile/src/main.rs
+++ b/crates/dirt-mobile/src/main.rs
@@ -16,6 +16,8 @@ mod launch;
 mod secret_store;
 #[cfg(any(target_os = "android", test))]
 mod sync_auth;
+#[cfg(target_os = "android")]
+mod ui;
 
 #[cfg(target_os = "android")]
 fn main() {

--- a/crates/dirt-mobile/src/ui.rs
+++ b/crates/dirt-mobile/src/ui.rs
@@ -1,0 +1,169 @@
+//! Shared mobile UI primitives aligned with official Dioxus component patterns.
+#![cfg_attr(not(target_os = "android"), allow(dead_code))]
+
+use dioxus::prelude::*;
+
+/// Shared styles for mobile button/input/textarea wrappers.
+pub const MOBILE_UI_STYLES: &str = r"
+.ui-button {
+    border-radius: 10px;
+    padding: 10px 12px;
+    font-size: 13px;
+    font-weight: 600;
+    border: 1px solid transparent;
+    transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.ui-button:disabled {
+    opacity: 0.55;
+}
+
+.ui-button--block {
+    width: 100%;
+}
+
+.ui-button--primary {
+    background: #2563eb;
+    color: #ffffff;
+    border-color: #2563eb;
+}
+
+.ui-button--secondary {
+    background: #111827;
+    color: #ffffff;
+    border-color: #111827;
+}
+
+.ui-button--outline {
+    background: #ffffff;
+    color: #374151;
+    border-color: #d1d5db;
+}
+
+.ui-button--ghost {
+    background: transparent;
+    color: #374151;
+    border-color: transparent;
+}
+
+.ui-button--danger {
+    background: #dc2626;
+    color: #ffffff;
+    border-color: #dc2626;
+}
+
+.ui-input {
+    width: 100%;
+    border: 1px solid #d1d5db;
+    border-radius: 10px;
+    padding: 10px 12px;
+    font-size: 13px;
+    background: #ffffff;
+    color: #111827;
+}
+
+.ui-textarea {
+    width: 100%;
+    border: 1px solid #d1d5db;
+    border-radius: 10px;
+    padding: 10px 12px;
+    font-size: 13px;
+    background: #ffffff;
+    color: #111827;
+    resize: none;
+}
+";
+
+/// Button variant mapping.
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub enum ButtonVariant {
+    #[default]
+    Primary,
+    Secondary,
+    Outline,
+    Ghost,
+    Danger,
+}
+
+impl ButtonVariant {
+    const fn class(self) -> &'static str {
+        match self {
+            Self::Primary => "ui-button--primary",
+            Self::Secondary => "ui-button--secondary",
+            Self::Outline => "ui-button--outline",
+            Self::Ghost => "ui-button--ghost",
+            Self::Danger => "ui-button--danger",
+        }
+    }
+}
+
+#[component]
+pub fn UiButton(
+    #[props(default)] variant: ButtonVariant,
+    #[props(default)] block: bool,
+    #[props(default)] disabled: bool,
+    onclick: Option<EventHandler<MouseEvent>>,
+    #[props(extends = GlobalAttributes)]
+    #[props(extends = button)]
+    attributes: Vec<Attribute>,
+    children: Element,
+) -> Element {
+    let mut class_name = format!("ui-button {}", variant.class());
+    if block {
+        class_name.push_str(" ui-button--block");
+    }
+
+    rsx! {
+        button {
+            class: "{class_name}",
+            disabled,
+            onclick: move |event| {
+                if let Some(handler) = &onclick {
+                    handler.call(event);
+                }
+            },
+            ..attributes,
+            {children}
+        }
+    }
+}
+
+#[component]
+pub fn UiInput(
+    oninput: Option<EventHandler<FormEvent>>,
+    onchange: Option<EventHandler<FormEvent>>,
+    #[props(extends = GlobalAttributes)]
+    #[props(extends = input)]
+    attributes: Vec<Attribute>,
+    children: Element,
+) -> Element {
+    rsx! {
+        input {
+            class: "ui-input",
+            oninput: move |event| _ = oninput.map(|handler| handler(event)),
+            onchange: move |event| _ = onchange.map(|handler| handler(event)),
+            ..attributes,
+            {children}
+        }
+    }
+}
+
+#[component]
+pub fn UiTextarea(
+    oninput: Option<EventHandler<FormEvent>>,
+    onchange: Option<EventHandler<FormEvent>>,
+    #[props(extends = GlobalAttributes)]
+    #[props(extends = textarea)]
+    attributes: Vec<Attribute>,
+    children: Element,
+) -> Element {
+    rsx! {
+        textarea {
+            class: "ui-textarea",
+            oninput: move |event| _ = oninput.map(|handler| handler(event)),
+            onchange: move |event| _ = onchange.map(|handler| handler(event)),
+            ..attributes,
+            {children}
+        }
+    }
+}

--- a/docs/mobile-ui-conventions.md
+++ b/docs/mobile-ui-conventions.md
@@ -1,0 +1,19 @@
+# Mobile UI Component Conventions
+
+This project uses the official Dioxus component ecosystem for mobile UI behavior.
+
+## Rules
+
+1. Prefer `dioxus_primitives` components when a primitive exists (`ScrollArea`, `Separator`, `Label`, `Toast`, etc).
+2. For baseline HTML controls (`button`, `input`, `textarea`), use shared wrappers in `crates/dirt-mobile/src/ui.rs`:
+   - `UiButton`
+   - `UiInput`
+   - `UiTextarea`
+3. Avoid introducing raw control tags directly in `app.rs`; route new controls through shared wrappers for consistent interaction and styling.
+4. Keep one shared style source (`MOBILE_UI_STYLES`) for those wrappers instead of repeating inline style blocks.
+
+## Why
+
+- Reduces style drift across list/editor/settings flows.
+- Keeps behavior consistent with official Dioxus component patterns.
+- Makes future mobile UI changes easier to review and maintain.


### PR DESCRIPTION
## Summary
- add a shared mobile UI primitives module (UiButton, UiInput, UiTextarea) for consistent control behavior and style
- migrate key list/editor/settings controls in dirt-mobile/src/app.rs away from ad-hoc raw control styling
- use dioxus_primitives::label::Label for mobile settings form labels
- document mobile UI component rules in docs/mobile-ui-conventions.md

## Validation
- cargo fmt --all
- cargo test -p dirt-mobile
- cargo clippy -p dirt-mobile --all-targets -- -D warnings
- cargo check -p dirt-mobile --target x86_64-linux-android

Closes #122