### PR TITLE
feat(mobile): wire Android share intent + widget launch plumbing (#119)

### DIFF
--- a/crates/dirt-mobile/Dioxus.toml
+++ b/crates/dirt-mobile/Dioxus.toml
@@ -1,0 +1,3 @@
+[application]
+android_manifest = "android/AndroidManifest.xml"
+android_main_activity = "android/MainActivity.kt"

--- a/crates/dirt-mobile/android/AndroidManifest.xml
+++ b/crates/dirt-mobile/android/AndroidManifest.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowNativeHeapPointerTagging="false"
+        android:extractNativeLibs="true"
+        android:hasCode="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme">
+        <activity
+            android:configChanges="orientation|screenLayout|screenSize|keyboardHidden"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:name="dev.dioxus.main.MainActivity">
+            <meta-data android:name="android.app.func_name" android:value="ANativeActivity_onCreate" />
+            <meta-data android:name="android.app.lib_name" android:value="dioxusmain" />
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/*" />
+            </intent-filter>
+        </activity>
+
+        <receiver
+            android:enabled="true"
+            android:exported="true"
+            android:name="dev.dioxus.main.QuickCaptureWidgetProvider">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/dirt_quick_capture_widget_info" />
+        </receiver>
+    </application>
+</manifest>

--- a/crates/dirt-mobile/android/MainActivity.kt
+++ b/crates/dirt-mobile/android/MainActivity.kt
@@ -1,0 +1,104 @@
+package dev.dioxus.main
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.system.Os
+import android.widget.RemoteViews
+
+private const val ACTION_QUICK_CAPTURE = "dev.dioxus.main.action.QUICK_CAPTURE"
+private const val EXTRA_QUICK_CAPTURE_CONTENT = "dev.dioxus.main.extra.QUICK_CAPTURE_CONTENT"
+
+private const val ENV_QUICK_CAPTURE = "DIRT_QUICK_CAPTURE"
+private const val ENV_QUICK_CAPTURE_CONTENT = "DIRT_QUICK_CAPTURE_CONTENT"
+private const val ENV_SHARE_TEXT = "DIRT_SHARE_TEXT"
+
+object BuildConfig {
+    val DEBUG: Boolean by lazy {
+        runCatching {
+            val activityThread = Class.forName("android.app.ActivityThread")
+            val app = activityThread.getMethod("currentApplication").invoke(null)
+            val packageName = app?.javaClass?.getMethod("getPackageName")?.invoke(app) as? String
+            if (packageName.isNullOrBlank()) {
+                false
+            } else {
+                Class.forName("$packageName.BuildConfig").getField("DEBUG").getBoolean(null)
+            }
+        }.getOrDefault(false)
+    }
+}
+
+class MainActivity : WryActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        applyLaunchIntentToEnvironment(intent)
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        applyLaunchIntentToEnvironment(intent)
+    }
+
+    private fun applyLaunchIntentToEnvironment(intent: Intent?) {
+        val action = intent?.action.orEmpty()
+        val sharedText = if (action == Intent.ACTION_SEND) {
+            intent?.getStringExtra(Intent.EXTRA_TEXT)?.trim().orEmpty()
+        } else {
+            ""
+        }
+        val quickCaptureText = if (action == ACTION_QUICK_CAPTURE) {
+            intent?.getStringExtra(EXTRA_QUICK_CAPTURE_CONTENT)?.trim().orEmpty()
+        } else {
+            ""
+        }
+        val quickCaptureEnabled = action == ACTION_QUICK_CAPTURE
+
+        setEnvValue(ENV_SHARE_TEXT, sharedText)
+        setEnvValue(ENV_QUICK_CAPTURE_CONTENT, quickCaptureText)
+        setEnvValue(ENV_QUICK_CAPTURE, if (quickCaptureEnabled) "true" else "")
+    }
+
+    private fun setEnvValue(name: String, value: String) {
+        try {
+            Os.setenv(name, value, true)
+        } catch (_: Exception) {
+            // Best effort only.
+        }
+    }
+}
+
+class QuickCaptureWidgetProvider : AppWidgetProvider() {
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        appWidgetIds.forEach { appWidgetId ->
+            appWidgetManager.updateAppWidget(appWidgetId, buildViews(context, appWidgetId))
+        }
+    }
+
+    private fun buildViews(context: Context, appWidgetId: Int): RemoteViews {
+        val launchIntent = Intent(context, MainActivity::class.java).apply {
+            action = ACTION_QUICK_CAPTURE
+            putExtra(EXTRA_QUICK_CAPTURE_CONTENT, "")
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        }
+
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            appWidgetId,
+            launchIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        return RemoteViews(context.packageName, android.R.layout.simple_list_item_1).apply {
+            setTextViewText(android.R.id.text1, "Quick capture")
+            setOnClickPendingIntent(android.R.id.text1, pendingIntent)
+        }
+    }
+}

--- a/crates/dirt-mobile/build.rs
+++ b/crates/dirt-mobile/build.rs
@@ -1,0 +1,55 @@
+use std::env;
+use std::ffi::OsStr;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+const QUICK_CAPTURE_WIDGET_XML: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="120dp"
+    android:minHeight="48dp"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@android:layout/simple_list_item_1"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />
+"#;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=WRY_ANDROID_KOTLIN_FILES_OUT_DIR");
+
+    if let Err(error) = write_android_widget_resources() {
+        println!("cargo:warning=failed to generate Android widget metadata: {error}");
+    }
+}
+
+fn write_android_widget_resources() -> io::Result<()> {
+    let Some(kotlin_out_dir) = env::var_os("WRY_ANDROID_KOTLIN_FILES_OUT_DIR") else {
+        return Ok(());
+    };
+
+    let Some(main_dir) = find_android_main_dir(Path::new(&kotlin_out_dir)) else {
+        return Ok(());
+    };
+
+    let xml_dir = main_dir.join("res").join("xml");
+    fs::create_dir_all(&xml_dir)?;
+    fs::write(
+        xml_dir.join("dirt_quick_capture_widget_info.xml"),
+        QUICK_CAPTURE_WIDGET_XML,
+    )?;
+
+    Ok(())
+}
+
+fn find_android_main_dir(path: &Path) -> Option<PathBuf> {
+    path.ancestors().find_map(|ancestor| {
+        let parent = ancestor.parent()?;
+        if ancestor.file_name() == Some(OsStr::new("main"))
+            && parent.file_name() == Some(OsStr::new("src"))
+        {
+            Some(ancestor.to_path_buf())
+        } else {
+            None
+        }
+    })
+}


### PR DESCRIPTION
## Summary
- add crates/dirt-mobile/Dioxus.toml to wire custom Android templates
- add custom Android manifest with share intent filter and widget provider receiver
- add custom MainActivity.kt to translate Android launch intents into DIRT_* env variables used by Rust launch parsing
- add a minimal QuickCaptureWidgetProvider that launches Dirt with quick-capture action
- add uild.rs to generate widget provider XML metadata into the generated Android project during dx Android builds

## Validation
- cargo fmt --all
- cargo test -p dirt-mobile
- cargo check -p dirt-mobile --target x86_64-linux-android
- dx build --platform android -p dirt-mobile

Closes #119