### PR TITLE
feat(api): add managed token broker and media signing foundation (#154)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,22 @@ SUPABASE_URL=
 # Use anon/public key (never use service_role in desktop app)
 SUPABASE_ANON_KEY=
 
+# Backend API (server-side only; do NOT ship these in desktop/mobile binaries)
+DIRT_API_BIND_ADDR=127.0.0.1:8080
+SUPABASE_JWKS_URL=
+SUPABASE_JWT_ISSUER=
+SUPABASE_JWT_AUDIENCE=authenticated
+SUPABASE_JWKS_CACHE_TTL_SECS=300
+TURSO_API_URL=https://api.turso.tech
+TURSO_ORGANIZATION_SLUG=
+TURSO_DATABASE_NAME=
+TURSO_PLATFORM_API_TOKEN=
+TURSO_SYNC_TOKEN_TTL_SECS=900
+MEDIA_SIGNED_URL_TTL_SECS=600
+
 # Notes:
 # - Mobile managed sync flow uses `TURSO_SYNC_TOKEN_ENDPOINT` + Supabase session to mint short-lived Turso tokens.
 # - `TURSO_AUTH_TOKEN` is only for local/dev fallback and should not be shipped in production mobile builds.
 # - Dev setup without SMTP: enable `mailer_autoconfirm` in Supabase Auth to bypass email delivery.
 # - Production setup: configure custom SMTP to avoid default email rate limits.
+# - R2 secrets should live on backend only; clients should use presigned URL flows.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -793,7 +793,7 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -804,6 +804,40 @@ dependencies = [
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core 0.5.6",
+ "axum-macros",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -821,6 +855,36 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2113,6 +2177,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirt-api"
+version = "0.1.0"
+dependencies = [
+ "aws-credential-types",
+ "aws-sdk-s3",
+ "aws-types",
+ "axum 0.8.8",
+ "base64 0.22.1",
+ "chrono",
+ "dotenvy",
+ "http 1.4.0",
+ "jsonwebtoken",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower-http 0.6.8",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "dirt-cli"
 version = "0.1.0"
 dependencies = [
@@ -3374,6 +3462,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -3799,6 +3888,21 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -4272,6 +4376,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maybe-rayon"
@@ -4965,6 +5075,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -6194,6 +6314,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6315,6 +6446,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -6951,7 +7094,7 @@ checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
  "h2 0.3.27",
@@ -7023,6 +7166,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -7061,6 +7205,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/dirt-api/Cargo.toml
+++ b/crates/dirt-api/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "dirt-api"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Backend API for secure credential brokering and media signing"
+
+[[bin]]
+name = "dirt-api"
+path = "src/main.rs"
+
+[dependencies]
+axum = { version = "0.8", features = ["macros", "json"] }
+tokio.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+chrono.workspace = true
+jsonwebtoken = "9.3"
+base64 = "0.22"
+http = "1"
+tower-http = { version = "0.6", features = ["cors", "trace"] }
+aws-sdk-s3 = "1"
+aws-types = "1"
+aws-credential-types = "1"
+url = "2"
+dotenvy = "0.15"
+
+[lints]
+workspace = true

--- a/crates/dirt-api/src/auth.rs
+++ b/crates/dirt-api/src/auth.rs
@@ -1,0 +1,270 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::http::HeaderMap;
+use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::sync::RwLock;
+
+use crate::config::AppConfig;
+use crate::error::AppError;
+
+#[derive(Debug, Clone)]
+pub struct AuthenticatedUser {
+    pub user_id: String,
+}
+
+#[derive(Clone)]
+pub struct SupabaseJwtVerifier {
+    client: reqwest::Client,
+    config: Arc<AppConfig>,
+    cache: Arc<RwLock<JwksCache>>,
+}
+
+impl SupabaseJwtVerifier {
+    pub fn new(config: Arc<AppConfig>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            config,
+            cache: Arc::new(RwLock::new(JwksCache::default())),
+        }
+    }
+
+    pub async fn verify_access_token(&self, token: &str) -> Result<AuthenticatedUser, AppError> {
+        let header = decode_header(token).map_err(|error| {
+            AppError::unauthorized(format!("Token header decode failed: {}", sanitize(&error)))
+        })?;
+        let kid = header
+            .kid
+            .ok_or_else(|| AppError::unauthorized("Token header missing `kid`"))?;
+
+        let key = self.find_key(&kid).await?;
+
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.validate_aud = false;
+        validation.set_issuer(&[self.config.supabase_jwt_issuer.as_str()]);
+
+        let decoded = decode::<SupabaseClaims>(token, &key, &validation).map_err(|error| {
+            AppError::unauthorized(format!("Token validation failed: {}", sanitize(&error)))
+        })?;
+
+        if !audience_matches(
+            decoded.claims.aud.as_ref(),
+            &self.config.supabase_jwt_audience,
+        ) {
+            return Err(AppError::unauthorized("Token audience is not allowed"));
+        }
+        if decoded.claims.sub.trim().is_empty() {
+            return Err(AppError::unauthorized("Token subject is missing"));
+        }
+
+        Ok(AuthenticatedUser {
+            user_id: decoded.claims.sub,
+        })
+    }
+
+    async fn find_key(&self, kid: &str) -> Result<DecodingKey, AppError> {
+        {
+            let cache = self.cache.read().await;
+            if !cache.is_stale(self.config.jwks_cache_ttl) {
+                if let Some(key) = cache.keys.get(kid) {
+                    return Ok(key.clone());
+                }
+            }
+        }
+
+        let mut cache = self.cache.write().await;
+        if !cache.is_stale(self.config.jwks_cache_ttl) {
+            if let Some(key) = cache.keys.get(kid) {
+                return Ok(key.clone());
+            }
+        }
+
+        let keys = fetch_jwks(&self.client, &self.config.supabase_jwks_url).await?;
+        cache.keys = keys;
+        cache.fetched_at = Some(Instant::now());
+
+        cache
+            .keys
+            .get(kid)
+            .cloned()
+            .ok_or_else(|| AppError::unauthorized("Signing key not found in Supabase JWKS"))
+    }
+}
+
+pub fn extract_bearer_token(headers: &HeaderMap) -> Result<&str, AppError> {
+    let header = headers
+        .get("authorization")
+        .ok_or_else(|| AppError::unauthorized("Missing Authorization header"))?
+        .to_str()
+        .map_err(|_| AppError::unauthorized("Authorization header is not valid UTF-8"))?;
+
+    let (scheme, token) = header
+        .split_once(' ')
+        .ok_or_else(|| AppError::unauthorized("Authorization header must be `Bearer <token>`"))?;
+
+    if !scheme.eq_ignore_ascii_case("bearer") {
+        return Err(AppError::unauthorized(
+            "Authorization scheme must be `Bearer`",
+        ));
+    }
+    let token = token.trim();
+    if token.is_empty() {
+        return Err(AppError::unauthorized("Bearer token is empty"));
+    }
+
+    Ok(token)
+}
+
+#[derive(Default)]
+struct JwksCache {
+    keys: HashMap<String, DecodingKey>,
+    fetched_at: Option<Instant>,
+}
+
+impl JwksCache {
+    fn is_stale(&self, ttl: std::time::Duration) -> bool {
+        self.fetched_at.map_or(true, |at| at.elapsed() > ttl)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct JwksDocument {
+    keys: Vec<Jwk>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Jwk {
+    kid: Option<String>,
+    kty: Option<String>,
+    use_: Option<String>,
+    n: Option<String>,
+    e: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SupabaseClaims {
+    sub: String,
+    aud: Option<Value>,
+}
+
+async fn fetch_jwks(
+    client: &reqwest::Client,
+    jwks_url: &str,
+) -> Result<HashMap<String, DecodingKey>, AppError> {
+    let response = client
+        .get(jwks_url)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .map_err(|error| {
+            AppError::external(format!("JWKS request failed: {}", sanitize(&error)))
+        })?;
+
+    if !response.status().is_success() {
+        return Err(AppError::external(format!(
+            "JWKS request failed with HTTP {}",
+            response.status().as_u16()
+        )));
+    }
+
+    let payload = response.json::<JwksDocument>().await.map_err(|error| {
+        AppError::external(format!("JWKS JSON parse failed: {}", sanitize(&error)))
+    })?;
+
+    let mut out = HashMap::new();
+    for key in payload.keys {
+        let Some(kid) = key.kid else {
+            continue;
+        };
+        if key.kty.as_deref() != Some("RSA") {
+            continue;
+        }
+        if key.use_.as_deref().is_some_and(|usage| usage != "sig") {
+            continue;
+        }
+        let Some(n) = key.n else {
+            continue;
+        };
+        let Some(e) = key.e else {
+            continue;
+        };
+        let decoding = DecodingKey::from_rsa_components(&n, &e).map_err(|error| {
+            AppError::external(format!("Invalid JWKS RSA key: {}", sanitize(&error)))
+        })?;
+        out.insert(kid, decoding);
+    }
+
+    if out.is_empty() {
+        return Err(AppError::external(
+            "JWKS did not include any usable RSA signing keys",
+        ));
+    }
+
+    Ok(out)
+}
+
+fn audience_matches(aud: Option<&Value>, expected: &str) -> bool {
+    let Some(aud) = aud else {
+        return false;
+    };
+
+    match aud {
+        Value::String(value) => value == expected,
+        Value::Array(values) => values
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|value| value == expected),
+        _ => false,
+    }
+}
+
+fn sanitize(error: &impl std::fmt::Display) -> String {
+    error.to_string().replace('\n', " ").trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::HeaderValue;
+
+    use super::*;
+
+    #[test]
+    fn bearer_token_extractor_accepts_standard_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            HeaderValue::from_static("Bearer abc.def.ghi"),
+        );
+
+        assert_eq!(extract_bearer_token(&headers).unwrap(), "abc.def.ghi");
+    }
+
+    #[test]
+    fn bearer_token_extractor_rejects_wrong_scheme() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", HeaderValue::from_static("Basic abc"));
+        assert!(extract_bearer_token(&headers).is_err());
+    }
+
+    #[test]
+    fn audience_matches_string_or_array() {
+        assert!(audience_matches(
+            Some(&Value::String("authenticated".to_string())),
+            "authenticated"
+        ));
+        assert!(audience_matches(
+            Some(&Value::Array(vec![
+                Value::String("anon".to_string()),
+                Value::String("authenticated".to_string())
+            ])),
+            "authenticated"
+        ));
+        assert!(!audience_matches(
+            Some(&Value::String("anon".to_string())),
+            "authenticated"
+        ));
+    }
+}

--- a/crates/dirt-api/src/config.rs
+++ b/crates/dirt-api/src/config.rs
@@ -1,0 +1,275 @@
+use std::collections::HashMap;
+use std::env;
+use std::fmt;
+use std::time::Duration;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("Missing required environment variable: {0}")]
+    MissingVar(&'static str),
+    #[error("Invalid configuration: {0}")]
+    Invalid(String),
+}
+
+#[derive(Clone)]
+pub struct AppConfig {
+    pub bind_addr: String,
+    pub supabase_url: String,
+    pub supabase_jwks_url: String,
+    pub supabase_jwt_issuer: String,
+    pub supabase_jwt_audience: String,
+    pub jwks_cache_ttl: Duration,
+    pub turso_api_url: String,
+    pub turso_organization_slug: String,
+    pub turso_database_name: String,
+    pub turso_database_url: String,
+    pub turso_platform_api_token: String,
+    pub turso_token_ttl: Duration,
+    pub media_url_ttl: Duration,
+    pub r2: Option<R2RuntimeConfig>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct R2RuntimeConfig {
+    pub account_id: String,
+    pub bucket: String,
+    pub access_key_id: String,
+    pub secret_access_key: String,
+}
+
+impl fmt::Debug for R2RuntimeConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("R2RuntimeConfig")
+            .field("account_id", &self.account_id)
+            .field("bucket", &self.bucket)
+            .field("access_key_id", &self.access_key_id)
+            .field("secret_access_key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl fmt::Debug for AppConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AppConfig")
+            .field("bind_addr", &self.bind_addr)
+            .field("supabase_url", &self.supabase_url)
+            .field("supabase_jwks_url", &self.supabase_jwks_url)
+            .field("supabase_jwt_issuer", &self.supabase_jwt_issuer)
+            .field("supabase_jwt_audience", &self.supabase_jwt_audience)
+            .field("jwks_cache_ttl", &self.jwks_cache_ttl)
+            .field("turso_api_url", &self.turso_api_url)
+            .field("turso_organization_slug", &self.turso_organization_slug)
+            .field("turso_database_name", &self.turso_database_name)
+            .field("turso_database_url", &self.turso_database_url)
+            .field("turso_platform_api_token", &"[REDACTED]")
+            .field("turso_token_ttl", &self.turso_token_ttl)
+            .field("media_url_ttl", &self.media_url_ttl)
+            .field("r2", &self.r2)
+            .finish()
+    }
+}
+
+impl AppConfig {
+    pub fn from_env() -> Result<Self, ConfigError> {
+        let values: HashMap<String, String> = env::vars().collect();
+        Self::from_lookup(|name| values.get(name).cloned())
+    }
+
+    fn from_lookup(lookup: impl Fn(&str) -> Option<String>) -> Result<Self, ConfigError> {
+        let bind_addr = value_or_default(&lookup, "DIRT_API_BIND_ADDR", "127.0.0.1:8080");
+
+        let supabase_url = required_trimmed(&lookup, "SUPABASE_URL")?;
+        if !is_http_url(&supabase_url) {
+            return Err(ConfigError::Invalid(
+                "SUPABASE_URL must start with http:// or https://".to_string(),
+            ));
+        }
+
+        let default_jwks = format!(
+            "{}/auth/v1/.well-known/jwks.json",
+            trim_trailing(&supabase_url)
+        );
+        let supabase_jwks_url = value_or_default(&lookup, "SUPABASE_JWKS_URL", &default_jwks);
+        if !is_http_url(&supabase_jwks_url) {
+            return Err(ConfigError::Invalid(
+                "SUPABASE_JWKS_URL must start with http:// or https://".to_string(),
+            ));
+        }
+
+        let default_issuer = format!("{}/auth/v1", trim_trailing(&supabase_url));
+        let supabase_jwt_issuer = value_or_default(&lookup, "SUPABASE_JWT_ISSUER", &default_issuer);
+        let supabase_jwt_audience =
+            value_or_default(&lookup, "SUPABASE_JWT_AUDIENCE", "authenticated");
+
+        let jwks_cache_ttl_secs = value_or_default(&lookup, "SUPABASE_JWKS_CACHE_TTL_SECS", "300")
+            .parse::<u64>()
+            .map_err(|_| {
+                ConfigError::Invalid(
+                    "SUPABASE_JWKS_CACHE_TTL_SECS must be an integer >= 30".to_string(),
+                )
+            })?;
+        if jwks_cache_ttl_secs < 30 {
+            return Err(ConfigError::Invalid(
+                "SUPABASE_JWKS_CACHE_TTL_SECS must be >= 30".to_string(),
+            ));
+        }
+
+        let turso_api_url = value_or_default(&lookup, "TURSO_API_URL", "https://api.turso.tech");
+        if !is_http_url(&turso_api_url) {
+            return Err(ConfigError::Invalid(
+                "TURSO_API_URL must start with http:// or https://".to_string(),
+            ));
+        }
+
+        let turso_organization_slug = required_trimmed(&lookup, "TURSO_ORGANIZATION_SLUG")?;
+        let turso_database_name = required_trimmed(&lookup, "TURSO_DATABASE_NAME")?;
+        let turso_database_url = required_trimmed(&lookup, "TURSO_DATABASE_URL")?;
+        let turso_platform_api_token = required_trimmed(&lookup, "TURSO_PLATFORM_API_TOKEN")?;
+
+        let turso_ttl_secs = value_or_default(&lookup, "TURSO_SYNC_TOKEN_TTL_SECS", "900")
+            .parse::<u64>()
+            .map_err(|_| {
+                ConfigError::Invalid(
+                    "TURSO_SYNC_TOKEN_TTL_SECS must be an integer in [60, 3600]".to_string(),
+                )
+            })?;
+        if !(60..=3_600).contains(&turso_ttl_secs) {
+            return Err(ConfigError::Invalid(
+                "TURSO_SYNC_TOKEN_TTL_SECS must be in [60, 3600]".to_string(),
+            ));
+        }
+
+        let media_ttl_secs = value_or_default(&lookup, "MEDIA_SIGNED_URL_TTL_SECS", "600")
+            .parse::<u64>()
+            .map_err(|_| {
+                ConfigError::Invalid(
+                    "MEDIA_SIGNED_URL_TTL_SECS must be an integer in [60, 3600]".to_string(),
+                )
+            })?;
+        if !(60..=3_600).contains(&media_ttl_secs) {
+            return Err(ConfigError::Invalid(
+                "MEDIA_SIGNED_URL_TTL_SECS must be in [60, 3600]".to_string(),
+            ));
+        }
+
+        let r2 = parse_r2_config(&lookup)?;
+
+        Ok(Self {
+            bind_addr,
+            supabase_url,
+            supabase_jwks_url,
+            supabase_jwt_issuer,
+            supabase_jwt_audience,
+            jwks_cache_ttl: Duration::from_secs(jwks_cache_ttl_secs),
+            turso_api_url,
+            turso_organization_slug,
+            turso_database_name,
+            turso_database_url,
+            turso_platform_api_token,
+            turso_token_ttl: Duration::from_secs(turso_ttl_secs),
+            media_url_ttl: Duration::from_secs(media_ttl_secs),
+            r2,
+        })
+    }
+}
+
+fn parse_r2_config(
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Result<Option<R2RuntimeConfig>, ConfigError> {
+    let account_id = optional_trimmed(&lookup, "R2_ACCOUNT_ID");
+    let bucket = optional_trimmed(&lookup, "R2_BUCKET");
+    let access_key_id = optional_trimmed(&lookup, "R2_ACCESS_KEY_ID");
+    let secret_access_key = optional_trimmed(&lookup, "R2_SECRET_ACCESS_KEY");
+
+    let any_set = account_id.is_some()
+        || bucket.is_some()
+        || access_key_id.is_some()
+        || secret_access_key.is_some();
+    if !any_set {
+        return Ok(None);
+    }
+
+    let account_id = account_id.ok_or(ConfigError::MissingVar("R2_ACCOUNT_ID"))?;
+    let bucket = bucket.ok_or(ConfigError::MissingVar("R2_BUCKET"))?;
+    let access_key_id = access_key_id.ok_or(ConfigError::MissingVar("R2_ACCESS_KEY_ID"))?;
+    let secret_access_key =
+        secret_access_key.ok_or(ConfigError::MissingVar("R2_SECRET_ACCESS_KEY"))?;
+
+    Ok(Some(R2RuntimeConfig {
+        account_id,
+        bucket,
+        access_key_id,
+        secret_access_key,
+    }))
+}
+
+fn value_or_default(lookup: impl Fn(&str) -> Option<String>, name: &str, default: &str) -> String {
+    optional_trimmed(lookup, name).unwrap_or_else(|| default.to_string())
+}
+
+fn required_trimmed(
+    lookup: impl Fn(&str) -> Option<String>,
+    name: &'static str,
+) -> Result<String, ConfigError> {
+    optional_trimmed(lookup, name).ok_or(ConfigError::MissingVar(name))
+}
+
+fn optional_trimmed(lookup: impl Fn(&str) -> Option<String>, name: &str) -> Option<String> {
+    lookup(name).and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn is_http_url(value: &str) -> bool {
+    value.starts_with("http://") || value.starts_with("https://")
+}
+
+fn trim_trailing(value: &str) -> &str {
+    value.trim_end_matches('/')
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn config_requires_minimum_secrets() {
+        let map: HashMap<&str, &str> = HashMap::new();
+        let err = AppConfig::from_lookup(|key| map.get(key).map(|value| (*value).to_string()))
+            .unwrap_err();
+        assert!(err.to_string().contains("SUPABASE_URL"));
+    }
+
+    #[test]
+    fn config_redacts_sensitive_debug_fields() {
+        let mut map = HashMap::new();
+        map.insert("SUPABASE_URL", "https://project.supabase.co");
+        map.insert("TURSO_ORGANIZATION_SLUG", "org");
+        map.insert("TURSO_DATABASE_NAME", "db");
+        map.insert("TURSO_DATABASE_URL", "libsql://db.turso.io");
+        map.insert("TURSO_PLATFORM_API_TOKEN", "sensitive-platform-token");
+        map.insert("R2_ACCOUNT_ID", "acc");
+        map.insert("R2_BUCKET", "bucket");
+        map.insert("R2_ACCESS_KEY_ID", "access");
+        map.insert("R2_SECRET_ACCESS_KEY", "sensitive-r2-secret");
+
+        let config =
+            AppConfig::from_lookup(|key| map.get(key).map(|value| (*value).to_string())).unwrap();
+
+        let debug_output = format!("{config:?}");
+        assert!(!debug_output.contains("sensitive-platform-token"));
+        assert!(!debug_output.contains("sensitive-r2-secret"));
+        assert!(debug_output.contains("[REDACTED]"));
+    }
+}

--- a/crates/dirt-api/src/error.rs
+++ b/crates/dirt-api/src/error.rs
@@ -1,0 +1,57 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AppError {
+    #[error("Invalid request: {0}")]
+    BadRequest(String),
+    #[error("Unauthorized: {0}")]
+    Unauthorized(String),
+    #[error("Configuration error: {0}")]
+    Config(String),
+    #[error("External dependency error: {0}")]
+    External(String),
+    #[error("Internal server error: {0}")]
+    Internal(String),
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorBody {
+    error: String,
+}
+
+impl AppError {
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self::BadRequest(message.into())
+    }
+
+    pub fn unauthorized(message: impl Into<String>) -> Self {
+        Self::Unauthorized(message.into())
+    }
+
+    pub fn external(message: impl Into<String>) -> Self {
+        Self::External(message.into())
+    }
+
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let status = match self {
+            Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+            Self::Unauthorized(_) => StatusCode::UNAUTHORIZED,
+            Self::External(_) => StatusCode::BAD_GATEWAY,
+            Self::Config(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        let body = ErrorBody {
+            error: self.to_string(),
+        };
+        (status, Json(body)).into_response()
+    }
+}

--- a/crates/dirt-api/src/main.rs
+++ b/crates/dirt-api/src/main.rs
@@ -1,0 +1,35 @@
+mod auth;
+mod config;
+mod error;
+mod media;
+mod routes;
+mod turso;
+
+use std::sync::Arc;
+
+use config::AppConfig;
+use routes::{app_router, AppState};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenvy::dotenv().ok();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("dirt_api=info".parse().expect("valid directive")),
+        )
+        .init();
+
+    let config = Arc::new(AppConfig::from_env()?);
+    tracing::info!("Starting dirt-api with config: {:?}", config);
+
+    let state = AppState::from_config(config);
+    let bind_addr = state.config.bind_addr.clone();
+    let router = app_router(state);
+
+    let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
+    tracing::info!("dirt-api listening on {}", bind_addr);
+    axum::serve(listener, router).await?;
+    Ok(())
+}

--- a/crates/dirt-api/src/media.rs
+++ b/crates/dirt-api/src/media.rs
@@ -1,0 +1,199 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use aws_credential_types::Credentials;
+use aws_sdk_s3::presigning::PresigningConfig;
+use aws_sdk_s3::Client;
+use aws_types::region::Region;
+use serde::Serialize;
+
+use crate::config::{AppConfig, R2RuntimeConfig};
+use crate::error::AppError;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PresignedOperation {
+    pub method: String,
+    pub url: String,
+    pub headers: Vec<(String, String)>,
+}
+
+#[derive(Clone)]
+pub struct R2PresignService {
+    bucket: String,
+    ttl: Duration,
+    client: Client,
+}
+
+impl R2PresignService {
+    pub fn from_config(config: &Arc<AppConfig>) -> Option<Self> {
+        config
+            .r2
+            .clone()
+            .map(|r2| Self::new(r2, config.media_url_ttl))
+    }
+
+    pub fn new(config: R2RuntimeConfig, ttl: Duration) -> Self {
+        let credentials = Credentials::new(
+            config.access_key_id,
+            config.secret_access_key,
+            None,
+            None,
+            "dirt-api-r2",
+        );
+
+        let endpoint = format!("https://{}.r2.cloudflarestorage.com", config.account_id);
+        let shared_config = aws_sdk_s3::Config::builder()
+            .region(Region::new("auto"))
+            .endpoint_url(endpoint)
+            .credentials_provider(credentials)
+            .force_path_style(true)
+            .build();
+
+        let client = Client::from_conf(shared_config);
+
+        Self {
+            bucket: config.bucket,
+            ttl,
+            client,
+        }
+    }
+
+    pub async fn presign_upload(
+        &self,
+        object_key: &str,
+        content_type: Option<&str>,
+    ) -> Result<PresignedOperation, AppError> {
+        let object_key = normalize_object_key(object_key)?;
+        let mut request = self
+            .client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(&object_key);
+        if let Some(content_type) = content_type.and_then(normalize_content_type) {
+            request = request.content_type(content_type);
+        }
+        let operation = request
+            .presigned(presign_config(self.ttl)?)
+            .await
+            .map_err(|error| {
+                AppError::external(format!(
+                    "Failed to presign upload URL: {}",
+                    sanitize(&error)
+                ))
+            })?;
+        Ok(map_presigned(
+            operation.method().to_string(),
+            operation.uri().to_string(),
+            operation.headers(),
+        ))
+    }
+
+    pub async fn presign_download(&self, object_key: &str) -> Result<PresignedOperation, AppError> {
+        let object_key = normalize_object_key(object_key)?;
+        let operation = self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(&object_key)
+            .presigned(presign_config(self.ttl)?)
+            .await
+            .map_err(|error| {
+                AppError::external(format!(
+                    "Failed to presign download URL: {}",
+                    sanitize(&error)
+                ))
+            })?;
+        Ok(map_presigned(
+            operation.method().to_string(),
+            operation.uri().to_string(),
+            operation.headers(),
+        ))
+    }
+
+    pub async fn presign_delete(&self, object_key: &str) -> Result<PresignedOperation, AppError> {
+        let object_key = normalize_object_key(object_key)?;
+        let operation = self
+            .client
+            .delete_object()
+            .bucket(&self.bucket)
+            .key(&object_key)
+            .presigned(presign_config(self.ttl)?)
+            .await
+            .map_err(|error| {
+                AppError::external(format!(
+                    "Failed to presign delete URL: {}",
+                    sanitize(&error)
+                ))
+            })?;
+        Ok(map_presigned(
+            operation.method().to_string(),
+            operation.uri().to_string(),
+            operation.headers(),
+        ))
+    }
+}
+
+fn normalize_content_type(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn map_presigned<'a>(
+    method: String,
+    url: String,
+    headers: impl Iterator<Item = (&'a str, &'a str)>,
+) -> PresignedOperation {
+    let headers = headers
+        .map(|(name, value)| (name.to_string(), value.to_string()))
+        .collect();
+    PresignedOperation {
+        method,
+        url,
+        headers,
+    }
+}
+
+fn normalize_object_key(raw: &str) -> Result<String, AppError> {
+    let key = raw.trim().trim_start_matches('/').to_string();
+    if key.is_empty() {
+        return Err(AppError::bad_request("object_key is required"));
+    }
+    if key.contains("..") {
+        return Err(AppError::bad_request(
+            "object_key must not contain path traversal segments",
+        ));
+    }
+    Ok(key)
+}
+
+fn presign_config(ttl: Duration) -> Result<PresigningConfig, AppError> {
+    PresigningConfig::expires_in(ttl)
+        .map_err(|error| AppError::internal(format!("Invalid presign TTL: {}", sanitize(&error))))
+}
+
+fn sanitize(error: &impl std::fmt::Display) -> String {
+    error.to_string().replace('\n', " ").trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_object_key_rejects_empty_or_parent_segments() {
+        assert!(normalize_object_key(" ").is_err());
+        assert!(normalize_object_key("../a").is_err());
+    }
+
+    #[test]
+    fn normalize_object_key_trims_prefix_slash() {
+        assert_eq!(
+            normalize_object_key("/notes/file.png").unwrap(),
+            "notes/file.png"
+        );
+    }
+}

--- a/crates/dirt-api/src/routes.rs
+++ b/crates/dirt-api/src/routes.rs
@@ -1,0 +1,148 @@
+use std::sync::Arc;
+
+use axum::extract::{Query, Request, State};
+use axum::middleware::{self, Next};
+use axum::response::Response;
+use axum::routing::{get, post};
+use axum::{Extension, Json, Router};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use tower_http::cors::{Any, CorsLayer};
+use tower_http::trace::TraceLayer;
+
+use crate::auth::{extract_bearer_token, AuthenticatedUser, SupabaseJwtVerifier};
+use crate::config::AppConfig;
+use crate::error::AppError;
+use crate::media::{PresignedOperation, R2PresignService};
+use crate::turso::{MintedSyncToken, TursoTokenBroker};
+
+#[derive(Clone)]
+pub struct AppState {
+    pub config: Arc<AppConfig>,
+    jwt_verifier: Arc<SupabaseJwtVerifier>,
+    turso_broker: Arc<TursoTokenBroker>,
+    r2_presign: Option<Arc<R2PresignService>>,
+}
+
+impl AppState {
+    pub fn from_config(config: Arc<AppConfig>) -> Self {
+        Self {
+            jwt_verifier: Arc::new(SupabaseJwtVerifier::new(config.clone())),
+            turso_broker: Arc::new(TursoTokenBroker::new(config.clone())),
+            r2_presign: R2PresignService::from_config(&config).map(Arc::new),
+            config,
+        }
+    }
+}
+
+pub fn app_router(state: AppState) -> Router {
+    let protected_routes = Router::new()
+        .route("/sync/token", post(mint_sync_token))
+        .route("/media/presign/upload", post(presign_upload))
+        .route("/media/presign/download", get(presign_download))
+        .route("/media/presign/delete", post(presign_delete))
+        .route_layer(middleware::from_fn_with_state(state.clone(), require_auth));
+
+    Router::new()
+        .route("/healthz", get(healthz))
+        .nest("/v1", protected_routes)
+        .layer(TraceLayer::new_for_http())
+        .layer(
+            CorsLayer::new()
+                .allow_origin(Any)
+                .allow_headers(Any)
+                .allow_methods(Any),
+        )
+        .with_state(state)
+}
+
+#[derive(Debug, Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    timestamp: i64,
+}
+
+async fn healthz() -> Json<HealthResponse> {
+    Json(HealthResponse {
+        status: "ok",
+        timestamp: Utc::now().timestamp(),
+    })
+}
+
+async fn require_auth(
+    State(state): State<AppState>,
+    mut request: Request,
+    next: Next,
+) -> Result<Response, AppError> {
+    let token = extract_bearer_token(request.headers())?;
+    let user = state.jwt_verifier.verify_access_token(token).await?;
+    request.extensions_mut().insert(user);
+    Ok(next.run(request).await)
+}
+
+async fn mint_sync_token(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+) -> Result<Json<MintedSyncToken>, AppError> {
+    let token = state.turso_broker.mint_sync_token(&user.user_id).await?;
+    Ok(Json(token))
+}
+
+#[derive(Debug, Deserialize)]
+struct UploadPresignRequest {
+    object_key: String,
+    content_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeletePresignRequest {
+    object_key: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DownloadPresignQuery {
+    object_key: String,
+}
+
+#[derive(Debug, Serialize)]
+struct PresignResponse {
+    operation: PresignedOperation,
+}
+
+async fn presign_upload(
+    State(state): State<AppState>,
+    _user: Extension<AuthenticatedUser>,
+    Json(request): Json<UploadPresignRequest>,
+) -> Result<Json<PresignResponse>, AppError> {
+    let signer = state.r2_presign.as_ref().ok_or_else(|| {
+        AppError::Config("R2 presign service is not configured on the backend".to_string())
+    })?;
+    let operation = signer
+        .presign_upload(&request.object_key, request.content_type.as_deref())
+        .await?;
+    Ok(Json(PresignResponse { operation }))
+}
+
+async fn presign_download(
+    State(state): State<AppState>,
+    _user: Extension<AuthenticatedUser>,
+    Query(query): Query<DownloadPresignQuery>,
+) -> Result<Json<PresignResponse>, AppError> {
+    let signer = state.r2_presign.as_ref().ok_or_else(|| {
+        AppError::Config("R2 presign service is not configured on the backend".to_string())
+    })?;
+    let operation = signer.presign_download(&query.object_key).await?;
+    Ok(Json(PresignResponse { operation }))
+}
+
+async fn presign_delete(
+    State(state): State<AppState>,
+    _user: Extension<AuthenticatedUser>,
+    Json(request): Json<DeletePresignRequest>,
+) -> Result<Json<PresignResponse>, AppError> {
+    let signer = state.r2_presign.as_ref().ok_or_else(|| {
+        AppError::Config("R2 presign service is not configured on the backend".to_string())
+    })?;
+    let operation = signer.presign_delete(&request.object_key).await?;
+    Ok(Json(PresignResponse { operation }))
+}

--- a/crates/dirt-api/src/turso.rs
+++ b/crates/dirt-api/src/turso.rs
@@ -1,0 +1,128 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use crate::config::AppConfig;
+use crate::error::AppError;
+
+#[derive(Debug, Clone)]
+pub struct TursoTokenBroker {
+    client: reqwest::Client,
+    config: Arc<AppConfig>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MintedSyncToken {
+    pub auth_token: String,
+    pub expires_at: i64,
+    pub database_url: String,
+}
+
+impl TursoTokenBroker {
+    pub fn new(config: Arc<AppConfig>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            config,
+        }
+    }
+
+    pub async fn mint_sync_token(&self, user_id: &str) -> Result<MintedSyncToken, AppError> {
+        let request_url = format!(
+            "{}/v1/organizations/{}/databases/{}/auth/tokens?expiration={}",
+            self.config.turso_api_url.trim_end_matches('/'),
+            self.config.turso_organization_slug,
+            self.config.turso_database_name,
+            expiration_query(self.config.turso_token_ttl),
+        );
+
+        let body = serde_json::json!({
+            "permissions": {
+                "full_access": true
+            },
+            "metadata": {
+                "subject": user_id
+            }
+        });
+
+        let response = self
+            .client
+            .post(&request_url)
+            .bearer_auth(&self.config.turso_platform_api_token)
+            .header("Accept", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| {
+                AppError::external(format!("Turso token request failed: {}", sanitize(&error)))
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AppError::external(format!(
+                "Turso token request failed with HTTP {}: {}",
+                status,
+                compact_body(&body)
+            )));
+        }
+
+        let payload = response
+            .json::<TursoTokenResponse>()
+            .await
+            .map_err(|error| {
+                AppError::external(format!("Turso token parse failed: {}", sanitize(&error)))
+            })?;
+
+        let token = payload
+            .auth_token
+            .or(payload.token)
+            .or(payload.jwt)
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| AppError::external("Turso token API returned no token"))?;
+
+        let expires_at = payload.expires_at.unwrap_or_else(|| {
+            Utc::now()
+                .timestamp()
+                .saturating_add(i64::try_from(self.config.turso_token_ttl.as_secs()).unwrap_or(900))
+        });
+
+        Ok(MintedSyncToken {
+            auth_token: token,
+            expires_at,
+            database_url: self.config.turso_database_url.clone(),
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TursoTokenResponse {
+    auth_token: Option<String>,
+    token: Option<String>,
+    jwt: Option<String>,
+    expires_at: Option<i64>,
+}
+
+fn expiration_query(ttl: Duration) -> String {
+    format!("{}s", ttl.as_secs())
+}
+
+fn sanitize(error: &impl std::fmt::Display) -> String {
+    error.to_string().replace('\n', " ").trim().to_string()
+}
+
+fn compact_body(body: &str) -> String {
+    body.trim().chars().take(180).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expiration_query_is_seconds_suffix() {
+        assert_eq!(expiration_query(Duration::from_secs(900)), "900s");
+    }
+}

--- a/docs/BACKEND_API.md
+++ b/docs/BACKEND_API.md
@@ -1,0 +1,72 @@
+# Dirt API (Managed Credential Backend)
+
+Last updated: 2026-02-10
+
+`dirt-api` is the backend service for secure credential brokering.
+
+## Why it exists
+
+- Client apps should be install-and-use.
+- Mobile/desktop/CLI must not require users to configure infra keys.
+- Long-lived credentials must stay server-side.
+
+## Security model
+
+- Clients authenticate with Supabase access tokens (`Bearer ...`).
+- Backend verifies JWT signatures against Supabase JWKS.
+- Backend returns short-lived credentials only:
+  - Turso sync token
+  - R2 presigned media operation URLs
+
+## Endpoints
+
+- `GET /healthz`
+  - Liveness probe.
+- `POST /v1/sync/token` (auth required)
+  - Exchanges authenticated user context for short-lived Turso token.
+  - Response shape:
+    - `auth_token`
+    - `expires_at` (unix seconds)
+    - `database_url`
+- `POST /v1/media/presign/upload` (auth required)
+  - Body: `object_key`, optional `content_type`
+  - Returns presigned URL + method + required headers.
+- `GET /v1/media/presign/download` (auth required)
+  - Query: `object_key`
+- `POST /v1/media/presign/delete` (auth required)
+  - Body: `object_key`
+
+## Configuration
+
+Use server environment variables (see `.env.example` backend section):
+
+- Supabase verification:
+  - `SUPABASE_URL`
+  - `SUPABASE_JWKS_URL` (optional override)
+  - `SUPABASE_JWT_ISSUER` (optional override)
+  - `SUPABASE_JWT_AUDIENCE`
+- Turso token broker:
+  - `TURSO_API_URL`
+  - `TURSO_ORGANIZATION_SLUG`
+  - `TURSO_DATABASE_NAME`
+  - `TURSO_DATABASE_URL`
+  - `TURSO_PLATFORM_API_TOKEN` (server-only secret)
+- Media signing (optional):
+  - `R2_ACCOUNT_ID`
+  - `R2_BUCKET`
+  - `R2_ACCESS_KEY_ID` (server-only secret)
+  - `R2_SECRET_ACCESS_KEY` (server-only secret)
+
+## Local run
+
+```bash
+cargo run -p dirt-api
+```
+
+Default bind address: `127.0.0.1:8080`.
+
+## Operational requirements
+
+- Never log raw tokens or secret keys.
+- Rotate `TURSO_PLATFORM_API_TOKEN` and R2 credentials periodically.
+- Revoke/rotate immediately on suspected compromise.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -214,8 +214,8 @@ dirt/
 | ID | Feature | Priority | Status | Blocks |
 |----|---------|----------|--------|--------|
 | F5.8 | Mobile bootstrap config (public values only) | P0 | Todo (`#149`) | F4.1, F2.3 |
-| F5.9 | Token exchange API (Supabase JWT -> short-lived Turso token) | P0 | Todo (`#154`) | F5.8 |
-| F5.10 | Media signing API (presigned upload/download/delete) | P0 | Todo (`#154`, `#150`) | F5.1, F2.3 |
+| F5.9 | Token exchange API (Supabase JWT -> short-lived Turso token) | P0 | In Progress (`#154`) | F5.8 |
+| F5.10 | Media signing API (presigned upload/download/delete) | P0 | In Progress (`#154`, `#150`) | F5.1, F2.3 |
 | F5.11 | Remove runtime env dependency from mobile prod path | P0 | Todo (`#149`, `#151`) | F5.8, F5.9 |
 | F5.12 | Replace mobile R2 client-secret flow with presigned flow | P0 | Todo (`#150`) | F5.10 |
 | F5.13 | Settings UX: user-centric provisioning states (no raw env names) | P1 | Todo (`#151`) | F5.11 |
@@ -555,6 +555,7 @@ Desktop apps will use GitHub Releases as the update source with Tauri-style upda
 
 **Reference**:
 - `docs/SECURITY_BASELINE.md` (threat model, credential policy, incident response, CI guardrails)
+- `docs/BACKEND_API.md` (token broker and media-signing API contract)
 
 ---
 


### PR DESCRIPTION
## Summary
- add new `dirt-api` backend crate for managed credential architecture
- implement Supabase JWT verification against JWKS (auth middleware)
- add `/v1/sync/token` endpoint to broker short-lived Turso sync tokens
- add media presign endpoints for upload/download/delete via R2
- add backend env documentation and API contract docs
- update roadmap statuses for F5.9/F5.10 and architecture issue mapping

## Security notes
- backend config/debug output redacts secret-bearing fields
- API requires bearer token on broker/signing routes
- no long-lived backend secrets are returned in responses

## Validation
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy -p dirt-api --all-targets -- -D warnings`
- `cargo test -p dirt-api`
- `bash .github/scripts/security-guard.sh`

Closes #154
Refs #149
Refs #150
Refs #156