### PR TITLE
feat(mobile): move attachments to backend-presigned media flow (#150)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 TURSO_DATABASE_URL=libsql://your-db-name.turso.io
 TURSO_AUTH_TOKEN=your-database-auth-token
 TURSO_SYNC_TOKEN_ENDPOINT=
+DIRT_API_BASE_URL=
 DIRT_ACCESS_TOKEN=
 
 # Supabase Auth (desktop sign-up/sign-in)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2290,6 +2290,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
 ]
 
 [[package]]

--- a/crates/dirt-mobile/Cargo.toml
+++ b/crates/dirt-mobile/Cargo.toml
@@ -25,6 +25,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 thiserror.workspace = true
 base64 = "0.22"
 mime_guess = "2.0"
+urlencoding = "2.1"
 
 [target.'cfg(target_os = "android")'.dependencies]
 dioxus = { workspace = true, features = ["mobile"] }

--- a/crates/dirt-mobile/build.rs
+++ b/crates/dirt-mobile/build.rs
@@ -21,6 +21,7 @@ struct MobileBootstrapConfig {
     supabase_url: Option<String>,
     supabase_anon_key: Option<String>,
     turso_sync_token_endpoint: Option<String>,
+    dirt_api_base_url: Option<String>,
 }
 
 fn main() {
@@ -28,6 +29,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=SUPABASE_URL");
     println!("cargo:rerun-if-env-changed=SUPABASE_ANON_KEY");
     println!("cargo:rerun-if-env-changed=TURSO_SYNC_TOKEN_ENDPOINT");
+    println!("cargo:rerun-if-env-changed=DIRT_API_BASE_URL");
 
     if let Err(error) = write_mobile_bootstrap_config() {
         println!("cargo:warning=failed to generate mobile bootstrap config: {error}");
@@ -82,6 +84,7 @@ fn write_mobile_bootstrap_config() -> io::Result<()> {
         supabase_url: env_var_trimmed("SUPABASE_URL"),
         supabase_anon_key: env_var_trimmed("SUPABASE_ANON_KEY"),
         turso_sync_token_endpoint: env_var_trimmed("TURSO_SYNC_TOKEN_ENDPOINT"),
+        dirt_api_base_url: env_var_trimmed("DIRT_API_BASE_URL"),
     };
 
     let content = serde_json::to_string_pretty(&config)

--- a/crates/dirt-mobile/src/bootstrap_config.rs
+++ b/crates/dirt-mobile/src/bootstrap_config.rs
@@ -15,6 +15,9 @@ pub struct MobileBootstrapConfig {
     pub supabase_anon_key: Option<String>,
     #[serde(default)]
     pub turso_sync_token_endpoint: Option<String>,
+    /// Optional managed API base URL used for media presign operations.
+    #[serde(default)]
+    pub dirt_api_base_url: Option<String>,
 }
 
 /// Loads the generated mobile bootstrap JSON from `OUT_DIR`.
@@ -42,6 +45,23 @@ pub fn normalize_text_option(value: Option<String>) -> Option<String> {
     }
 }
 
+impl MobileBootstrapConfig {
+    /// Returns the managed API base URL for authenticated media operations.
+    ///
+    /// Prefers `dirt_api_base_url` when present; otherwise derives the base URL
+    /// from `turso_sync_token_endpoint` by stripping `/v1/sync/token`.
+    pub fn managed_api_base_url(&self) -> Option<String> {
+        if let Some(url) = normalize_text_option(self.dirt_api_base_url.clone()) {
+            return Some(url);
+        }
+
+        let endpoint = normalize_text_option(self.turso_sync_token_endpoint.clone())?;
+        endpoint
+            .strip_suffix("/v1/sync/token")
+            .map(std::string::ToString::to_string)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -57,6 +77,18 @@ mod tests {
         assert_eq!(
             normalize_text_option(Some(" https://example.com ".to_string())),
             Some("https://example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn managed_api_base_url_falls_back_to_sync_endpoint_prefix() {
+        let config = MobileBootstrapConfig {
+            turso_sync_token_endpoint: Some("https://api.example.com/v1/sync/token".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            config.managed_api_base_url().as_deref(),
+            Some("https://api.example.com")
         );
     }
 }

--- a/crates/dirt-mobile/src/main.rs
+++ b/crates/dirt-mobile/src/main.rs
@@ -21,6 +21,8 @@ mod filters;
 #[cfg(any(target_os = "android", test))]
 mod launch;
 #[cfg(any(target_os = "android", test))]
+mod media_api;
+#[cfg(any(target_os = "android", test))]
 mod secret_store;
 #[cfg(any(target_os = "android", test))]
 mod sync_auth;

--- a/crates/dirt-mobile/src/media_api.rs
+++ b/crates/dirt-mobile/src/media_api.rs
@@ -1,0 +1,266 @@
+//! Backend media signing client for mobile attachment operations.
+#![cfg_attr(not(target_os = "android"), allow(dead_code))]
+
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+
+use crate::bootstrap_config::MobileBootstrapConfig;
+
+/// HTTP client for managed media operations backed by the Dirt API service.
+#[derive(Debug, Clone)]
+pub struct MediaApiClient {
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl MediaApiClient {
+    /// Builds a client from mobile bootstrap configuration.
+    ///
+    /// Returns `Ok(None)` when managed media is not configured.
+    pub fn new_from_bootstrap(config: &MobileBootstrapConfig) -> Result<Option<Self>, String> {
+        let Some(base_url) = config.managed_api_base_url() else {
+            return Ok(None);
+        };
+        Ok(Some(Self::new(base_url)?))
+    }
+
+    /// Builds a client for an explicit API base URL.
+    pub fn new(base_url: impl Into<String>) -> Result<Self, String> {
+        let base_url = normalize_base_url(base_url.into().as_str())?;
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(|error| format!("Failed to construct HTTP client: {error}"))?;
+        Ok(Self { base_url, client })
+    }
+
+    /// Returns the normalized API base URL used by this client.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Uploads attachment bytes using a backend-issued presigned operation.
+    pub async fn upload(
+        &self,
+        access_token: &str,
+        object_key: &str,
+        content_type: &str,
+        bytes: &[u8],
+    ) -> Result<(), String> {
+        let operation = self
+            .request_presigned(
+                access_token,
+                "/v1/media/presign/upload",
+                &serde_json::json!({
+                    "object_key": object_key,
+                    "content_type": content_type,
+                }),
+            )
+            .await?;
+
+        let method = parse_method(&operation.method)?;
+        let mut request = self.client.request(method, &operation.url);
+        for (name, value) in operation.headers {
+            if name.eq_ignore_ascii_case("host") {
+                continue;
+            }
+            request = request.header(name, value);
+        }
+        let response = request
+            .body(bytes.to_vec())
+            .send()
+            .await
+            .map_err(|error| format!("Upload request failed: {error}"))?;
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "Upload request failed with HTTP {status}: {}",
+                compact_body(&body)
+            ));
+        }
+        Ok(())
+    }
+
+    /// Downloads attachment bytes using a backend-issued presigned operation.
+    ///
+    /// Returns raw bytes and an optional content type returned by the storage backend.
+    pub async fn download(
+        &self,
+        access_token: &str,
+        object_key: &str,
+    ) -> Result<(Vec<u8>, Option<String>), String> {
+        let encoded_object_key = urlencoding::encode(object_key);
+        let url = format!(
+            "{}/v1/media/presign/download?object_key={}",
+            self.base_url, encoded_object_key
+        );
+
+        let response = self
+            .client
+            .get(url)
+            .bearer_auth(access_token)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|error| format!("Failed to request download URL: {error}"))?;
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "Download URL request failed with HTTP {status}: {}",
+                compact_body(&body)
+            ));
+        }
+        let payload = response
+            .json::<PresignResponse>()
+            .await
+            .map_err(|error| format!("Failed to parse download URL response: {error}"))?;
+
+        let operation = payload.operation;
+        let method = parse_method(&operation.method)?;
+        let mut request = self.client.request(method, &operation.url);
+        for (name, value) in operation.headers {
+            if name.eq_ignore_ascii_case("host") {
+                continue;
+            }
+            request = request.header(name, value);
+        }
+        let response = request
+            .send()
+            .await
+            .map_err(|error| format!("Download request failed: {error}"))?;
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "Download request failed with HTTP {status}: {}",
+                compact_body(&body)
+            ));
+        }
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(ToString::to_string);
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|error| format!("Failed to read attachment bytes: {error}"))?;
+        Ok((bytes.to_vec(), content_type))
+    }
+
+    /// Deletes an attachment object using a backend-issued presigned operation.
+    pub async fn delete(&self, access_token: &str, object_key: &str) -> Result<(), String> {
+        let operation = self
+            .request_presigned(
+                access_token,
+                "/v1/media/presign/delete",
+                &serde_json::json!({
+                    "object_key": object_key,
+                }),
+            )
+            .await?;
+
+        let method = parse_method(&operation.method)?;
+        let mut request = self.client.request(method, &operation.url);
+        for (name, value) in operation.headers {
+            if name.eq_ignore_ascii_case("host") {
+                continue;
+            }
+            request = request.header(name, value);
+        }
+        let response = request
+            .send()
+            .await
+            .map_err(|error| format!("Delete request failed: {error}"))?;
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "Delete request failed with HTTP {status}: {}",
+                compact_body(&body)
+            ));
+        }
+        Ok(())
+    }
+
+    async fn request_presigned(
+        &self,
+        access_token: &str,
+        route: &str,
+        body: &serde_json::Value,
+    ) -> Result<PresignedOperation, String> {
+        let response = self
+            .client
+            .post(format!("{}{}", self.base_url, route))
+            .bearer_auth(access_token)
+            .header("Accept", "application/json")
+            .json(body)
+            .send()
+            .await
+            .map_err(|error| format!("Failed to request signed URL: {error}"))?;
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "Signed URL request failed with HTTP {status}: {}",
+                compact_body(&body)
+            ));
+        }
+        let payload = response
+            .json::<PresignResponse>()
+            .await
+            .map_err(|error| format!("Failed to parse signed URL response: {error}"))?;
+        Ok(payload.operation)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PresignResponse {
+    operation: PresignedOperation,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PresignedOperation {
+    method: String,
+    url: String,
+    headers: Vec<(String, String)>,
+}
+
+fn normalize_base_url(raw: &str) -> Result<String, String> {
+    let base = raw.trim().trim_end_matches('/').to_string();
+    if base.is_empty() {
+        return Err("DIRT_API_BASE_URL must not be empty".to_string());
+    }
+    if !(base.starts_with("https://") || base.starts_with("http://")) {
+        return Err("DIRT_API_BASE_URL must include http:// or https://".to_string());
+    }
+    Ok(base)
+}
+
+fn parse_method(raw: &str) -> Result<Method, String> {
+    Method::from_bytes(raw.as_bytes()).map_err(|error| format!("Unsupported HTTP method: {error}"))
+}
+
+fn compact_body(body: &str) -> String {
+    body.trim().chars().take(180).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_base_url_rejects_invalid_values() {
+        assert!(normalize_base_url("").is_err());
+        assert!(normalize_base_url("example.com").is_err());
+    }
+
+    #[test]
+    fn normalize_base_url_trims_trailing_slash() {
+        assert_eq!(
+            normalize_base_url("https://api.example.com/").unwrap(),
+            "https://api.example.com"
+        );
+    }
+}


### PR DESCRIPTION
## Summary\n- switch mobile attachment upload/download/delete to backend-presigned media operations\n- add MediaApiClient and bootstrap support for DIRT_API_BASE_URL (with sync-endpoint fallback)\n- wire attachment actions through authenticated managed API path and remove direct client-side R2 secret dependency\n\n## Validation\n- cargo fmt --all\n- cargo test -p dirt-mobile\n- cargo clippy -p dirt-mobile --all-targets -- -D warnings\n\n## Notes\n- mobile now requires authenticated Supabase session + managed API endpoint for attachment operations\n- settings diagnostics mark media path as backend-managed when configured