### PR TITLE
Split .env into role-separated client and server configs

### DIFF
--- a/.env.client.example
+++ b/.env.client.example
@@ -1,0 +1,19 @@
+# Client build-time configuration
+# These values are read by build.rs and baked into the bootstrap JSON
+# embedded in desktop/mobile binaries. Safe to embed — no secrets here.
+#
+# Copy to .env.client and fill in your values:
+#   cp .env.client.example .env.client
+
+# Supabase Auth (public anon key — safe for client binaries)
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_ANON_KEY=
+
+# Managed sync token endpoint (set by API server bootstrap)
+TURSO_SYNC_TOKEN_ENDPOINT=
+
+# API server base URL (used to derive bootstrap manifest URL)
+DIRT_API_BASE_URL=
+
+# Override bootstrap manifest URL directly (optional)
+DIRT_BOOTSTRAP_URL=

--- a/.env.example
+++ b/.env.example
@@ -1,40 +1,13 @@
-TURSO_DATABASE_URL=libsql://your-db-name.turso.io
-TURSO_AUTH_TOKEN=your-database-auth-token
-TURSO_SYNC_TOKEN_ENDPOINT=
-DIRT_API_BASE_URL=
-DIRT_BOOTSTRAP_URL=
-DIRT_ACCESS_TOKEN=
-
-# Supabase Auth (desktop sign-up/sign-in)
-# Example: https://your-project-ref.supabase.co
-SUPABASE_URL=
-# Use anon/public key (never use service_role in desktop app)
-SUPABASE_ANON_KEY=
-
-# Backend API (server-side only; do NOT ship these in desktop/mobile binaries)
-DIRT_API_BIND_ADDR=127.0.0.1:8080
-BOOTSTRAP_PUBLIC_API_BASE_URL=
-BOOTSTRAP_MANIFEST_VERSION=1
-BOOTSTRAP_CACHE_MAX_AGE_SECS=300
-SUPABASE_JWKS_URL=
-SUPABASE_JWT_ISSUER=
-SUPABASE_JWT_AUDIENCE=authenticated
-SUPABASE_JWKS_CACHE_TTL_SECS=300
-TURSO_API_URL=https://api.turso.tech
-TURSO_ORGANIZATION_SLUG=
-TURSO_DATABASE_NAME=
-TURSO_PLATFORM_API_TOKEN=
-TURSO_SYNC_TOKEN_TTL_SECS=900
-MEDIA_SIGNED_URL_TTL_SECS=600
-AUTH_CLOCK_SKEW_SECS=60
-RATE_LIMIT_WINDOW_SECS=60
-SYNC_TOKEN_RATE_LIMIT_PER_WINDOW=20
-MEDIA_PRESIGN_RATE_LIMIT_PER_WINDOW=120
-
-# Notes:
-# - Mobile managed sync flow uses `TURSO_SYNC_TOKEN_ENDPOINT` + Supabase session to mint short-lived Turso tokens.
-# - `DIRT_BOOTSTRAP_URL` can point clients/CLI to `https://<api-host>/v1/bootstrap` for managed zero-config setup.
-# - `TURSO_AUTH_TOKEN` is only for local/dev fallback and should not be shipped in production mobile builds.
-# - Dev setup without SMTP: enable `mailer_autoconfirm` in Supabase Auth to bypass email delivery.
-# - Production setup: configure custom SMTP to avoid default email rate limits.
-# - R2 secrets should live on backend only; clients should use presigned URL flows.
+# Environment configuration has been split by role:
+#
+#   .env.client.example  — Build-time config for desktop/mobile (safe to embed)
+#   .env.server.example  — Server-side secrets for dirt-api (NEVER ship in clients)
+#
+# Quick start:
+#   cp .env.client.example .env.client   # for building desktop/mobile
+#   cp .env.server.example .env.server   # for running dirt-api locally
+#
+# This legacy .env file is still supported as a fallback but will be removed
+# in a future release. Prefer the role-separated files above.
+#
+# See docs/DESIGN.md for the full configuration architecture.

--- a/.env.server.example
+++ b/.env.server.example
@@ -1,0 +1,47 @@
+# Server-side configuration (dirt-api only)
+# These secrets must NEVER reach client binaries.
+#
+# Copy to .env.server and fill in your values:
+#   cp .env.server.example .env.server
+#
+# In production, use platform-native env injection instead:
+#   fly secrets set TURSO_PLATFORM_API_TOKEN=...
+#   docker run -e TURSO_PLATFORM_API_TOKEN=...
+
+# --- Server binding ---
+DIRT_API_BIND_ADDR=127.0.0.1:8080
+
+# --- Bootstrap manifest ---
+BOOTSTRAP_PUBLIC_API_BASE_URL=
+BOOTSTRAP_MANIFEST_VERSION=1
+BOOTSTRAP_CACHE_MAX_AGE_SECS=300
+
+# --- Supabase JWT verification ---
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_ANON_KEY=
+SUPABASE_JWKS_URL=
+SUPABASE_JWT_ISSUER=
+SUPABASE_JWT_AUDIENCE=authenticated
+SUPABASE_JWKS_CACHE_TTL_SECS=300
+
+# --- Turso (database provisioning + sync tokens) ---
+TURSO_API_URL=https://api.turso.tech
+TURSO_ORGANIZATION_SLUG=
+TURSO_DATABASE_NAME=
+TURSO_PLATFORM_API_TOKEN=
+TURSO_SYNC_TOKEN_TTL_SECS=900
+
+# --- Media / R2 storage ---
+MEDIA_SIGNED_URL_TTL_SECS=600
+
+# --- Auth tuning ---
+AUTH_CLOCK_SKEW_SECS=60
+
+# --- Rate limiting ---
+RATE_LIMIT_WINDOW_SECS=60
+SYNC_TOKEN_RATE_LIMIT_PER_WINDOW=20
+MEDIA_PRESIGN_RATE_LIMIT_PER_WINDOW=120
+
+# --- Dev-only fallbacks (do NOT use in production) ---
+# TURSO_DATABASE_URL=libsql://your-db-name.turso.io
+# TURSO_AUTH_TOKEN=your-database-auth-token

--- a/.gitignore
+++ b/.gitignore
@@ -24,10 +24,12 @@ Thumbs.db
 *.wasm
 dx.lock
 
-# Environment
+# Environment (all .env files except examples are gitignored)
 .env
 .env.local
 .env.*.local
+.env.client
+.env.server
 
 # Database
 *.db

--- a/crates/dirt-api/src/main.rs
+++ b/crates/dirt-api/src/main.rs
@@ -11,9 +11,21 @@ use std::sync::Arc;
 use config::AppConfig;
 use routes::{app_router, AppState};
 
+/// Load .env.server (preferred) or legacy .env for local development only.
+#[cfg(debug_assertions)]
+fn load_dev_dotenv() {
+    let server_env = std::path::Path::new(".env.server");
+    if server_env.exists() {
+        let _ = dotenvy::from_path(server_env);
+    } else {
+        dotenvy::dotenv().ok();
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    dotenvy::dotenv().ok();
+    #[cfg(debug_assertions)]
+    load_dev_dotenv();
 
     tracing_subscriber::fmt()
         .with_env_filter(

--- a/crates/dirt-desktop/build.rs
+++ b/crates/dirt-desktop/build.rs
@@ -58,9 +58,16 @@ fn write_desktop_bootstrap_config() -> io::Result<()> {
 fn load_workspace_dotenv() {
     let manifest_dir =
         env::var_os("CARGO_MANIFEST_DIR").map_or_else(|| PathBuf::from("."), PathBuf::from);
-    let candidate = manifest_dir.join("..").join("..").join(".env");
-    if candidate.exists() {
-        let _ = dotenvy::from_path(candidate);
+    let workspace_root = manifest_dir.join("..").join("..");
+
+    // Prefer .env.client (role-separated) over legacy .env
+    let client_env = workspace_root.join(".env.client");
+    let legacy_env = workspace_root.join(".env");
+
+    if client_env.exists() {
+        let _ = dotenvy::from_path(client_env);
+    } else if legacy_env.exists() {
+        let _ = dotenvy::from_path(legacy_env);
     }
 }
 

--- a/crates/dirt-mobile/build.rs
+++ b/crates/dirt-mobile/build.rs
@@ -106,9 +106,16 @@ fn write_mobile_bootstrap_config() -> io::Result<()> {
 fn load_workspace_dotenv() {
     let manifest_dir =
         env::var_os("CARGO_MANIFEST_DIR").map_or_else(|| PathBuf::from("."), PathBuf::from);
-    let candidate = manifest_dir.join("..").join("..").join(".env");
-    if candidate.exists() {
-        let _ = dotenvy::from_path(candidate);
+    let workspace_root = manifest_dir.join("..").join("..");
+
+    // Prefer .env.client (role-separated) over legacy .env
+    let client_env = workspace_root.join(".env.client");
+    let legacy_env = workspace_root.join(".env");
+
+    if client_env.exists() {
+        let _ = dotenvy::from_path(client_env);
+    } else if legacy_env.exists() {
+        let _ = dotenvy::from_path(legacy_env);
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `.env.client.example` with build-time client config only (Supabase public URL/key, API endpoints)
- Add `.env.server.example` with server-side secrets only (Turso API tokens, R2 keys, rate limits)
- Update `build.rs` in desktop and mobile to prefer `.env.client` over legacy `.env`
- Update API server to prefer `.env.server` over legacy `.env` (debug builds only)
- Update `.gitignore` to cover new `.env.client` and `.env.server`
- Replace `.env.example` with a redirect to the role-separated files

Legacy `.env` still works as a fallback for backwards compatibility.

## Test plan

- [x] `cargo check --all` — all crates compile
- [x] `cargo test --all` — 57 tests pass
- [ ] Manual: verify `cp .env.client.example .env.client && cargo build -p dirt-desktop` picks up client config
- [ ] Manual: verify `cp .env.server.example .env.server && cargo run -p dirt-api` picks up server config

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)