### PR TITLE
Fix binary name collision between dirt-desktop and dirt-cli

### DIFF
--- a/crates/dirt-desktop/Cargo.toml
+++ b/crates/dirt-desktop/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "Desktop application for Dirt"
 
 [[bin]]
-name = "dirt"
+name = "dirt-desktop"
 path = "src/main.rs"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- Rename desktop binary from `dirt` to `dirt-desktop` in `crates/dirt-desktop/Cargo.toml`
- Keep CLI binary as `dirt` for existing UX (`dirt "my thought"`)
- No Makefile or Dioxus config changes required: run target is package-based (`dx serve --package dirt-desktop`)

## Validation

- `cargo check -p dirt-cli -p dirt-desktop`
- `cargo metadata --no-deps --format-version 1` confirms unique bin names:
  - `dirt-cli` -> `dirt`
  - `dirt-desktop` -> `dirt-desktop`

Closes #188
