### PR TITLE
refactor(core): consolidate shared auth/sync/media/config services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2235,12 +2235,14 @@ dependencies = [
  "libsql",
  "pretty_assertions",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "urlencoding",
  "uuid",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: fmt lint check test build run clean
+.PHONY: fmt lint check test build run clean ci api mobile-android dev-android help
+
+EMULATOR_API_BASE_URL ?= http://10.0.2.2:8080
+EMULATOR_BOOTSTRAP_URL ?= $(EMULATOR_API_BASE_URL)/v1/bootstrap
+EMULATOR_SYNC_TOKEN_ENDPOINT ?= $(EMULATOR_API_BASE_URL)/v1/sync/token
 
 # Format code
 fmt:
@@ -24,9 +28,47 @@ build:
 run:
 	dx serve --platform desktop --package dirt-desktop
 
+# Run backend API (loads .env if present)
+api:
+	@sh -c 'set -a; [ -f .env ] && . ./.env; set +a; cargo run -p dirt-api'
+
+# Run Android app with emulator-safe API URLs (requires SUPABASE_URL + SUPABASE_ANON_KEY in .env)
+mobile-android:
+	@sh -c 'set -a; [ -f .env ] && . ./.env; set +a; \
+		test -n "$$SUPABASE_URL" || { echo "SUPABASE_URL is required (.env)"; exit 1; }; \
+		test -n "$$SUPABASE_ANON_KEY" || { echo "SUPABASE_ANON_KEY is required (.env)"; exit 1; }; \
+		DIRT_API_BASE_URL="$(EMULATOR_API_BASE_URL)" \
+		DIRT_BOOTSTRAP_URL="$(EMULATOR_BOOTSTRAP_URL)" \
+		TURSO_SYNC_TOKEN_ENDPOINT="$(EMULATOR_SYNC_TOKEN_ENDPOINT)" \
+		SUPABASE_URL="$$SUPABASE_URL" \
+		SUPABASE_ANON_KEY="$$SUPABASE_ANON_KEY" \
+		dx serve --platform android --package dirt-mobile'
+
+# Start API + Android app together (Ctrl+C stops both)
+dev-android:
+	@sh -c 'set -a; [ -f .env ] && . ./.env; set +a; \
+		test -n "$$SUPABASE_URL" || { echo "SUPABASE_URL is required (.env)"; exit 1; }; \
+		test -n "$$SUPABASE_ANON_KEY" || { echo "SUPABASE_ANON_KEY is required (.env)"; exit 1; }; \
+		cargo run -p dirt-api & api_pid=$$!; \
+		trap "kill $$api_pid 2>/dev/null || true" EXIT INT TERM; \
+		DIRT_API_BASE_URL="$(EMULATOR_API_BASE_URL)" \
+		DIRT_BOOTSTRAP_URL="$(EMULATOR_BOOTSTRAP_URL)" \
+		TURSO_SYNC_TOKEN_ENDPOINT="$(EMULATOR_SYNC_TOKEN_ENDPOINT)" \
+		SUPABASE_URL="$$SUPABASE_URL" \
+		SUPABASE_ANON_KEY="$$SUPABASE_ANON_KEY" \
+		dx serve --platform android --package dirt-mobile'
+
 # Clean build artifacts
 clean:
 	cargo clean
 
 # All checks (fmt + lint + test)
 ci: fmt lint test
+
+help:
+	@echo "Targets:"
+	@echo "  make api              - run dirt-api with .env"
+	@echo "  make mobile-android   - run Android app with emulator env"
+	@echo "  make dev-android      - run API + Android app together"
+	@echo "  make run              - run desktop app"
+	@echo "  make ci               - fmt + lint + test"

--- a/crates/dirt-cli/src/auth.rs
+++ b/crates/dirt-cli/src/auth.rs
@@ -2,73 +2,21 @@
 
 #[cfg(test)]
 use std::collections::HashMap;
-use std::fmt;
 #[cfg(test)]
 use std::sync::{Mutex, OnceLock};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(not(test))]
 use keyring::Entry;
-use reqwest::{Client, RequestBuilder, StatusCode};
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
 
-use crate::config_profiles::{is_http_url, CliProfile};
+use crate::config_profiles::CliProfile;
+
+use dirt_core::auth::{
+    resolve_optional_supabase_config, AuthResult, SessionPersistence, SupabaseAuthClient,
+};
+pub use dirt_core::auth::{AuthError, AuthSession};
 
 #[cfg(not(test))]
 const KEYRING_SERVICE_NAME: &str = "dirt-cli";
-const EXPIRY_SKEW_SECONDS: i64 = 60;
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AuthUser {
-    pub id: String,
-    pub email: Option<String>,
-}
-
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AuthSession {
-    pub access_token: String,
-    pub refresh_token: String,
-    pub expires_at: i64,
-    pub user: AuthUser,
-}
-
-impl AuthSession {
-    #[must_use]
-    pub fn is_expired(&self) -> bool {
-        self.expires_at <= unix_timestamp_now() + EXPIRY_SKEW_SECONDS
-    }
-}
-
-impl fmt::Debug for AuthSession {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("AuthSession")
-            .field("access_token", &"[REDACTED]")
-            .field("refresh_token", &"[REDACTED]")
-            .field("expires_at", &self.expires_at)
-            .field("user", &self.user)
-            .finish()
-    }
-}
-
-#[derive(Debug, Error)]
-pub enum AuthError {
-    #[error("Auth is not configured for profile '{0}'")]
-    NotConfigured(String),
-    #[error("Invalid auth configuration: {0}")]
-    InvalidConfiguration(&'static str),
-    #[error("HTTP request failed: {0}")]
-    Http(#[from] reqwest::Error),
-    #[error("JSON error: {0}")]
-    Json(#[from] serde_json::Error),
-    #[error("Auth API error: {0}")]
-    Api(String),
-    #[error("Secure storage error: {0}")]
-    SecureStorage(String),
-}
-
-type AuthResult<T> = Result<T, AuthError>;
 
 #[derive(Clone)]
 struct SessionStore {
@@ -93,9 +41,11 @@ impl SessionStore {
         Entry::new(KEYRING_SERVICE_NAME, &self.username)
             .map_err(|error| AuthError::SecureStorage(error.to_string()))
     }
+}
 
+impl SessionPersistence for SessionStore {
     #[cfg(not(test))]
-    fn load(&self) -> AuthResult<Option<AuthSession>> {
+    fn load_session(&self) -> AuthResult<Option<AuthSession>> {
         let entry = self.entry()?;
         match entry.get_password() {
             Ok(raw) => Ok(Some(serde_json::from_str(&raw)?)),
@@ -105,7 +55,7 @@ impl SessionStore {
     }
 
     #[cfg(test)]
-    fn load(&self) -> AuthResult<Option<AuthSession>> {
+    fn load_session(&self) -> AuthResult<Option<AuthSession>> {
         let store = Self::test_store();
         let guard = store
             .lock()
@@ -118,7 +68,7 @@ impl SessionStore {
     }
 
     #[cfg(not(test))]
-    fn save(&self, session: &AuthSession) -> AuthResult<()> {
+    fn save_session(&self, session: &AuthSession) -> AuthResult<()> {
         let raw = serde_json::to_string(session)?;
         self.entry()?
             .set_password(&raw)
@@ -127,7 +77,7 @@ impl SessionStore {
     }
 
     #[cfg(test)]
-    fn save(&self, session: &AuthSession) -> AuthResult<()> {
+    fn save_session(&self, session: &AuthSession) -> AuthResult<()> {
         let raw = serde_json::to_string(session)?;
         let store = Self::test_store();
         let mut guard = store
@@ -138,7 +88,7 @@ impl SessionStore {
     }
 
     #[cfg(not(test))]
-    fn clear(&self) -> AuthResult<()> {
+    fn clear_session(&self) -> AuthResult<()> {
         let entry = self.entry()?;
         match entry.delete_credential() {
             Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
@@ -147,7 +97,7 @@ impl SessionStore {
     }
 
     #[cfg(test)]
-    fn clear(&self) -> AuthResult<()> {
+    fn clear_session(&self) -> AuthResult<()> {
         let store = Self::test_store();
         let mut guard = store
             .lock()
@@ -159,22 +109,18 @@ impl SessionStore {
 
 #[derive(Clone)]
 pub struct SupabaseAuthService {
-    auth_url: String,
-    anon_key: String,
-    client: Client,
-    store: SessionStore,
+    inner: SupabaseAuthClient<SessionStore>,
 }
 
 impl SupabaseAuthService {
     pub fn new_for_profile(profile_name: &str, profile: &CliProfile) -> AuthResult<Option<Self>> {
-        let url = profile.supabase_url();
-        let anon_key = profile.supabase_anon_key();
+        let Some((url, anon_key)) =
+            resolve_optional_supabase_config(profile.supabase_url(), profile.supabase_anon_key())?
+        else {
+            return Ok(None);
+        };
 
-        match (url, anon_key) {
-            (None, None) => Ok(None),
-            (Some(url), Some(anon_key)) => Self::new(profile_name, &url, &anon_key).map(Some),
-            _ => Err(AuthError::NotConfigured(profile_name.to_string())),
-        }
+        Ok(Some(Self::new(profile_name, &url, &anon_key)?))
     }
 
     pub fn new(
@@ -182,272 +128,45 @@ impl SupabaseAuthService {
         url: impl AsRef<str>,
         anon_key: impl AsRef<str>,
     ) -> AuthResult<Self> {
-        let auth_url = normalize_auth_url(url.as_ref())?;
-        let anon_key = anon_key.as_ref().trim().to_string();
-        if anon_key.is_empty() {
-            return Err(AuthError::InvalidConfiguration(
-                "Supabase anon key must not be empty",
-            ));
-        }
-
         Ok(Self {
-            auth_url,
-            anon_key,
-            client: Client::builder().build()?,
-            store: SessionStore::new(profile_name),
+            inner: SupabaseAuthClient::new(
+                url,
+                anon_key.as_ref().to_string(),
+                SessionStore::new(profile_name),
+            )?,
         })
     }
 
     pub async fn sign_in(&self, email: &str, password: &str) -> AuthResult<AuthSession> {
-        validate_credentials(email, password)?;
-
-        let payload = serde_json::json!({
-            "email": email,
-            "password": password,
-        });
-        let request = self.public_request(
-            self.client
-                .post(format!("{}/token", self.auth_url))
-                .query(&[("grant_type", "password")])
-                .json(&payload),
-        );
-        let response = self.send_auth_request(request).await?;
-        let session = response.into_session()?.ok_or_else(|| {
-            AuthError::Api("Sign-in response did not include an active session".to_string())
-        })?;
-        self.store.save(&session)?;
-        Ok(session)
+        self.inner.sign_in(email, password).await
     }
 
     pub async fn restore_session(&self) -> AuthResult<Option<AuthSession>> {
-        let Some(stored_session) = self.store.load()? else {
-            return Ok(None);
-        };
-
-        if !stored_session.is_expired() {
-            return Ok(Some(stored_session));
-        }
-
-        match self.refresh_session(&stored_session.refresh_token).await {
-            Ok(session) => Ok(Some(session)),
-            Err(error) => {
-                tracing::warn!("Failed to refresh CLI auth session: {}", error);
-                self.store.clear()?;
-                Ok(None)
-            }
-        }
+        self.inner.restore_session().await
     }
 
     pub async fn refresh_session(&self, refresh_token: &str) -> AuthResult<AuthSession> {
-        if refresh_token.trim().is_empty() {
-            return Err(AuthError::InvalidConfiguration(
-                "Refresh token must not be empty",
-            ));
-        }
-
-        let payload = serde_json::json!({
-            "refresh_token": refresh_token,
-        });
-        let request = self.public_request(
-            self.client
-                .post(format!("{}/token", self.auth_url))
-                .query(&[("grant_type", "refresh_token")])
-                .json(&payload),
-        );
-        let response = self.send_auth_request(request).await?;
-        let session = response.into_session()?.ok_or_else(|| {
-            AuthError::Api("Refresh response did not include an active session".to_string())
-        })?;
-        self.store.save(&session)?;
-        Ok(session)
+        self.inner.refresh_session(refresh_token).await
     }
 
     pub async fn sign_out(&self, access_token: &str) -> AuthResult<()> {
-        let request = self
-            .client
-            .post(format!("{}/logout", self.auth_url))
-            .header("apikey", &self.anon_key)
-            .bearer_auth(access_token);
-
-        let response = request.send().await?;
-        if !(response.status().is_success() || response.status() == StatusCode::UNAUTHORIZED) {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AuthError::Api(parse_api_error(status, &body)));
-        }
-
-        self.store.clear()
+        self.inner.sign_out(access_token).await
     }
 }
 
 pub fn load_stored_session(profile_name: &str) -> AuthResult<Option<AuthSession>> {
-    SessionStore::new(profile_name).load()
+    SessionStore::new(profile_name).load_session()
 }
 
 pub fn clear_stored_session(profile_name: &str) -> AuthResult<()> {
-    SessionStore::new(profile_name).clear()
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseAuthResponse {
-    access_token: Option<String>,
-    refresh_token: Option<String>,
-    expires_at: Option<i64>,
-    expires_in: Option<i64>,
-    user: Option<SupabaseUser>,
-    session: Option<SupabaseAuthResponseSession>,
-}
-
-impl SupabaseAuthResponse {
-    fn into_session(self) -> AuthResult<Option<AuthSession>> {
-        let nested_session = self.session;
-        let access_token = self
-            .access_token
-            .or_else(|| nested_session.as_ref().and_then(|s| s.access_token.clone()));
-        let refresh_token = self.refresh_token.or_else(|| {
-            nested_session
-                .as_ref()
-                .and_then(|s| s.refresh_token.clone())
-        });
-        let expires_at = self
-            .expires_at
-            .or_else(|| nested_session.as_ref().and_then(|s| s.expires_at))
-            .or_else(|| {
-                self.expires_in
-                    .or_else(|| nested_session.as_ref().and_then(|s| s.expires_in))
-                    .map(|expires_in| unix_timestamp_now().saturating_add(expires_in))
-            });
-        let user = self
-            .user
-            .or_else(|| nested_session.and_then(|s| s.user))
-            .map(Into::into);
-
-        match (access_token, refresh_token, expires_at, user) {
-            (Some(access_token), Some(refresh_token), Some(expires_at), Some(user)) => {
-                Ok(Some(AuthSession {
-                    access_token,
-                    refresh_token,
-                    expires_at,
-                    user,
-                }))
-            }
-            (None, None, None, Some(_)) => Ok(None),
-            _ => Err(AuthError::Api(
-                "Auth response did not include enough session fields".to_string(),
-            )),
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseAuthResponseSession {
-    access_token: Option<String>,
-    refresh_token: Option<String>,
-    expires_at: Option<i64>,
-    expires_in: Option<i64>,
-    user: Option<SupabaseUser>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseUser {
-    id: String,
-    email: Option<String>,
-}
-
-impl From<SupabaseUser> for AuthUser {
-    fn from(value: SupabaseUser) -> Self {
-        Self {
-            id: value.id,
-            email: value.email,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseErrorResponse {
-    error: Option<String>,
-    error_description: Option<String>,
-    message: Option<String>,
-    msg: Option<String>,
-}
-
-fn parse_api_error(status: StatusCode, body: &str) -> String {
-    if let Ok(payload) = serde_json::from_str::<SupabaseErrorResponse>(body) {
-        if let Some(message) = payload
-            .message
-            .or(payload.msg)
-            .or(payload.error_description)
-            .or(payload.error)
-        {
-            return format!("{} ({})", message.trim(), status.as_u16());
-        }
-    }
-
-    let trimmed = body.trim();
-    if trimmed.is_empty() {
-        format!("HTTP {}", status.as_u16())
-    } else {
-        format!("{} ({})", trimmed, status.as_u16())
-    }
-}
-
-fn normalize_auth_url(url: &str) -> AuthResult<String> {
-    let trimmed = url.trim().trim_end_matches('/');
-    if trimmed.is_empty() {
-        return Err(AuthError::InvalidConfiguration(
-            "Supabase URL must not be empty",
-        ));
-    }
-    if !is_http_url(trimmed) {
-        return Err(AuthError::InvalidConfiguration(
-            "Supabase URL must include http:// or https://",
-        ));
-    }
-    if trimmed.ends_with("/auth/v1") {
-        Ok(trimmed.to_string())
-    } else {
-        Ok(format!("{trimmed}/auth/v1"))
-    }
-}
-
-fn validate_credentials(email: &str, password: &str) -> AuthResult<()> {
-    if email.trim().is_empty() {
-        return Err(AuthError::Api("Email is required".to_string()));
-    }
-    if password.trim().is_empty() {
-        return Err(AuthError::Api("Password is required".to_string()));
-    }
-    Ok(())
-}
-
-fn unix_timestamp_now() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| {
-            i64::try_from(duration.as_secs()).unwrap_or(i64::MAX)
-        })
-}
-
-impl SupabaseAuthService {
-    fn public_request(&self, request: RequestBuilder) -> RequestBuilder {
-        request
-            .header("apikey", &self.anon_key)
-            .header("Authorization", format!("Bearer {}", self.anon_key))
-    }
-
-    async fn send_auth_request(&self, request: RequestBuilder) -> AuthResult<SupabaseAuthResponse> {
-        let response = request.send().await?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AuthError::Api(parse_api_error(status, &body)));
-        }
-        Ok(response.json::<SupabaseAuthResponse>().await?)
-    }
+    SessionStore::new(profile_name).clear_session()
 }
 
 #[cfg(test)]
 mod tests {
+    use dirt_core::auth::normalize_auth_url;
+    use dirt_core::auth::AuthUser;
+
     use super::*;
 
     #[test]
@@ -460,22 +179,6 @@ mod tests {
     fn normalize_auth_url_keeps_auth_suffix() {
         let normalized = normalize_auth_url("https://demo.supabase.co/auth/v1").unwrap();
         assert_eq!(normalized, "https://demo.supabase.co/auth/v1");
-    }
-
-    #[test]
-    fn response_with_only_user_returns_confirmation_required() {
-        let response = SupabaseAuthResponse {
-            access_token: None,
-            refresh_token: None,
-            expires_at: None,
-            expires_in: None,
-            user: Some(SupabaseUser {
-                id: "user".to_string(),
-                email: Some("user@example.com".to_string()),
-            }),
-            session: None,
-        };
-        assert!(response.into_session().unwrap().is_none());
     }
 
     #[test]

--- a/crates/dirt-cli/src/bootstrap_manifest.rs
+++ b/crates/dirt-cli/src/bootstrap_manifest.rs
@@ -1,174 +1,34 @@
 //! Managed bootstrap manifest client for CLI profile initialization.
 
-use std::time::Duration;
-
-use serde::Deserialize;
 use thiserror::Error;
 
-use crate::config_profiles::is_http_url;
+pub type ManagedBootstrapConfig = dirt_core::config::ManagedBootstrapConfig;
 
-const BOOTSTRAP_SCHEMA_VERSION: u32 = 1;
-const BOOTSTRAP_HTTP_TIMEOUT_SECS: u64 = 5;
-
-/// Managed runtime configuration loaded from the backend bootstrap endpoint.
-///
-/// These values are public bootstrap fields that allow the CLI to initialize
-/// profile auth/sync configuration without user-provided infra secrets.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ManagedBootstrapConfig {
-    /// Supabase project URL used for auth flows.
-    pub supabase_url: String,
-    /// Supabase anon/public key used by client auth requests.
-    pub supabase_anon_key: String,
-    /// Public Dirt API base URL used for managed backend operations.
-    pub api_base_url: String,
-    /// Optional explicit managed sync token endpoint.
-    pub sync_token_endpoint: Option<String>,
-    /// Whether managed sync token exchange is enabled.
-    pub managed_sync: bool,
-    /// Whether managed media presign flows are enabled.
-    pub managed_media: bool,
-}
-
-/// Errors returned while fetching or parsing managed bootstrap manifests.
 #[derive(Debug, Error)]
 pub enum ManagedBootstrapError {
-    #[error("Invalid bootstrap URL: {0}")]
-    InvalidUrl(String),
-    #[error("Bootstrap request failed: {0}")]
-    Request(#[from] reqwest::Error),
-    #[error("Bootstrap endpoint returned HTTP {status}: {body}")]
-    HttpStatus { status: u16, body: String },
-    #[error("Invalid bootstrap payload: {0}")]
-    InvalidPayload(String),
+    #[error("{0}")]
+    Message(String),
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct ManagedBootstrapManifest {
-    schema_version: u32,
-    manifest_version: String,
-    supabase_url: String,
-    supabase_anon_key: String,
-    api_base_url: String,
-    #[serde(default)]
-    turso_sync_token_endpoint: Option<String>,
-    feature_flags: ManagedFeatureFlags,
+impl From<String> for ManagedBootstrapError {
+    fn from(value: String) -> Self {
+        Self::Message(value)
+    }
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct ManagedFeatureFlags {
-    managed_sync: bool,
-    managed_media: bool,
-}
-
-/// Fetches and validates a managed bootstrap manifest from the given URL.
-///
-/// This call enforces schema validation and URL normalization before returning
-/// runtime client configuration.
 pub async fn fetch_bootstrap_manifest(
     bootstrap_url: &str,
 ) -> Result<ManagedBootstrapConfig, ManagedBootstrapError> {
-    let bootstrap_url = normalize_url(bootstrap_url, "bootstrap_url")?;
-
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(BOOTSTRAP_HTTP_TIMEOUT_SECS))
-        .build()?;
-
-    let response = client
-        .get(&bootstrap_url)
-        .header(reqwest::header::ACCEPT, "application/json")
-        .send()
-        .await?;
-
-    if !response.status().is_success() {
-        let status = response.status().as_u16();
-        let body = response.text().await.unwrap_or_default();
-        return Err(ManagedBootstrapError::HttpStatus {
-            status,
-            body: compact_text(&body),
-        });
-    }
-
-    let body = response.text().await?;
-    parse_bootstrap_manifest(&body)
+    dirt_core::config::fetch_managed_bootstrap_manifest(bootstrap_url)
+        .await
+        .map_err(Into::into)
 }
 
-/// Parses a bootstrap manifest JSON payload into runtime configuration.
-///
-/// Parsing rejects unknown fields and unsupported schema versions.
+#[allow(dead_code)]
 pub fn parse_bootstrap_manifest(
     payload: &str,
 ) -> Result<ManagedBootstrapConfig, ManagedBootstrapError> {
-    let manifest: ManagedBootstrapManifest = serde_json::from_str(payload)
-        .map_err(|error| ManagedBootstrapError::InvalidPayload(error.to_string()))?;
-    manifest.into_runtime_config()
-}
-
-impl ManagedBootstrapManifest {
-    fn into_runtime_config(self) -> Result<ManagedBootstrapConfig, ManagedBootstrapError> {
-        if self.schema_version != BOOTSTRAP_SCHEMA_VERSION {
-            return Err(ManagedBootstrapError::InvalidPayload(format!(
-                "unsupported schema_version {} (expected {})",
-                self.schema_version, BOOTSTRAP_SCHEMA_VERSION
-            )));
-        }
-        if self.manifest_version.trim().is_empty() {
-            return Err(ManagedBootstrapError::InvalidPayload(
-                "manifest_version must not be empty".to_string(),
-            ));
-        }
-
-        let supabase_url = normalize_url(&self.supabase_url, "supabase_url")?;
-        let supabase_anon_key =
-            normalize_required_value(&self.supabase_anon_key, "supabase_anon_key")?;
-        let api_base_url = normalize_url(&self.api_base_url, "api_base_url")?;
-
-        let sync_token_endpoint = if self.feature_flags.managed_sync {
-            match self.turso_sync_token_endpoint {
-                Some(endpoint) => Some(normalize_url(&endpoint, "turso_sync_token_endpoint")?),
-                None => Some(format!("{api_base_url}/v1/sync/token")),
-            }
-        } else {
-            None
-        };
-
-        Ok(ManagedBootstrapConfig {
-            supabase_url,
-            supabase_anon_key,
-            api_base_url,
-            sync_token_endpoint,
-            managed_sync: self.feature_flags.managed_sync,
-            managed_media: self.feature_flags.managed_media,
-        })
-    }
-}
-
-fn normalize_required_value(value: &str, field: &str) -> Result<String, ManagedBootstrapError> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        Err(ManagedBootstrapError::InvalidPayload(format!(
-            "field '{field}' must not be empty"
-        )))
-    } else {
-        Ok(trimmed.to_string())
-    }
-}
-
-fn normalize_url(value: &str, field: &str) -> Result<String, ManagedBootstrapError> {
-    let value = normalize_required_value(value, field)?;
-    if is_http_url(&value) {
-        Ok(value.trim_end_matches('/').to_string())
-    } else {
-        Err(ManagedBootstrapError::InvalidUrl(format!(
-            "field '{field}' must include http:// or https://"
-        )))
-    }
-}
-
-fn compact_text(value: &str) -> String {
-    value.trim().chars().take(180).collect()
+    dirt_core::config::parse_managed_bootstrap_manifest(payload).map_err(Into::into)
 }
 
 #[cfg(test)]
@@ -222,26 +82,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_bootstrap_manifest_rejects_invalid_schema() {
-        let payload = r#"
-        {
-          "schema_version": 2,
-          "manifest_version": "v1",
-          "supabase_url": "https://project.supabase.co",
-          "supabase_anon_key": "anon",
-          "api_base_url": "https://api.example.com",
-          "feature_flags": {
-            "managed_sync": true,
-            "managed_media": false
-          }
-        }
-        "#;
-
-        let error = parse_bootstrap_manifest(payload).unwrap_err();
-        assert!(error.to_string().contains("schema_version"));
-    }
-
-    #[test]
     fn parse_bootstrap_manifest_derives_sync_endpoint() {
         let payload = r#"
         {
@@ -267,7 +107,8 @@ mod tests {
 
     #[tokio::test]
     async fn fetch_bootstrap_manifest_parses_valid_payload() {
-        let payload = r#"{
+        let body = r#"
+        {
           "schema_version": 1,
           "manifest_version": "v1",
           "supabase_url": "https://project.supabase.co",
@@ -277,11 +118,13 @@ mod tests {
             "managed_sync": true,
             "managed_media": true
           }
-        }"#;
-        let url = spawn_one_shot_server("200 OK", payload).await;
+        }
+        "#;
+        let url = spawn_one_shot_server("200 OK", body).await;
+
         let parsed = fetch_bootstrap_manifest(&url)
             .await
-            .expect("bootstrap manifest should parse");
+            .expect("bootstrap fetch should succeed");
         assert_eq!(
             parsed.sync_token_endpoint.as_deref(),
             Some("https://api.example.com/v1/sync/token")
@@ -292,10 +135,10 @@ mod tests {
 
     #[tokio::test]
     async fn fetch_bootstrap_manifest_surfaces_http_failure() {
-        let url = spawn_one_shot_server("503 Service Unavailable", "{\"error\":\"down\"}").await;
+        let url = spawn_one_shot_server("500 Internal Server Error", "{\"error\":\"boom\"}").await;
         let error = fetch_bootstrap_manifest(&url)
             .await
-            .expect_err("expected HTTP status error");
-        assert!(error.to_string().contains("HTTP 503"));
+            .expect_err("bootstrap fetch should fail");
+        assert!(error.to_string().contains("HTTP 500"));
     }
 }

--- a/crates/dirt-cli/src/managed_sync.rs
+++ b/crates/dirt-cli/src/managed_sync.rs
@@ -1,12 +1,6 @@
 //! Managed sync token exchange client for CLI profiles.
 
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use reqwest::StatusCode;
-use serde::Deserialize;
-use thiserror::Error;
-
-use crate::config_profiles::is_http_url;
+pub type ManagedSyncError = dirt_core::sync::SyncAuthError;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ManagedSyncToken {
@@ -15,144 +9,33 @@ pub struct ManagedSyncToken {
     pub expires_at: i64,
 }
 
-#[derive(Debug, Error)]
-pub enum ManagedSyncError {
-    #[error("Invalid managed sync configuration: {0}")]
-    InvalidConfiguration(&'static str),
-    #[error("Managed sync HTTP request failed: {0}")]
-    Http(#[from] reqwest::Error),
-    #[error("Managed sync API error: {0}")]
-    Api(String),
-}
-
-type ManagedSyncResult<T> = Result<T, ManagedSyncError>;
-
 #[derive(Clone)]
 pub struct ManagedSyncAuthClient {
-    endpoint: String,
-    client: reqwest::Client,
+    inner: dirt_core::sync::TursoSyncAuthClient,
 }
 
 impl ManagedSyncAuthClient {
-    pub fn new(endpoint: impl Into<String>) -> ManagedSyncResult<Self> {
-        let endpoint = normalize_endpoint(&endpoint.into())?;
+    pub fn new(endpoint: impl Into<String>) -> Result<Self, ManagedSyncError> {
         Ok(Self {
-            endpoint,
-            client: reqwest::Client::builder().build()?,
+            inner: dirt_core::sync::TursoSyncAuthClient::new(endpoint)?,
         })
     }
 
     pub async fn exchange_token(
         &self,
         supabase_access_token: &str,
-    ) -> ManagedSyncResult<ManagedSyncToken> {
-        let supabase_access_token = supabase_access_token.trim();
-        if supabase_access_token.is_empty() {
-            return Err(ManagedSyncError::InvalidConfiguration(
-                "Supabase access token must not be empty",
-            ));
-        }
-
-        let response = self
-            .client
-            .post(&self.endpoint)
-            .bearer_auth(supabase_access_token)
-            .header("Accept", "application/json")
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(ManagedSyncError::Api(parse_api_error(status, &body)));
-        }
-
-        let payload = response.json::<ManagedSyncTokenResponse>().await?;
-        let auth_token = payload
-            .auth_token
-            .or(payload.token)
-            .map(|value| value.trim().to_string())
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| {
-                ManagedSyncError::Api("Response did not include a sync token".to_string())
-            })?;
-        let database_url = payload
-            .database_url
-            .map(|value| value.trim().to_string())
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| {
-                ManagedSyncError::Api("Response did not include database_url".to_string())
-            })?;
-        let expires_at = payload
-            .expires_at
-            .or_else(|| {
-                payload
-                    .expires_in
-                    .map(|expires| unix_timestamp_now().saturating_add(expires))
-            })
-            .ok_or_else(|| {
-                ManagedSyncError::Api("Response did not include token expiry".to_string())
-            })?;
+    ) -> Result<ManagedSyncToken, ManagedSyncError> {
+        let token = self.inner.exchange_token(supabase_access_token).await?;
+        let database_url = token.database_url.ok_or_else(|| {
+            ManagedSyncError::InvalidPayload("Response did not include database_url".to_string())
+        })?;
 
         Ok(ManagedSyncToken {
-            auth_token,
+            auth_token: token.token,
             database_url,
-            expires_at,
+            expires_at: token.expires_at,
         })
     }
-}
-
-#[derive(Debug, Deserialize)]
-struct ManagedSyncTokenResponse {
-    auth_token: Option<String>,
-    token: Option<String>,
-    database_url: Option<String>,
-    expires_at: Option<i64>,
-    expires_in: Option<i64>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ManagedSyncErrorBody {
-    error: Option<String>,
-    message: Option<String>,
-}
-
-fn parse_api_error(status: StatusCode, body: &str) -> String {
-    if let Ok(payload) = serde_json::from_str::<ManagedSyncErrorBody>(body) {
-        if let Some(message) = payload.message.or(payload.error) {
-            return format!("{} ({})", message.trim(), status.as_u16());
-        }
-    }
-
-    let trimmed = body.trim();
-    if trimmed.is_empty() {
-        format!("HTTP {}", status.as_u16())
-    } else {
-        format!("{} ({})", trimmed, status.as_u16())
-    }
-}
-
-fn normalize_endpoint(endpoint: &str) -> ManagedSyncResult<String> {
-    let endpoint = endpoint.trim().trim_end_matches('/').to_string();
-    if endpoint.is_empty() {
-        return Err(ManagedSyncError::InvalidConfiguration(
-            "Managed sync endpoint must not be empty",
-        ));
-    }
-    if !is_http_url(&endpoint) {
-        return Err(ManagedSyncError::InvalidConfiguration(
-            "Managed sync endpoint must include http:// or https://",
-        ));
-    }
-    Ok(endpoint)
-}
-
-fn unix_timestamp_now() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| {
-            i64::try_from(duration.as_secs()).unwrap_or(i64::MAX)
-        })
 }
 
 #[cfg(test)]
@@ -161,16 +44,15 @@ mod tests {
 
     #[test]
     fn normalize_endpoint_rejects_invalid_values() {
-        let empty = normalize_endpoint("  ").unwrap_err();
+        let empty = ManagedSyncAuthClient::new("  ").err().unwrap();
         assert!(empty.to_string().contains("must not be empty"));
 
-        let missing_scheme = normalize_endpoint("api.example.com").unwrap_err();
+        let missing_scheme = ManagedSyncAuthClient::new("api.example.com").err().unwrap();
         assert!(missing_scheme.to_string().contains("http:// or https://"));
     }
 
     #[test]
     fn normalize_endpoint_trims_trailing_slash() {
-        let normalized = normalize_endpoint("https://api.example.com/v1/sync/token/").unwrap();
-        assert_eq!(normalized, "https://api.example.com/v1/sync/token");
+        assert!(ManagedSyncAuthClient::new("https://api.example.com/v1/sync/token/").is_ok());
     }
 }

--- a/crates/dirt-core/Cargo.toml
+++ b/crates/dirt-core/Cargo.toml
@@ -16,6 +16,8 @@ regex.workspace = true
 libsql.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+urlencoding = "2.1"
 aws-credential-types = "1"
 aws-sdk-s3 = { version = "1", features = ["behavior-version-latest"] }
 aws-types = "1"

--- a/crates/dirt-core/src/auth/mod.rs
+++ b/crates/dirt-core/src/auth/mod.rs
@@ -1,0 +1,514 @@
+//! Shared Supabase auth client logic.
+
+use std::fmt;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use reqwest::{Client, RequestBuilder, StatusCode};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::config::normalize_text_option;
+
+const EXPIRY_SKEW_SECONDS: i64 = 60;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthUser {
+    pub id: String,
+    pub email: Option<String>,
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthSession {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_at: i64,
+    pub user: AuthUser,
+}
+
+impl AuthSession {
+    #[must_use]
+    pub fn is_expired(&self) -> bool {
+        self.expires_at <= unix_timestamp_now() + EXPIRY_SKEW_SECONDS
+    }
+}
+
+impl fmt::Debug for AuthSession {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuthSession")
+            .field("access_token", &"[REDACTED]")
+            .field("refresh_token", &"[REDACTED]")
+            .field("expires_at", &self.expires_at)
+            .field("user", &self.user)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SignUpOutcome {
+    SignedIn(AuthSession),
+    ConfirmationRequired,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct AuthConfigStatus {
+    pub email_enabled: bool,
+    pub signup_enabled: bool,
+    pub mailer_autoconfirm: bool,
+    pub smtp_configured: bool,
+    pub rate_limit_email_sent: Option<i64>,
+}
+
+#[derive(Debug, Error)]
+pub enum AuthError {
+    #[error("Supabase auth is not configured for this build.")]
+    NotConfigured,
+    #[error("Invalid auth configuration: {0}")]
+    InvalidConfiguration(&'static str),
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("Failed to parse JSON payload: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("Auth API error: {0}")]
+    Api(String),
+    #[error("Secure storage error: {0}")]
+    SecureStorage(String),
+}
+
+pub type AuthResult<T> = Result<T, AuthError>;
+
+pub trait SessionPersistence: Clone + Send + Sync + 'static {
+    fn load_session(&self) -> AuthResult<Option<AuthSession>>;
+    fn save_session(&self, session: &AuthSession) -> AuthResult<()>;
+    fn clear_session(&self) -> AuthResult<()>;
+}
+
+#[derive(Clone)]
+pub struct SupabaseAuthClient<S: SessionPersistence> {
+    auth_url: String,
+    anon_key: String,
+    client: Client,
+    store: S,
+}
+
+impl<S: SessionPersistence> SupabaseAuthClient<S> {
+    pub fn new(url: impl AsRef<str>, anon_key: impl Into<String>, store: S) -> AuthResult<Self> {
+        let auth_url = normalize_auth_url(url.as_ref())?;
+        let anon_key = anon_key.into().trim().to_string();
+        if anon_key.is_empty() {
+            return Err(AuthError::InvalidConfiguration(
+                "Supabase anon key must not be empty",
+            ));
+        }
+
+        Ok(Self {
+            auth_url,
+            anon_key,
+            client: Client::builder().build()?,
+            store,
+        })
+    }
+
+    pub async fn restore_session(&self) -> AuthResult<Option<AuthSession>> {
+        let Some(stored_session) = self.store.load_session()? else {
+            return Ok(None);
+        };
+
+        if !stored_session.is_expired() {
+            return Ok(Some(stored_session));
+        }
+
+        match self.refresh_session(&stored_session.refresh_token).await {
+            Ok(refreshed) => {
+                self.store.save_session(&refreshed)?;
+                Ok(Some(refreshed))
+            }
+            Err(error) => {
+                tracing::warn!("Failed to refresh persisted session: {}", error);
+                self.store.clear_session()?;
+                Ok(None)
+            }
+        }
+    }
+
+    pub async fn sign_up(&self, email: &str, password: &str) -> AuthResult<SignUpOutcome> {
+        validate_credentials(email, password)?;
+
+        let payload = serde_json::json!({
+            "email": email,
+            "password": password,
+        });
+        let request = self.public_request(
+            self.client
+                .post(format!("{}/signup", self.auth_url))
+                .json(&payload),
+        );
+        let response = self.send_auth_request(request).await?;
+        match response.into_session()? {
+            Some(session) => {
+                self.store.save_session(&session)?;
+                Ok(SignUpOutcome::SignedIn(session))
+            }
+            None => Ok(SignUpOutcome::ConfirmationRequired),
+        }
+    }
+
+    pub async fn sign_in(&self, email: &str, password: &str) -> AuthResult<AuthSession> {
+        validate_credentials(email, password)?;
+
+        let payload = serde_json::json!({
+            "email": email,
+            "password": password,
+        });
+        let request = self.public_request(
+            self.client
+                .post(format!("{}/token", self.auth_url))
+                .query(&[("grant_type", "password")])
+                .json(&payload),
+        );
+
+        let response = self.send_auth_request(request).await?;
+        let session = response.into_session()?.ok_or_else(|| {
+            AuthError::Api("Sign-in response did not include an active session".to_string())
+        })?;
+
+        self.store.save_session(&session)?;
+        Ok(session)
+    }
+
+    pub async fn refresh_session(&self, refresh_token: &str) -> AuthResult<AuthSession> {
+        if refresh_token.trim().is_empty() {
+            return Err(AuthError::InvalidConfiguration(
+                "Refresh token must not be empty",
+            ));
+        }
+
+        let payload = serde_json::json!({
+            "refresh_token": refresh_token,
+        });
+        let request = self.public_request(
+            self.client
+                .post(format!("{}/token", self.auth_url))
+                .query(&[("grant_type", "refresh_token")])
+                .json(&payload),
+        );
+        let response = self.send_auth_request(request).await?;
+        let session = response.into_session()?.ok_or_else(|| {
+            AuthError::Api("Refresh response did not include an active session".to_string())
+        })?;
+
+        self.store.save_session(&session)?;
+        Ok(session)
+    }
+
+    pub async fn sign_out(&self, access_token: &str) -> AuthResult<()> {
+        let request = self
+            .client
+            .post(format!("{}/logout", self.auth_url))
+            .header("apikey", &self.anon_key)
+            .bearer_auth(access_token);
+
+        let response = request.send().await?;
+        if !(response.status().is_success() || response.status() == StatusCode::UNAUTHORIZED) {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AuthError::Api(parse_api_error(status, &body)));
+        }
+
+        self.store.clear_session()?;
+        Ok(())
+    }
+
+    pub async fn verify_configuration(&self) -> AuthResult<AuthConfigStatus> {
+        let request = self.public_request(
+            self.client
+                .get(format!("{}/settings", self.auth_url))
+                .header("Accept", "application/json"),
+        );
+        let response = request.send().await?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AuthError::Api(parse_api_error(status, &body)));
+        }
+        let payload = response.json::<SupabaseSettingsResponse>().await?;
+        Ok(payload.into())
+    }
+
+    fn public_request(&self, request: RequestBuilder) -> RequestBuilder {
+        request
+            .header("apikey", &self.anon_key)
+            .header("Authorization", format!("Bearer {}", self.anon_key))
+    }
+
+    async fn send_auth_request(&self, request: RequestBuilder) -> AuthResult<SupabaseAuthResponse> {
+        let response = request.send().await?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AuthError::Api(parse_api_error(status, &body)));
+        }
+        Ok(response.json::<SupabaseAuthResponse>().await?)
+    }
+}
+
+pub fn normalize_auth_url(url: &str) -> AuthResult<String> {
+    let trimmed = url.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return Err(AuthError::InvalidConfiguration(
+            "Supabase URL must not be empty",
+        ));
+    }
+    if !(trimmed.starts_with("http://") || trimmed.starts_with("https://")) {
+        return Err(AuthError::InvalidConfiguration(
+            "Supabase URL must include http:// or https://",
+        ));
+    }
+    if trimmed.ends_with("/auth/v1") {
+        Ok(trimmed.to_string())
+    } else {
+        Ok(format!("{trimmed}/auth/v1"))
+    }
+}
+
+pub fn resolve_optional_supabase_config(
+    url: Option<String>,
+    anon_key: Option<String>,
+) -> AuthResult<Option<(String, String)>> {
+    let url = normalize_text_option(url);
+    let anon_key = normalize_text_option(anon_key);
+
+    match (url, anon_key) {
+        (None, None) => Ok(None),
+        (Some(url), Some(anon_key)) => Ok(Some((url, anon_key))),
+        _ => Err(AuthError::NotConfigured),
+    }
+}
+
+fn validate_credentials(email: &str, password: &str) -> AuthResult<()> {
+    if email.trim().is_empty() {
+        return Err(AuthError::Api("Email is required".to_string()));
+    }
+    if password.trim().is_empty() {
+        return Err(AuthError::Api("Password is required".to_string()));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct SupabaseAuthResponse {
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+    expires_at: Option<i64>,
+    expires_in: Option<i64>,
+    user: Option<SupabaseUser>,
+    session: Option<SupabaseAuthResponseSession>,
+}
+
+impl SupabaseAuthResponse {
+    fn into_session(self) -> AuthResult<Option<AuthSession>> {
+        let nested_session = self.session;
+        let access_token = self.access_token.or_else(|| {
+            nested_session
+                .as_ref()
+                .and_then(|session| session.access_token.clone())
+        });
+        let refresh_token = self.refresh_token.or_else(|| {
+            nested_session
+                .as_ref()
+                .and_then(|session| session.refresh_token.clone())
+        });
+        let expires_at = self
+            .expires_at
+            .or_else(|| {
+                nested_session
+                    .as_ref()
+                    .and_then(|session| session.expires_at)
+            })
+            .or_else(|| {
+                self.expires_in
+                    .or_else(|| {
+                        nested_session
+                            .as_ref()
+                            .and_then(|session| session.expires_in)
+                    })
+                    .map(|expires_in| unix_timestamp_now().saturating_add(expires_in))
+            });
+        let user = self
+            .user
+            .or_else(|| nested_session.and_then(|session| session.user))
+            .map(Into::into);
+
+        match (access_token, refresh_token, expires_at, user) {
+            (Some(access_token), Some(refresh_token), Some(expires_at), Some(user)) => {
+                Ok(Some(AuthSession {
+                    access_token,
+                    refresh_token,
+                    expires_at,
+                    user,
+                }))
+            }
+            (None, None, None, Some(_)) => Ok(None),
+            _ => Err(AuthError::Api(
+                "Auth response did not include enough session fields".to_string(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SupabaseAuthResponseSession {
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+    expires_at: Option<i64>,
+    expires_in: Option<i64>,
+    user: Option<SupabaseUser>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SupabaseUser {
+    id: String,
+    email: Option<String>,
+}
+
+impl From<SupabaseUser> for AuthUser {
+    fn from(value: SupabaseUser) -> Self {
+        Self {
+            id: value.id,
+            email: value.email,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SupabaseSettingsResponse {
+    external: Option<SupabaseSettingsExternal>,
+    disable_signup: Option<bool>,
+    mailer_autoconfirm: Option<bool>,
+    rate_limit_email_sent: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SupabaseSettingsExternal {
+    email: Option<bool>,
+    #[serde(default)]
+    smtp_admin_email: Option<String>,
+    #[serde(default)]
+    smtp_host: Option<String>,
+}
+
+impl From<SupabaseSettingsResponse> for AuthConfigStatus {
+    fn from(value: SupabaseSettingsResponse) -> Self {
+        let external = value.external;
+        let email_enabled = external.as_ref().and_then(|cfg| cfg.email).unwrap_or(false);
+        let signup_enabled = !value.disable_signup.unwrap_or(true);
+        let mailer_autoconfirm = value.mailer_autoconfirm.unwrap_or(false);
+
+        let smtp_configured = external.as_ref().is_some_and(|cfg| {
+            let has_email = cfg
+                .smtp_admin_email
+                .as_ref()
+                .is_some_and(|email| !email.trim().is_empty());
+            let has_host = cfg
+                .smtp_host
+                .as_ref()
+                .is_some_and(|host| !host.trim().is_empty());
+            has_email || has_host
+        });
+
+        Self {
+            email_enabled,
+            signup_enabled,
+            mailer_autoconfirm,
+            smtp_configured,
+            rate_limit_email_sent: value.rate_limit_email_sent,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SupabaseErrorResponse {
+    error: Option<String>,
+    error_description: Option<String>,
+    message: Option<String>,
+    msg: Option<String>,
+}
+
+fn parse_api_error(status: StatusCode, body: &str) -> String {
+    if let Ok(payload) = serde_json::from_str::<SupabaseErrorResponse>(body) {
+        if let Some(message) = payload
+            .message
+            .or(payload.msg)
+            .or(payload.error_description)
+            .or(payload.error)
+        {
+            return format!("{} ({})", message.trim(), status.as_u16());
+        }
+    }
+
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        format!("HTTP {}", status.as_u16())
+    } else {
+        format!("{} ({})", trimmed, status.as_u16())
+    }
+}
+
+fn unix_timestamp_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| {
+            i64::try_from(duration.as_secs()).unwrap_or(i64::MAX)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_auth_url_appends_auth_path() {
+        let normalized = normalize_auth_url("https://demo.supabase.co").unwrap();
+        assert_eq!(normalized, "https://demo.supabase.co/auth/v1");
+    }
+
+    #[test]
+    fn normalize_auth_url_keeps_existing_auth_path() {
+        let normalized = normalize_auth_url("https://demo.supabase.co/auth/v1").unwrap();
+        assert_eq!(normalized, "https://demo.supabase.co/auth/v1");
+    }
+
+    #[test]
+    fn response_without_session_fields_means_confirmation_required() {
+        let response = SupabaseAuthResponse {
+            access_token: None,
+            refresh_token: None,
+            expires_at: None,
+            expires_in: None,
+            user: Some(SupabaseUser {
+                id: "user".to_string(),
+                email: Some("user@example.com".to_string()),
+            }),
+            session: None,
+        };
+        assert!(response.into_session().unwrap().is_none());
+    }
+
+    #[test]
+    fn session_debug_redacts_tokens() {
+        let session = AuthSession {
+            access_token: "secret-access-token".to_string(),
+            refresh_token: "secret-refresh-token".to_string(),
+            expires_at: 1_700_000_000,
+            user: AuthUser {
+                id: "user".to_string(),
+                email: None,
+            },
+        };
+        let rendered = format!("{session:?}");
+        assert!(!rendered.contains("secret-access-token"));
+        assert!(!rendered.contains("secret-refresh-token"));
+        assert!(rendered.contains("[REDACTED]"));
+    }
+}

--- a/crates/dirt-core/src/config/mod.rs
+++ b/crates/dirt-core/src/config/mod.rs
@@ -1,0 +1,320 @@
+//! Shared bootstrap/config helpers used by desktop, mobile, and CLI.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+const BOOTSTRAP_SCHEMA_VERSION: u32 = 1;
+const CLIENT_BOOTSTRAP_HTTP_TIMEOUT_SECS: u64 = 4;
+const MANAGED_BOOTSTRAP_HTTP_TIMEOUT_SECS: u64 = 5;
+
+/// Shared client bootstrap configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BootstrapConfig {
+    #[serde(default)]
+    pub bootstrap_manifest_url: Option<String>,
+    #[serde(default)]
+    pub supabase_url: Option<String>,
+    #[serde(default)]
+    pub supabase_anon_key: Option<String>,
+    #[serde(default)]
+    pub turso_sync_token_endpoint: Option<String>,
+    #[serde(default)]
+    pub dirt_api_base_url: Option<String>,
+}
+
+impl BootstrapConfig {
+    /// Returns the managed API base URL for authenticated media operations.
+    #[must_use]
+    pub fn managed_api_base_url(&self) -> Option<String> {
+        if let Some(url) = normalize_text_option(self.dirt_api_base_url.clone()) {
+            return Some(url);
+        }
+
+        let endpoint = normalize_text_option(self.turso_sync_token_endpoint.clone())?;
+        endpoint
+            .strip_suffix("/v1/sync/token")
+            .map(std::string::ToString::to_string)
+    }
+}
+
+/// Normalized managed bootstrap payload used by CLI profile setup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedBootstrapConfig {
+    pub supabase_url: String,
+    pub supabase_anon_key: String,
+    pub api_base_url: String,
+    pub sync_token_endpoint: Option<String>,
+    pub managed_sync: bool,
+    pub managed_media: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct ManagedBootstrapManifest {
+    schema_version: u32,
+    manifest_version: String,
+    supabase_url: String,
+    supabase_anon_key: String,
+    api_base_url: String,
+    #[serde(default)]
+    turso_sync_token_endpoint: Option<String>,
+    feature_flags: ManagedFeatureFlags,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct ManagedFeatureFlags {
+    managed_sync: bool,
+    managed_media: bool,
+}
+
+/// Normalize optional text by trimming and discarding empty values.
+#[must_use]
+pub fn normalize_text_option(value: Option<String>) -> Option<String> {
+    let value = value?;
+    let value = value.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+/// Resolve runtime bootstrap config by fetching bootstrap manifest when configured.
+pub async fn resolve_bootstrap_config(fallback: BootstrapConfig) -> BootstrapConfig {
+    let Some(manifest_url) = normalize_text_option(fallback.bootstrap_manifest_url.clone()) else {
+        return fallback;
+    };
+
+    match fetch_bootstrap_manifest_with_timeout(&manifest_url, CLIENT_BOOTSTRAP_HTTP_TIMEOUT_SECS)
+        .await
+    {
+        Ok(config) => config,
+        Err(error) => {
+            tracing::warn!(
+                "Failed to resolve runtime bootstrap from {}: {}. Falling back to embedded config.",
+                manifest_url,
+                error
+            );
+            fallback
+        }
+    }
+}
+
+/// Fetch and parse a managed bootstrap endpoint into client runtime config.
+pub async fn fetch_bootstrap_manifest(url: &str) -> Result<BootstrapConfig, String> {
+    fetch_bootstrap_manifest_with_timeout(url, CLIENT_BOOTSTRAP_HTTP_TIMEOUT_SECS).await
+}
+
+/// Parse managed bootstrap JSON for client runtime usage.
+pub fn parse_bootstrap_manifest(
+    payload: &str,
+    manifest_url: &str,
+) -> Result<BootstrapConfig, String> {
+    let manifest: ManagedBootstrapManifest = serde_json::from_str(payload)
+        .map_err(|error| format!("invalid bootstrap manifest JSON: {error}"))?;
+    manifest.into_client_config(manifest_url)
+}
+
+/// Fetch and parse managed bootstrap endpoint into CLI managed config.
+pub async fn fetch_managed_bootstrap_manifest(url: &str) -> Result<ManagedBootstrapConfig, String> {
+    let body = fetch_bootstrap_payload(url, MANAGED_BOOTSTRAP_HTTP_TIMEOUT_SECS).await?;
+    parse_managed_bootstrap_manifest(&body)
+}
+
+/// Parse managed bootstrap JSON into normalized managed config.
+pub fn parse_managed_bootstrap_manifest(payload: &str) -> Result<ManagedBootstrapConfig, String> {
+    let manifest: ManagedBootstrapManifest = serde_json::from_str(payload)
+        .map_err(|error| format!("invalid bootstrap manifest JSON: {error}"))?;
+    manifest.into_managed_config()
+}
+
+async fn fetch_bootstrap_manifest_with_timeout(
+    url: &str,
+    timeout_secs: u64,
+) -> Result<BootstrapConfig, String> {
+    let body = fetch_bootstrap_payload(url, timeout_secs).await?;
+    parse_bootstrap_manifest(&body, url)
+}
+
+async fn fetch_bootstrap_payload(url: &str, timeout_secs: u64) -> Result<String, String> {
+    let url = normalize_required_http_url(url.to_string(), "bootstrap_url")?;
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(timeout_secs))
+        .build()
+        .map_err(|error| format!("failed to build bootstrap HTTP client: {error}"))?;
+
+    let response = client
+        .get(&url)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .send()
+        .await
+        .map_err(|error| format!("bootstrap request failed: {error}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status().as_u16();
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!(
+            "bootstrap endpoint returned HTTP {status}: {}",
+            compact_text(&body)
+        ));
+    }
+
+    response
+        .text()
+        .await
+        .map_err(|error| format!("failed to read bootstrap response body: {error}"))
+}
+
+impl ManagedBootstrapManifest {
+    fn into_client_config(self, manifest_url: &str) -> Result<BootstrapConfig, String> {
+        if self.schema_version != BOOTSTRAP_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported bootstrap schema_version {} (expected {})",
+                self.schema_version, BOOTSTRAP_SCHEMA_VERSION
+            ));
+        }
+        if self.manifest_version.trim().is_empty() {
+            return Err("bootstrap manifest_version must not be empty".to_string());
+        }
+
+        let supabase_url = normalize_required_http_url(self.supabase_url, "supabase_url")?;
+        let supabase_anon_key =
+            normalize_required_value(self.supabase_anon_key, "supabase_anon_key")?;
+        let api_base_url = normalize_required_http_url(self.api_base_url, "api_base_url")?;
+
+        let sync_endpoint = if self.feature_flags.managed_sync {
+            match normalize_text_option(self.turso_sync_token_endpoint) {
+                Some(endpoint) => Some(normalize_required_http_url(
+                    endpoint,
+                    "turso_sync_token_endpoint",
+                )?),
+                None => Some(format!("{api_base_url}/v1/sync/token")),
+            }
+        } else {
+            None
+        };
+
+        let api_base_for_clients =
+            if self.feature_flags.managed_sync || self.feature_flags.managed_media {
+                Some(api_base_url)
+            } else {
+                None
+            };
+
+        Ok(BootstrapConfig {
+            bootstrap_manifest_url: Some(manifest_url.to_string()),
+            supabase_url: Some(supabase_url),
+            supabase_anon_key: Some(supabase_anon_key),
+            turso_sync_token_endpoint: sync_endpoint,
+            dirt_api_base_url: api_base_for_clients,
+        })
+    }
+
+    fn into_managed_config(self) -> Result<ManagedBootstrapConfig, String> {
+        if self.schema_version != BOOTSTRAP_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported schema_version {} (expected {})",
+                self.schema_version, BOOTSTRAP_SCHEMA_VERSION
+            ));
+        }
+        if self.manifest_version.trim().is_empty() {
+            return Err("manifest_version must not be empty".to_string());
+        }
+
+        let supabase_url = normalize_required_http_url(self.supabase_url, "supabase_url")?;
+        let supabase_anon_key =
+            normalize_required_value(self.supabase_anon_key, "supabase_anon_key")?;
+        let api_base_url = normalize_required_http_url(self.api_base_url, "api_base_url")?;
+
+        let sync_token_endpoint = if self.feature_flags.managed_sync {
+            match self.turso_sync_token_endpoint {
+                Some(endpoint) => Some(normalize_required_http_url(
+                    endpoint,
+                    "turso_sync_token_endpoint",
+                )?),
+                None => Some(format!("{api_base_url}/v1/sync/token")),
+            }
+        } else {
+            None
+        };
+
+        Ok(ManagedBootstrapConfig {
+            supabase_url,
+            supabase_anon_key,
+            api_base_url,
+            sync_token_endpoint,
+            managed_sync: self.feature_flags.managed_sync,
+            managed_media: self.feature_flags.managed_media,
+        })
+    }
+}
+
+fn normalize_required_value(raw: String, field: &str) -> Result<String, String> {
+    normalize_text_option(Some(raw)).ok_or_else(|| format!("bootstrap field '{field}' is required"))
+}
+
+fn normalize_required_http_url(raw: String, field: &str) -> Result<String, String> {
+    let value = normalize_required_value(raw, field)?;
+    if value.starts_with("http://") || value.starts_with("https://") {
+        Ok(value.trim_end_matches('/').to_string())
+    } else {
+        Err(format!(
+            "bootstrap field '{field}' must include http:// or https://"
+        ))
+    }
+}
+
+fn compact_text(value: &str) -> String {
+    value.trim().chars().take(180).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_text_option_rejects_empty() {
+        assert_eq!(normalize_text_option(None), None);
+        assert_eq!(normalize_text_option(Some("   ".to_string())), None);
+    }
+
+    #[test]
+    fn managed_api_base_url_falls_back_to_sync_endpoint_prefix() {
+        let config = BootstrapConfig {
+            turso_sync_token_endpoint: Some("https://api.example.com/v1/sync/token".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            config.managed_api_base_url().as_deref(),
+            Some("https://api.example.com")
+        );
+    }
+
+    #[test]
+    fn parse_managed_bootstrap_manifest_derives_sync_endpoint() {
+        let payload = r#"
+        {
+          "schema_version": 1,
+          "manifest_version": "v1",
+          "supabase_url": "https://project.supabase.co",
+          "supabase_anon_key": "anon",
+          "api_base_url": "https://api.example.com",
+          "feature_flags": {
+            "managed_sync": true,
+            "managed_media": false
+          }
+        }
+        "#;
+
+        let parsed = parse_managed_bootstrap_manifest(payload).expect("manifest parse");
+        assert_eq!(
+            parsed.sync_token_endpoint.as_deref(),
+            Some("https://api.example.com/v1/sync/token")
+        );
+        assert!(!parsed.managed_media);
+    }
+}

--- a/crates/dirt-core/src/lib.rs
+++ b/crates/dirt-core/src/lib.rs
@@ -3,12 +3,17 @@
 //! This crate contains the shared models, database layer, and business logic
 //! used by all Dirt interfaces (desktop, mobile, CLI, TUI).
 
+pub mod auth;
+pub mod config;
 pub mod db;
 pub mod error;
 pub mod export;
+pub mod media;
 pub mod models;
 pub mod search;
+pub mod services;
 pub mod storage;
+pub mod sync;
 
 pub use error::{Error, Result};
 pub use export::ExportNote;

--- a/crates/dirt-core/src/media/mod.rs
+++ b/crates/dirt-core/src/media/mod.rs
@@ -1,0 +1,244 @@
+//! Shared backend media signing client for attachment operations.
+
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone)]
+pub struct MediaApiClient {
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl MediaApiClient {
+    pub fn new(base_url: impl Into<String>) -> Result<Self, String> {
+        let base_url = normalize_base_url(base_url.into().as_str())?;
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(|error| format!("Failed to construct HTTP client: {error}"))?;
+        Ok(Self { base_url, client })
+    }
+
+    pub async fn upload(
+        &self,
+        access_token: &str,
+        object_key: &str,
+        content_type: &str,
+        bytes: &[u8],
+    ) -> Result<(), String> {
+        let operation = self
+            .request_presigned(
+                access_token,
+                "/v1/media/presign/upload",
+                &serde_json::json!({
+                    "object_key": object_key,
+                    "content_type": content_type,
+                }),
+            )
+            .await?;
+
+        let method = parse_method(&operation.method)?;
+        let mut request = self.client.request(method, &operation.url);
+        for (name, value) in operation.headers {
+            if name.eq_ignore_ascii_case("host") {
+                continue;
+            }
+            request = request.header(name, value);
+        }
+        let response = request
+            .body(bytes.to_vec())
+            .send()
+            .await
+            .map_err(|error| format!("Upload request failed: {error}"))?;
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "Upload request failed with HTTP {status}: {}",
+                compact_body(&body)
+            ));
+        }
+        Ok(())
+    }
+
+    pub async fn download(
+        &self,
+        access_token: &str,
+        object_key: &str,
+    ) -> Result<(Vec<u8>, Option<String>), String> {
+        let encoded_object_key = urlencoding::encode(object_key);
+        let url = format!(
+            "{}/v1/media/presign/download?object_key={}",
+            self.base_url, encoded_object_key
+        );
+
+        let response = self
+            .client
+            .get(url)
+            .bearer_auth(access_token)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|error| format!("Failed to request download URL: {error}"))?;
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "Download URL request failed with HTTP {status}: {}",
+                compact_body(&body)
+            ));
+        }
+        let payload = response
+            .json::<PresignResponse>()
+            .await
+            .map_err(|error| format!("Failed to parse download URL response: {error}"))?;
+
+        let operation = payload.operation;
+        let method = parse_method(&operation.method)?;
+        let mut request = self.client.request(method, &operation.url);
+        for (name, value) in operation.headers {
+            if name.eq_ignore_ascii_case("host") {
+                continue;
+            }
+            request = request.header(name, value);
+        }
+        let response = request
+            .send()
+            .await
+            .map_err(|error| format!("Download request failed: {error}"))?;
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "Download request failed with HTTP {status}: {}",
+                compact_body(&body)
+            ));
+        }
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(ToString::to_string);
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|error| format!("Failed to read attachment bytes: {error}"))?;
+        Ok((bytes.to_vec(), content_type))
+    }
+
+    pub async fn delete(&self, access_token: &str, object_key: &str) -> Result<(), String> {
+        let operation = self
+            .request_presigned(
+                access_token,
+                "/v1/media/presign/delete",
+                &serde_json::json!({
+                    "object_key": object_key,
+                }),
+            )
+            .await?;
+
+        let method = parse_method(&operation.method)?;
+        let mut request = self.client.request(method, &operation.url);
+        for (name, value) in operation.headers {
+            if name.eq_ignore_ascii_case("host") {
+                continue;
+            }
+            request = request.header(name, value);
+        }
+        let response = request
+            .send()
+            .await
+            .map_err(|error| format!("Delete request failed: {error}"))?;
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "Delete request failed with HTTP {status}: {}",
+                compact_body(&body)
+            ));
+        }
+        Ok(())
+    }
+
+    async fn request_presigned(
+        &self,
+        access_token: &str,
+        route: &str,
+        body: &serde_json::Value,
+    ) -> Result<PresignedOperation, String> {
+        let response = self
+            .client
+            .post(format!("{}{}", self.base_url, route))
+            .bearer_auth(access_token)
+            .header("Accept", "application/json")
+            .json(body)
+            .send()
+            .await
+            .map_err(|error| format!("Failed to request signed URL: {error}"))?;
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "Signed URL request failed with HTTP {status}: {}",
+                compact_body(&body)
+            ));
+        }
+        let payload = response
+            .json::<PresignResponse>()
+            .await
+            .map_err(|error| format!("Failed to parse signed URL response: {error}"))?;
+        Ok(payload.operation)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PresignResponse {
+    operation: PresignedOperation,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PresignedOperation {
+    method: String,
+    url: String,
+    headers: Vec<(String, String)>,
+}
+
+fn normalize_base_url(raw: &str) -> Result<String, String> {
+    let base = raw.trim().trim_end_matches('/').to_string();
+    if base.is_empty() {
+        return Err("DIRT_API_BASE_URL must not be empty".to_string());
+    }
+    if !(base.starts_with("https://") || base.starts_with("http://")) {
+        return Err("DIRT_API_BASE_URL must include http:// or https://".to_string());
+    }
+    Ok(base)
+}
+
+fn parse_method(raw: &str) -> Result<Method, String> {
+    Method::from_bytes(raw.trim().as_bytes()).map_err(|error| {
+        format!(
+            "Unsupported presigned HTTP method '{}': {error}",
+            raw.trim()
+        )
+    })
+}
+
+fn compact_body(body: &str) -> String {
+    body.trim().chars().take(180).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_base_url_rejects_invalid_values() {
+        assert!(normalize_base_url("  ").is_err());
+        assert!(normalize_base_url("api.example.com").is_err());
+    }
+
+    #[test]
+    fn normalize_base_url_trims_trailing_slash() {
+        let normalized = normalize_base_url("https://api.example.com/").unwrap();
+        assert_eq!(normalized, "https://api.example.com");
+    }
+}

--- a/crates/dirt-core/src/services/database.rs
+++ b/crates/dirt-core/src/services/database.rs
@@ -1,0 +1,163 @@
+//! Shared async database wrapper for app clients.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use crate::db::{
+    Database, LibSqlNoteRepository, LibSqlSettingsRepository, NoteRepository, SettingsRepository,
+};
+use crate::models::{Attachment, AttachmentId, Note, Settings};
+use crate::{NoteId, Result, SyncConflict};
+
+#[derive(Clone)]
+pub struct DatabaseService {
+    db: Arc<Mutex<Database>>,
+}
+
+impl DatabaseService {
+    #[must_use]
+    pub fn from_database(db: Database) -> Self {
+        Self {
+            db: Arc::new(Mutex::new(db)),
+        }
+    }
+
+    pub async fn open(db_path: impl AsRef<Path>) -> Result<Self> {
+        let db = Database::open(db_path.as_ref()).await?;
+        Ok(Self::from_database(db))
+    }
+
+    pub async fn open_with_sync(
+        db_path: impl AsRef<Path>,
+        sync_config: crate::db::SyncConfig,
+    ) -> Result<Self> {
+        let db = Database::open_with_sync(db_path.as_ref(), sync_config).await?;
+        Ok(Self::from_database(db))
+    }
+
+    pub async fn open_in_memory() -> Result<Self> {
+        let db = Database::open_in_memory().await?;
+        Ok(Self::from_database(db))
+    }
+
+    pub async fn sync(&self) -> Result<()> {
+        let db = self.db.lock().await;
+        db.sync().await
+    }
+
+    pub async fn is_sync_enabled(&self) -> bool {
+        let db = self.db.lock().await;
+        db.is_sync_enabled()
+    }
+
+    pub async fn list_notes(&self, limit: usize, offset: usize) -> Result<Vec<Note>> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.list(limit, offset).await
+    }
+
+    pub async fn list_all_notes(&self) -> Result<Vec<Note>> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.list(usize::MAX, 0).await
+    }
+
+    pub async fn get_note(&self, id: &NoteId) -> Result<Option<Note>> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.get(id).await
+    }
+
+    pub async fn create_note(&self, content: &str) -> Result<Note> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.create(content).await
+    }
+
+    pub async fn create_note_with_id(&self, note: &Note) -> Result<Note> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.create_with_note(note).await
+    }
+
+    pub async fn update_note(&self, id: &NoteId, content: &str) -> Result<Note> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.update(id, content).await
+    }
+
+    pub async fn delete_note(&self, id: &NoteId) -> Result<()> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.delete(id).await
+    }
+
+    pub async fn search_notes(&self, query: &str, limit: usize) -> Result<Vec<Note>> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.search(query, limit).await
+    }
+
+    pub async fn list_notes_by_tag(
+        &self,
+        tag: &str,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<Note>> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.list_by_tag(tag, limit, offset).await
+    }
+
+    pub async fn list_tags(&self) -> Result<Vec<(String, usize)>> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.list_tags().await
+    }
+
+    pub async fn create_attachment(
+        &self,
+        note_id: &NoteId,
+        filename: &str,
+        mime_type: &str,
+        size_bytes: i64,
+        r2_key: &str,
+    ) -> Result<Attachment> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.create_attachment(note_id, filename, mime_type, size_bytes, r2_key)
+            .await
+    }
+
+    pub async fn list_attachments(&self, note_id: &NoteId) -> Result<Vec<Attachment>> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.list_attachments(note_id).await
+    }
+
+    pub async fn delete_attachment(&self, attachment_id: &AttachmentId) -> Result<()> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.delete_attachment(attachment_id).await
+    }
+
+    pub async fn list_conflicts(&self, limit: usize) -> Result<Vec<SyncConflict>> {
+        let db = self.db.lock().await;
+        let repo = LibSqlNoteRepository::new(db.connection());
+        repo.list_conflicts(limit).await
+    }
+
+    pub async fn load_settings(&self) -> Result<Settings> {
+        let db = self.db.lock().await;
+        let repo = LibSqlSettingsRepository::new(db.connection());
+        repo.load().await
+    }
+
+    pub async fn save_settings(&self, settings: &Settings) -> Result<()> {
+        let db = self.db.lock().await;
+        let repo = LibSqlSettingsRepository::new(db.connection());
+        repo.save(settings).await
+    }
+}

--- a/crates/dirt-core/src/services/mod.rs
+++ b/crates/dirt-core/src/services/mod.rs
@@ -1,0 +1,3 @@
+//! Shared high-level services built on top of dirt-core primitives.
+
+pub mod database;

--- a/crates/dirt-core/src/sync/mod.rs
+++ b/crates/dirt-core/src/sync/mod.rs
@@ -1,0 +1,198 @@
+//! Shared managed Turso sync token exchange client.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use reqwest::StatusCode;
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::config::normalize_text_option;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct SyncToken {
+    pub token: String,
+    pub expires_at: i64,
+    pub database_url: Option<String>,
+}
+
+impl std::fmt::Debug for SyncToken {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SyncToken")
+            .field("token", &"[REDACTED]")
+            .field("expires_at", &self.expires_at)
+            .field("database_url", &self.database_url)
+            .finish()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SyncAuthError {
+    #[error("Invalid sync auth configuration: {0}")]
+    InvalidConfiguration(String),
+    #[error("Sync auth HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("Sync auth API error: {0}")]
+    Api(String),
+    #[error("Invalid sync token payload: {0}")]
+    InvalidPayload(String),
+}
+
+pub type SyncAuthResult<T> = Result<T, SyncAuthError>;
+
+#[derive(Clone)]
+pub struct TursoSyncAuthClient {
+    endpoint: String,
+    client: reqwest::Client,
+}
+
+impl TursoSyncAuthClient {
+    pub fn new(endpoint: impl Into<String>) -> SyncAuthResult<Self> {
+        let endpoint = normalize_endpoint(endpoint.into())?;
+        Ok(Self {
+            endpoint,
+            client: reqwest::Client::builder().build()?,
+        })
+    }
+
+    pub async fn exchange_token(&self, supabase_access_token: &str) -> SyncAuthResult<SyncToken> {
+        let supabase_access_token = supabase_access_token.trim();
+        if supabase_access_token.is_empty() {
+            return Err(SyncAuthError::InvalidConfiguration(
+                "Supabase access token must not be empty".to_string(),
+            ));
+        }
+
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .bearer_auth(supabase_access_token)
+            .header("Accept", "application/json")
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(SyncAuthError::Api(parse_api_error(status, &body)));
+        }
+
+        let payload = response.json::<SyncTokenResponse>().await?;
+        payload.try_into()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SyncTokenResponse {
+    auth_token: Option<String>,
+    token: Option<String>,
+    expires_at: Option<i64>,
+    expires_in: Option<i64>,
+    database_url: Option<String>,
+}
+
+impl TryFrom<SyncTokenResponse> for SyncToken {
+    type Error = SyncAuthError;
+
+    fn try_from(value: SyncTokenResponse) -> SyncAuthResult<Self> {
+        let token = value
+            .auth_token
+            .or(value.token)
+            .map(|token| token.trim().to_string())
+            .filter(|token| !token.is_empty())
+            .ok_or_else(|| {
+                SyncAuthError::InvalidPayload(
+                    "response did not include auth_token/token".to_string(),
+                )
+            })?;
+
+        let expires_at = value
+            .expires_at
+            .or_else(|| {
+                value
+                    .expires_in
+                    .map(|expires_in| unix_timestamp_now().saturating_add(expires_in))
+            })
+            .ok_or_else(|| {
+                SyncAuthError::InvalidPayload(
+                    "response did not include expires_at/expires_in".to_string(),
+                )
+            })?;
+
+        let database_url = value
+            .database_url
+            .map(|database_url| database_url.trim().to_string())
+            .filter(|database_url| !database_url.is_empty());
+
+        Ok(Self {
+            token,
+            expires_at,
+            database_url,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SyncAuthErrorBody {
+    error: Option<String>,
+    message: Option<String>,
+}
+
+fn parse_api_error(status: StatusCode, body: &str) -> String {
+    if let Ok(payload) = serde_json::from_str::<SyncAuthErrorBody>(body) {
+        if let Some(message) = payload.message.or(payload.error) {
+            return format!("{} ({})", message.trim(), status.as_u16());
+        }
+    }
+
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        format!("HTTP {}", status.as_u16())
+    } else {
+        format!("{} ({})", trimmed, status.as_u16())
+    }
+}
+
+fn normalize_endpoint(raw: String) -> SyncAuthResult<String> {
+    let endpoint = normalize_text_option(Some(raw)).ok_or_else(|| {
+        SyncAuthError::InvalidConfiguration("endpoint must not be empty".to_string())
+    })?;
+    if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+        Ok(endpoint.trim_end_matches('/').to_string())
+    } else {
+        Err(SyncAuthError::InvalidConfiguration(
+            "endpoint must include http:// or https://".to_string(),
+        ))
+    }
+}
+
+fn unix_timestamp_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| {
+            i64::try_from(duration.as_secs()).unwrap_or(i64::MAX)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_endpoint_rejects_invalid_values() {
+        assert!(normalize_endpoint(String::new()).is_err());
+        assert!(normalize_endpoint("api.example.com".to_string()).is_err());
+    }
+
+    #[test]
+    fn sync_token_debug_redacts_token() {
+        let token = SyncToken {
+            token: "secret".to_string(),
+            expires_at: 123,
+            database_url: Some("libsql://example.turso.io".to_string()),
+        };
+        let debug = format!("{token:?}");
+        assert!(!debug.contains("secret"));
+        assert!(debug.contains("[REDACTED]"));
+    }
+}

--- a/crates/dirt-desktop/src/bootstrap_config.rs
+++ b/crates/dirt-desktop/src/bootstrap_config.rs
@@ -1,55 +1,13 @@
 //! Desktop bootstrap configuration loaded from build-time generated JSON.
 
-use std::time::Duration;
+pub use dirt_core::config::normalize_text_option;
+use dirt_core::config::{
+    resolve_bootstrap_config as resolve_core_bootstrap_config, BootstrapConfig,
+};
 
-use serde::{Deserialize, Serialize};
-
-const BOOTSTRAP_SCHEMA_VERSION: u32 = 1;
-const BOOTSTRAP_HTTP_TIMEOUT_SECS: u64 = 4;
-
-/// Build-provisioned client configuration embedded into desktop binaries.
-///
-/// These values are safe-to-ship public endpoints/keys required to bootstrap
-/// auth, sync, and media flows. Secret credentials must never be stored here.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct DesktopBootstrapConfig {
-    #[serde(default)]
-    pub bootstrap_manifest_url: Option<String>,
-    #[serde(default)]
-    pub supabase_url: Option<String>,
-    #[serde(default)]
-    pub supabase_anon_key: Option<String>,
-    #[serde(default)]
-    pub turso_sync_token_endpoint: Option<String>,
-    #[serde(default)]
-    pub dirt_api_base_url: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct ManagedBootstrapManifest {
-    schema_version: u32,
-    manifest_version: String,
-    supabase_url: String,
-    supabase_anon_key: String,
-    api_base_url: String,
-    #[serde(default)]
-    turso_sync_token_endpoint: Option<String>,
-    feature_flags: ManagedFeatureFlags,
-}
-
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct ManagedFeatureFlags {
-    managed_sync: bool,
-    managed_media: bool,
-}
+pub type DesktopBootstrapConfig = BootstrapConfig;
 
 /// Loads the generated desktop bootstrap JSON from `OUT_DIR`.
-///
-/// If parsing fails, this logs a warning and returns a default empty config so
-/// the app can continue running in local-only mode.
 pub fn load_bootstrap_config() -> DesktopBootstrapConfig {
     let raw = include_str!(concat!(env!("OUT_DIR"), "/desktop-bootstrap.json"));
     serde_json::from_str(raw).unwrap_or_else(|error| {
@@ -58,160 +16,9 @@ pub fn load_bootstrap_config() -> DesktopBootstrapConfig {
     })
 }
 
-/// Resolve runtime bootstrap config.
-///
-/// Attempts to fetch managed bootstrap manifest from `bootstrap_manifest_url`.
-/// When fetching/parsing/validation fails, this safely falls back to the
-/// embedded build-time config.
+/// Resolve runtime bootstrap config with managed manifest fallback.
 pub async fn resolve_bootstrap_config(fallback: DesktopBootstrapConfig) -> DesktopBootstrapConfig {
-    let Some(manifest_url) = normalize_text_option(fallback.bootstrap_manifest_url.clone()) else {
-        return fallback;
-    };
-
-    match fetch_bootstrap_manifest(&manifest_url).await {
-        Ok(config) => config,
-        Err(error) => {
-            tracing::warn!(
-                "Failed to resolve runtime desktop bootstrap from {}: {}. Falling back to embedded config.",
-                manifest_url,
-                error
-            );
-            fallback
-        }
-    }
-}
-
-/// Normalizes optional text config by trimming whitespace and removing empties.
-///
-/// Returns `None` when the input is `None` or the trimmed value is empty.
-pub fn normalize_text_option(value: Option<String>) -> Option<String> {
-    let value = value?;
-    let value = value.trim();
-    if value.is_empty() {
-        None
-    } else {
-        Some(value.to_string())
-    }
-}
-
-impl DesktopBootstrapConfig {
-    /// Returns the managed API base URL for authenticated media operations.
-    ///
-    /// Prefers `dirt_api_base_url` when present; otherwise derives the base URL
-    /// from `turso_sync_token_endpoint` by stripping `/v1/sync/token`.
-    pub fn managed_api_base_url(&self) -> Option<String> {
-        if let Some(url) = normalize_text_option(self.dirt_api_base_url.clone()) {
-            return Some(url);
-        }
-
-        let endpoint = normalize_text_option(self.turso_sync_token_endpoint.clone())?;
-        endpoint
-            .strip_suffix("/v1/sync/token")
-            .map(std::string::ToString::to_string)
-    }
-}
-
-async fn fetch_bootstrap_manifest(url: &str) -> Result<DesktopBootstrapConfig, String> {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(BOOTSTRAP_HTTP_TIMEOUT_SECS))
-        .build()
-        .map_err(|error| format!("failed to build bootstrap HTTP client: {error}"))?;
-
-    let response = client
-        .get(url)
-        .header(reqwest::header::ACCEPT, "application/json")
-        .send()
-        .await
-        .map_err(|error| format!("bootstrap request failed: {error}"))?;
-
-    if !response.status().is_success() {
-        let status = response.status().as_u16();
-        let body = response.text().await.unwrap_or_default();
-        return Err(format!(
-            "bootstrap endpoint returned HTTP {status}: {}",
-            compact_text(&body)
-        ));
-    }
-
-    let body = response
-        .text()
-        .await
-        .map_err(|error| format!("failed to read bootstrap response body: {error}"))?;
-    parse_bootstrap_manifest(&body, url)
-}
-
-fn parse_bootstrap_manifest(
-    payload: &str,
-    manifest_url: &str,
-) -> Result<DesktopBootstrapConfig, String> {
-    let manifest: ManagedBootstrapManifest = serde_json::from_str(payload)
-        .map_err(|error| format!("invalid bootstrap manifest JSON: {error}"))?;
-    manifest.into_runtime_config(manifest_url)
-}
-
-impl ManagedBootstrapManifest {
-    fn into_runtime_config(self, manifest_url: &str) -> Result<DesktopBootstrapConfig, String> {
-        if self.schema_version != BOOTSTRAP_SCHEMA_VERSION {
-            return Err(format!(
-                "unsupported bootstrap schema_version {} (expected {})",
-                self.schema_version, BOOTSTRAP_SCHEMA_VERSION
-            ));
-        }
-        if self.manifest_version.trim().is_empty() {
-            return Err("bootstrap manifest_version must not be empty".to_string());
-        }
-
-        let supabase_url = normalize_required_http_url(self.supabase_url, "supabase_url")?;
-        let supabase_anon_key =
-            normalize_required_value(self.supabase_anon_key, "supabase_anon_key")?;
-        let api_base_url = normalize_required_http_url(self.api_base_url, "api_base_url")?;
-
-        let sync_endpoint = if self.feature_flags.managed_sync {
-            match normalize_text_option(self.turso_sync_token_endpoint) {
-                Some(endpoint) => Some(normalize_required_http_url(
-                    endpoint,
-                    "turso_sync_token_endpoint",
-                )?),
-                None => Some(format!("{api_base_url}/v1/sync/token")),
-            }
-        } else {
-            None
-        };
-
-        let api_base_for_clients =
-            if self.feature_flags.managed_sync || self.feature_flags.managed_media {
-                Some(api_base_url)
-            } else {
-                None
-            };
-
-        Ok(DesktopBootstrapConfig {
-            bootstrap_manifest_url: Some(manifest_url.to_string()),
-            supabase_url: Some(supabase_url),
-            supabase_anon_key: Some(supabase_anon_key),
-            turso_sync_token_endpoint: sync_endpoint,
-            dirt_api_base_url: api_base_for_clients,
-        })
-    }
-}
-
-fn normalize_required_value(raw: String, field: &str) -> Result<String, String> {
-    normalize_text_option(Some(raw)).ok_or_else(|| format!("bootstrap field '{field}' is required"))
-}
-
-fn normalize_required_http_url(raw: String, field: &str) -> Result<String, String> {
-    let value = normalize_required_value(raw, field)?;
-    if value.starts_with("http://") || value.starts_with("https://") {
-        Ok(value.trim_end_matches('/').to_string())
-    } else {
-        Err(format!(
-            "bootstrap field '{field}' must include http:// or https://"
-        ))
-    }
-}
-
-fn compact_text(value: &str) -> String {
-    value.trim().chars().take(180).collect()
+    resolve_core_bootstrap_config(fallback).await
 }
 
 #[cfg(test)]
@@ -240,77 +47,6 @@ mod tests {
         };
         assert_eq!(
             config.managed_api_base_url().as_deref(),
-            Some("https://api.example.com")
-        );
-    }
-
-    #[test]
-    fn parse_manifest_rejects_unknown_fields() {
-        let payload = r#"
-        {
-          "schema_version": 1,
-          "manifest_version": "v1",
-          "supabase_url": "https://project.supabase.co",
-          "supabase_anon_key": "anon",
-          "api_base_url": "https://api.example.com",
-          "feature_flags": {
-            "managed_sync": true,
-            "managed_media": true,
-            "unexpected": true
-          }
-        }
-        "#;
-
-        let error =
-            parse_bootstrap_manifest(payload, "https://api.example.com/v1/bootstrap").unwrap_err();
-        assert!(error.contains("unknown field"));
-    }
-
-    #[test]
-    fn parse_manifest_rejects_invalid_schema_version() {
-        let payload = r#"
-        {
-          "schema_version": 9,
-          "manifest_version": "v1",
-          "supabase_url": "https://project.supabase.co",
-          "supabase_anon_key": "anon",
-          "api_base_url": "https://api.example.com",
-          "feature_flags": {
-            "managed_sync": true,
-            "managed_media": true
-          }
-        }
-        "#;
-
-        let error =
-            parse_bootstrap_manifest(payload, "https://api.example.com/v1/bootstrap").unwrap_err();
-        assert!(error.contains("schema_version"));
-    }
-
-    #[test]
-    fn parse_manifest_derives_sync_endpoint_when_missing() {
-        let payload = r#"
-        {
-          "schema_version": 1,
-          "manifest_version": "v2",
-          "supabase_url": "https://project.supabase.co",
-          "supabase_anon_key": "anon",
-          "api_base_url": "https://api.example.com",
-          "feature_flags": {
-            "managed_sync": true,
-            "managed_media": false
-          }
-        }
-        "#;
-
-        let parsed = parse_bootstrap_manifest(payload, "https://api.example.com/v1/bootstrap")
-            .expect("manifest should parse");
-        assert_eq!(
-            parsed.turso_sync_token_endpoint.as_deref(),
-            Some("https://api.example.com/v1/sync/token")
-        );
-        assert_eq!(
-            parsed.dirt_api_base_url.as_deref(),
             Some("https://api.example.com")
         );
     }

--- a/crates/dirt-desktop/src/services/auth.rs
+++ b/crates/dirt-desktop/src/services/auth.rs
@@ -1,108 +1,16 @@
 //! Supabase authentication service with secure session storage.
 
-use std::fmt;
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use keyring::Entry;
-use reqwest::{Client, RequestBuilder, StatusCode};
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
 
-use crate::bootstrap_config::{normalize_text_option, DesktopBootstrapConfig};
+use crate::bootstrap_config::DesktopBootstrapConfig;
+
+use dirt_core::auth::{
+    resolve_optional_supabase_config, AuthResult, SessionPersistence, SupabaseAuthClient,
+};
+pub use dirt_core::auth::{AuthConfigStatus, AuthError, AuthSession, SignUpOutcome};
 
 const KEYRING_SERVICE_NAME: &str = "dirt";
 const KEYRING_SESSION_USERNAME: &str = "supabase_session";
-const EXPIRY_SKEW_SECONDS: i64 = 60;
-
-/// Authenticated user metadata.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AuthUser {
-    /// Provider user id.
-    pub id: String,
-    /// Optional email from provider profile.
-    pub email: Option<String>,
-}
-
-/// Persisted session used for API authorization.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AuthSession {
-    /// Short-lived access token.
-    pub access_token: String,
-    /// Refresh token for obtaining new access tokens.
-    pub refresh_token: String,
-    /// Unix timestamp (seconds) when access token expires.
-    pub expires_at: i64,
-    /// Authenticated user profile.
-    pub user: AuthUser,
-}
-
-impl AuthSession {
-    #[must_use]
-    pub fn is_expired(&self) -> bool {
-        self.is_expired_at(unix_timestamp_now())
-    }
-
-    #[must_use]
-    const fn is_expired_at(&self, now_secs: i64) -> bool {
-        self.expires_at <= now_secs + EXPIRY_SKEW_SECONDS
-    }
-}
-
-impl fmt::Debug for AuthSession {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("AuthSession")
-            .field("access_token", &"[REDACTED]")
-            .field("refresh_token", &"[REDACTED]")
-            .field("expires_at", &self.expires_at)
-            .field("user", &self.user)
-            .finish()
-    }
-}
-
-/// Sign-up result from provider.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SignUpOutcome {
-    /// Account created and session started immediately.
-    SignedIn(AuthSession),
-    /// Account created but provider requires email confirmation.
-    ConfirmationRequired,
-}
-
-/// Auth configuration status returned from Supabase settings endpoint.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(clippy::struct_excessive_bools)]
-pub struct AuthConfigStatus {
-    /// Whether email auth provider is enabled.
-    pub email_enabled: bool,
-    /// Whether sign-ups are allowed.
-    pub signup_enabled: bool,
-    /// Whether sign-ups are auto-confirmed without email delivery.
-    pub mailer_autoconfirm: bool,
-    /// Whether custom SMTP credentials are configured.
-    pub smtp_configured: bool,
-    /// Current Supabase email send rate limit (requests/hour).
-    pub rate_limit_email_sent: Option<i64>,
-}
-
-/// Errors from authentication and secure storage flows.
-#[derive(Debug, Error)]
-pub enum AuthError {
-    #[error("Supabase auth is not configured for this build.")]
-    NotConfigured,
-    #[error("Invalid auth configuration: {0}")]
-    InvalidConfiguration(&'static str),
-    #[error("HTTP request failed: {0}")]
-    Http(#[from] reqwest::Error),
-    #[error("Failed to parse JSON payload: {0}")]
-    Json(#[from] serde_json::Error),
-    #[error("Auth API error: {0}")]
-    Api(String),
-    #[error("Secure storage error: {0}")]
-    SecureStorage(String),
-}
-
-type AuthResult<T> = Result<T, AuthError>;
 
 #[derive(Debug, Clone)]
 struct SessionStore {
@@ -124,7 +32,9 @@ impl SessionStore {
         Entry::new(&self.service_name, &self.username)
             .map_err(|error| AuthError::SecureStorage(error.to_string()))
     }
+}
 
+impl SessionPersistence for SessionStore {
     fn load_session(&self) -> AuthResult<Option<AuthSession>> {
         let entry = self.entry()?;
         match entry.get_password() {
@@ -150,386 +60,72 @@ impl SessionStore {
     }
 }
 
-/// Supabase auth API client.
 #[derive(Clone)]
 pub struct SupabaseAuthService {
-    auth_url: String,
-    anon_key: String,
-    client: Client,
-    session_store: SessionStore,
+    inner: SupabaseAuthClient<SessionStore>,
 }
 
 impl SupabaseAuthService {
-    /// Create a service from desktop bootstrap config.
     pub fn new_from_bootstrap(config: &DesktopBootstrapConfig) -> AuthResult<Option<Self>> {
-        let url = normalize_text_option(config.supabase_url.clone());
-        let anon_key = normalize_text_option(config.supabase_anon_key.clone());
-
-        match (url, anon_key) {
-            (None, None) => Ok(None),
-            (Some(url), Some(anon_key)) => {
-                let service = Self::new(url, anon_key)?;
-                Ok(Some(service))
-            }
-            _ => Err(AuthError::NotConfigured),
-        }
-    }
-
-    /// Create a service from `SUPABASE_URL` and `SUPABASE_ANON_KEY`.
-    pub fn new_from_env() -> AuthResult<Option<Self>> {
-        let url = std::env::var("SUPABASE_URL").ok();
-        let anon_key = std::env::var("SUPABASE_ANON_KEY").ok();
-
-        match (url, anon_key) {
-            (None, None) => Ok(None),
-            (Some(url), Some(anon_key)) => {
-                let service = Self::new(url, anon_key)?;
-                Ok(Some(service))
-            }
-            _ => Err(AuthError::NotConfigured),
-        }
-    }
-
-    /// Create a service with explicit Supabase project URL and anon key.
-    pub fn new(url: impl AsRef<str>, anon_key: impl Into<String>) -> AuthResult<Self> {
-        let auth_url = normalize_auth_url(url.as_ref())?;
-        let anon_key = anon_key.into().trim().to_string();
-        if anon_key.is_empty() {
-            return Err(AuthError::InvalidConfiguration(
-                "Supabase anon key must not be empty",
-            ));
-        }
-
-        let client = Client::builder().build()?;
-
-        Ok(Self {
-            auth_url,
-            anon_key,
-            client,
-            session_store: SessionStore::default(),
-        })
-    }
-
-    /// Restore session from secure storage. If expired, refresh automatically.
-    pub async fn restore_session(&self) -> AuthResult<Option<AuthSession>> {
-        let Some(stored_session) = self.session_store.load_session()? else {
+        let Some((url, anon_key)) = resolve_optional_supabase_config(
+            config.supabase_url.clone(),
+            config.supabase_anon_key.clone(),
+        )?
+        else {
             return Ok(None);
         };
 
-        if !stored_session.is_expired() {
-            return Ok(Some(stored_session));
-        }
-
-        match self.refresh_session(&stored_session.refresh_token).await {
-            Ok(refreshed) => {
-                self.session_store.save_session(&refreshed)?;
-                Ok(Some(refreshed))
-            }
-            Err(error) => {
-                tracing::warn!("Failed to refresh persisted session: {}", error);
-                self.session_store.clear_session()?;
-                Ok(None)
-            }
-        }
+        Ok(Some(Self::new(url, anon_key)?))
     }
 
-    /// Sign up a user by email/password.
+    pub fn new_from_env() -> AuthResult<Option<Self>> {
+        let Some((url, anon_key)) = resolve_optional_supabase_config(
+            std::env::var("SUPABASE_URL").ok(),
+            std::env::var("SUPABASE_ANON_KEY").ok(),
+        )?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(Self::new(url, anon_key)?))
+    }
+
+    pub fn new(url: impl AsRef<str>, anon_key: impl Into<String>) -> AuthResult<Self> {
+        Ok(Self {
+            inner: SupabaseAuthClient::new(url, anon_key, SessionStore::default())?,
+        })
+    }
+
+    pub async fn restore_session(&self) -> AuthResult<Option<AuthSession>> {
+        self.inner.restore_session().await
+    }
+
     pub async fn sign_up(&self, email: &str, password: &str) -> AuthResult<SignUpOutcome> {
-        validate_credentials(email, password)?;
-
-        let payload = serde_json::json!({
-            "email": email,
-            "password": password,
-        });
-        let request = self.public_request(
-            self.client
-                .post(format!("{}/signup", self.auth_url))
-                .json(&payload),
-        );
-        let response = self.send_auth_request(request).await?;
-        match response.into_session()? {
-            Some(session) => {
-                self.session_store.save_session(&session)?;
-                Ok(SignUpOutcome::SignedIn(session))
-            }
-            None => Ok(SignUpOutcome::ConfirmationRequired),
-        }
+        self.inner.sign_up(email, password).await
     }
 
-    /// Sign in an existing user by email/password.
     pub async fn sign_in(&self, email: &str, password: &str) -> AuthResult<AuthSession> {
-        validate_credentials(email, password)?;
-
-        let payload = serde_json::json!({
-            "email": email,
-            "password": password,
-        });
-        let request = self.public_request(
-            self.client
-                .post(format!("{}/token", self.auth_url))
-                .query(&[("grant_type", "password")])
-                .json(&payload),
-        );
-        let response = self.send_auth_request(request).await?;
-        let session = response.into_session()?.ok_or_else(|| {
-            AuthError::Api("Sign-in response did not include an active session".to_string())
-        })?;
-        self.session_store.save_session(&session)?;
-        Ok(session)
+        self.inner.sign_in(email, password).await
     }
 
-    /// Refresh an access token using the refresh token.
+    #[allow(dead_code)]
     pub async fn refresh_session(&self, refresh_token: &str) -> AuthResult<AuthSession> {
-        if refresh_token.trim().is_empty() {
-            return Err(AuthError::InvalidConfiguration(
-                "Refresh token must not be empty",
-            ));
-        }
-
-        let payload = serde_json::json!({
-            "refresh_token": refresh_token,
-        });
-        let request = self.public_request(
-            self.client
-                .post(format!("{}/token", self.auth_url))
-                .query(&[("grant_type", "refresh_token")])
-                .json(&payload),
-        );
-        let response = self.send_auth_request(request).await?;
-        let session = response.into_session()?.ok_or_else(|| {
-            AuthError::Api("Refresh response did not include an active session".to_string())
-        })?;
-        self.session_store.save_session(&session)?;
-        Ok(session)
+        self.inner.refresh_session(refresh_token).await
     }
 
-    /// Sign out and clear local session storage.
     pub async fn sign_out(&self, access_token: &str) -> AuthResult<()> {
-        let server_logout = async {
-            let request = self
-                .client
-                .post(format!("{}/logout", self.auth_url))
-                .header("apikey", &self.anon_key)
-                .bearer_auth(access_token);
-            let response = request.send().await?;
-            if response.status().is_success() || response.status() == StatusCode::UNAUTHORIZED {
-                Ok(())
-            } else {
-                let status = response.status();
-                let body = response.text().await.unwrap_or_default();
-                Err(AuthError::Api(parse_api_error(status, &body)))
-            }
-        }
-        .await;
-
-        // Always clear local credentials when user requests sign-out.
-        self.session_store.clear_session()?;
-
-        if let Err(error) = server_logout {
-            tracing::warn!(
-                "Server logout failed after clearing local session: {}",
-                error
-            );
-        }
-
-        Ok(())
+        self.inner.sign_out(access_token).await
     }
 
-    /// Verify Supabase auth configuration and return a summary for UI diagnostics.
     pub async fn verify_configuration(&self) -> AuthResult<AuthConfigStatus> {
-        let request = self.public_request(self.client.get(format!("{}/settings", self.auth_url)));
-        let response = request.send().await?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AuthError::Api(parse_api_error(status, &body)));
-        }
-
-        let payload = response.json::<SupabaseAuthSettings>().await?;
-        Ok(AuthConfigStatus {
-            email_enabled: payload.external.email,
-            signup_enabled: !payload.disable_signup,
-            mailer_autoconfirm: payload.mailer_autoconfirm,
-            smtp_configured: payload.smtp_host.is_some(),
-            rate_limit_email_sent: payload.rate_limit_email_sent,
-        })
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseAuthResponse {
-    access_token: Option<String>,
-    refresh_token: Option<String>,
-    expires_at: Option<i64>,
-    expires_in: Option<i64>,
-    user: Option<SupabaseUser>,
-    session: Option<SupabaseAuthResponseSession>,
-}
-
-impl SupabaseAuthResponse {
-    fn into_session(self) -> AuthResult<Option<AuthSession>> {
-        let session = self.session;
-        let access_token = self
-            .access_token
-            .or_else(|| session.as_ref().and_then(|s| s.access_token.clone()));
-        let refresh_token = self
-            .refresh_token
-            .or_else(|| session.as_ref().and_then(|s| s.refresh_token.clone()));
-        let expires_at = self
-            .expires_at
-            .or_else(|| session.as_ref().and_then(|s| s.expires_at))
-            .or_else(|| {
-                self.expires_in
-                    .or_else(|| session.as_ref().and_then(|s| s.expires_in))
-                    .map(|expires_in| unix_timestamp_now().saturating_add(expires_in))
-            });
-        let user = self
-            .user
-            .or_else(|| session.and_then(|s| s.user))
-            .map(Into::into);
-
-        match (access_token, refresh_token, expires_at, user) {
-            (Some(access_token), Some(refresh_token), Some(expires_at), Some(user)) => {
-                Ok(Some(AuthSession {
-                    access_token,
-                    refresh_token,
-                    expires_at,
-                    user,
-                }))
-            }
-            (None, None, None, Some(_)) => Ok(None),
-            _ => Err(AuthError::Api(
-                "Auth response did not include enough session fields".to_string(),
-            )),
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseAuthResponseSession {
-    access_token: Option<String>,
-    refresh_token: Option<String>,
-    expires_at: Option<i64>,
-    expires_in: Option<i64>,
-    user: Option<SupabaseUser>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseUser {
-    id: String,
-    email: Option<String>,
-}
-
-impl From<SupabaseUser> for AuthUser {
-    fn from(value: SupabaseUser) -> Self {
-        Self {
-            id: value.id,
-            email: value.email,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseErrorResponse {
-    error: Option<String>,
-    error_description: Option<String>,
-    message: Option<String>,
-    msg: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseAuthSettings {
-    external: SupabaseExternalSettings,
-    disable_signup: bool,
-    mailer_autoconfirm: bool,
-    smtp_host: Option<String>,
-    rate_limit_email_sent: Option<i64>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseExternalSettings {
-    email: bool,
-}
-
-fn parse_api_error(status: StatusCode, body: &str) -> String {
-    if let Ok(payload) = serde_json::from_str::<SupabaseErrorResponse>(body) {
-        if let Some(message) = payload
-            .message
-            .or(payload.msg)
-            .or(payload.error_description)
-            .or(payload.error)
-        {
-            return format!("{} ({})", message.trim(), status.as_u16());
-        }
-    }
-
-    let trimmed = body.trim();
-    if trimmed.is_empty() {
-        format!("HTTP {}", status.as_u16())
-    } else {
-        format!("{} ({})", trimmed, status.as_u16())
-    }
-}
-
-fn normalize_auth_url(url: &str) -> AuthResult<String> {
-    let trimmed = url.trim().trim_end_matches('/');
-    if trimmed.is_empty() {
-        return Err(AuthError::InvalidConfiguration(
-            "Supabase URL must not be empty",
-        ));
-    }
-    if !(trimmed.starts_with("https://") || trimmed.starts_with("http://")) {
-        return Err(AuthError::InvalidConfiguration(
-            "Supabase URL must include http:// or https://",
-        ));
-    }
-
-    if trimmed.ends_with("/auth/v1") {
-        Ok(trimmed.to_string())
-    } else {
-        Ok(format!("{trimmed}/auth/v1"))
-    }
-}
-
-fn validate_credentials(email: &str, password: &str) -> AuthResult<()> {
-    if email.trim().is_empty() {
-        return Err(AuthError::Api("Email is required".to_string()));
-    }
-    if password.trim().is_empty() {
-        return Err(AuthError::Api("Password is required".to_string()));
-    }
-    Ok(())
-}
-
-fn unix_timestamp_now() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| {
-            i64::try_from(duration.as_secs()).unwrap_or(i64::MAX)
-        })
-}
-
-impl SupabaseAuthService {
-    fn public_request(&self, request: RequestBuilder) -> RequestBuilder {
-        request
-            .header("apikey", &self.anon_key)
-            .header("Authorization", format!("Bearer {}", self.anon_key))
-    }
-
-    async fn send_auth_request(&self, request: RequestBuilder) -> AuthResult<SupabaseAuthResponse> {
-        let response = request.send().await?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AuthError::Api(parse_api_error(status, &body)));
-        }
-
-        Ok(response.json::<SupabaseAuthResponse>().await?)
+        self.inner.verify_configuration().await
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use dirt_core::auth::normalize_auth_url;
+
     use super::*;
 
     #[test]
@@ -545,36 +141,10 @@ mod tests {
     }
 
     #[test]
-    fn response_without_session_fields_means_confirmation_required() {
-        let response = SupabaseAuthResponse {
-            access_token: None,
-            refresh_token: None,
-            expires_at: None,
-            expires_in: None,
-            user: Some(SupabaseUser {
-                id: "user-id".to_string(),
-                email: Some("test@example.com".to_string()),
-            }),
-            session: None,
-        };
-
-        let session = response.into_session().unwrap();
-        assert!(session.is_none());
-    }
-
-    #[test]
-    fn session_expiry_uses_safety_skew() {
-        let session = AuthSession {
-            access_token: "access".to_string(),
-            refresh_token: "refresh".to_string(),
-            expires_at: 1_000,
-            user: AuthUser {
-                id: "user".to_string(),
-                email: None,
-            },
-        };
-
-        assert!(session.is_expired_at(940));
-        assert!(!session.is_expired_at(900));
+    fn new_from_bootstrap_returns_none_when_values_missing() {
+        let config = DesktopBootstrapConfig::default();
+        assert!(SupabaseAuthService::new_from_bootstrap(&config)
+            .unwrap()
+            .is_none());
     }
 }

--- a/crates/dirt-desktop/src/services/database.rs
+++ b/crates/dirt-desktop/src/services/database.rs
@@ -1,327 +1,134 @@
-//! Database service for the desktop application
-
-#![allow(dead_code)] // Methods will be used in future features
+//! Desktop database service wrapper.
 
 use std::path::PathBuf;
-use std::sync::Arc;
 
-use dirt_core::db::{
-    Database, LibSqlNoteRepository, LibSqlSettingsRepository, NoteRepository, SettingsRepository,
-    SyncConfig,
-};
-use dirt_core::error::Result;
-use dirt_core::models::{Attachment, AttachmentId, Note, Settings, SyncConflict};
-use dirt_core::NoteId;
-use tokio::sync::Mutex;
+use dirt_core::db::{Database, SyncConfig};
+use dirt_core::models::{Attachment, AttachmentId, Note, Settings};
+use dirt_core::services::database::DatabaseService as CoreDatabaseService;
+use dirt_core::{NoteId, Result, SyncConflict};
 
-/// Service for database operations
-///
-/// Wraps the database connection and provides thread-safe async access.
 #[derive(Clone)]
 pub struct DatabaseService {
-    db: Arc<Mutex<Database>>,
-    db_path: Option<PathBuf>,
-    sync_config: Option<SyncConfig>,
+    inner: CoreDatabaseService,
 }
 
 impl DatabaseService {
-    /// Create a new database service, auto-detecting sync config from environment
-    ///
-    /// If `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` are set, sync is enabled automatically.
-    /// Otherwise, falls back to local-only mode.
     pub async fn new() -> Result<Self> {
         let db_path = Self::default_db_path();
-
-        // Ensure parent directory exists
         if let Some(parent) = db_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
-        // Check for sync config from environment
         let sync_config = Self::sync_config_from_env();
-
-        let db = Self::open_database(db_path.clone(), sync_config.clone()).await?;
-
-        Ok(Self {
-            db: Arc::new(Mutex::new(db)),
-            db_path: Some(db_path),
-            sync_config,
-        })
+        let inner = Self::open_database(db_path, sync_config).await?;
+        Ok(Self { inner })
     }
 
-    /// Read sync configuration from environment variables
     fn sync_config_from_env() -> Option<SyncConfig> {
-        let url = std::env::var("TURSO_DATABASE_URL").ok()?;
-        let token = std::env::var("TURSO_AUTH_TOKEN").ok()?;
-
-        if url.is_empty() || token.is_empty() {
-            return None;
+        let url = std::env::var("TURSO_DATABASE_URL").ok();
+        let auth_token = std::env::var("TURSO_AUTH_TOKEN").ok();
+        match (url, auth_token) {
+            (Some(url), Some(auth_token)) if !url.is_empty() && !auth_token.is_empty() => {
+                Some(SyncConfig::new(url, auth_token))
+            }
+            _ => None,
         }
-
-        Some(SyncConfig::new(url, token))
     }
 
-    /// Create a new database service with explicit sync config
     pub async fn new_with_sync(sync_config: SyncConfig) -> Result<Self> {
         let db_path = Self::default_db_path();
-
-        // Ensure parent directory exists
         if let Some(parent) = db_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
-        let db = Self::open_database(db_path.clone(), Some(sync_config.clone())).await?;
-        Ok(Self {
-            db: Arc::new(Mutex::new(db)),
-            db_path: Some(db_path),
-            sync_config: Some(sync_config),
-        })
+        let inner = Self::open_database(db_path, Some(sync_config)).await?;
+        Ok(Self { inner })
     }
 
-    /// Create an in-memory database service (for testing)
     #[allow(dead_code)]
     pub async fn in_memory() -> Result<Self> {
-        let db = Database::open_in_memory().await?;
         Ok(Self {
-            db: Arc::new(Mutex::new(db)),
-            db_path: None,
-            sync_config: None,
+            inner: CoreDatabaseService::open_in_memory().await?,
         })
     }
 
-    /// Open a local DB or embedded replica using the same initialization strategy
-    /// as app startup.
-    async fn open_database(db_path: PathBuf, sync_config: Option<SyncConfig>) -> Result<Database> {
-        if let Some(config) = sync_config {
-            Self::open_database_with_sync_recovery(db_path, config)
-        } else {
-            tracing::info!("Running in local-only mode (no TURSO_DATABASE_URL/TURSO_AUTH_TOKEN)");
-            Database::open(&db_path).await
-        }
-    }
-
-    fn open_database_with_sync_recovery(
+    async fn open_database(
         db_path: PathBuf,
-        sync_config: SyncConfig,
-    ) -> Result<Database> {
-        tracing::info!(
-            "Sync enabled with Turso: {}",
-            sync_config.url.as_deref().unwrap_or("unknown")
-        );
-        match Self::open_database_with_sync_thread(db_path.clone(), sync_config.clone()) {
-            Ok(db) => Ok(db),
-            Err(error) if Self::is_recoverable_local_replica_error(&error) => {
-                tracing::warn!(
-                    "Detected inconsistent local replica state at {}: {}. Resetting local replica files and retrying once.",
-                    db_path.display(),
-                    error
-                );
-                Self::quarantine_corrupted_db_files(&db_path)?;
-                Self::open_database_with_sync_thread(db_path, sync_config)
+        sync_config: Option<SyncConfig>,
+    ) -> Result<CoreDatabaseService> {
+        match sync_config {
+            Some(sync_config) => {
+                let db = Database::open_with_sync(&db_path, sync_config).await?;
+                Ok(CoreDatabaseService::from_database(db))
             }
-            Err(error) => Err(error),
+            None => Ok(CoreDatabaseService::open(&db_path).await?),
         }
     }
 
-    fn open_database_with_sync_thread(
-        db_path: PathBuf,
-        sync_config: SyncConfig,
-    ) -> Result<Database> {
-        std::thread::Builder::new()
-            .stack_size(8 * 1024 * 1024) // 8MB stack
-            .spawn(move || {
-                tokio::runtime::Builder::new_multi_thread()
-                    .enable_all()
-                    .build()
-                    .unwrap()
-                    .block_on(Database::open_with_sync(&db_path, sync_config))
-            })
-            .map_err(|error| dirt_core::error::Error::Database(error.to_string()))?
-            .join()
-            .map_err(|_| dirt_core::error::Error::Database("Thread panicked".to_string()))?
-    }
-
-    fn is_corrupted_db_error(error: &dirt_core::Error) -> bool {
-        error
-            .to_string()
-            .to_ascii_lowercase()
-            .contains("file is not a database")
-    }
-
-    fn is_recoverable_local_replica_error(error: &dirt_core::Error) -> bool {
-        if Self::is_corrupted_db_error(error) {
-            return true;
-        }
-
-        let message = error.to_string().to_ascii_lowercase();
-        message.contains("invalid local state")
-            || message.contains("metadata file exists but db file does not")
-    }
-
-    fn quarantine_corrupted_db_files(db_path: &PathBuf) -> Result<()> {
-        if db_path.exists() {
-            let timestamp = chrono::Utc::now().timestamp_millis();
-            let backup_name = format!("dirt.db.corrupt-{timestamp}");
-            let backup_path = db_path.with_file_name(backup_name);
-
-            std::fs::rename(db_path, &backup_path)?;
-            tracing::warn!(
-                "Moved corrupted local DB file from {} to {}",
-                db_path.display(),
-                backup_path.display()
-            );
-        }
-
-        let Some(parent) = db_path.parent() else {
-            return Ok(());
-        };
-        let Some(base_name) = db_path.file_name().and_then(|name| name.to_str()) else {
-            return Ok(());
-        };
-        let sidecar_prefix = format!("{base_name}-");
-
-        for entry in std::fs::read_dir(parent)? {
-            let entry = entry?;
-            if !entry.file_type()?.is_file() {
-                continue;
-            }
-            let file_name = entry.file_name();
-            let file_name = file_name.to_string_lossy();
-            if file_name.starts_with(&sidecar_prefix) {
-                let path = entry.path();
-                std::fs::remove_file(&path)?;
-                tracing::warn!("Removed stale local replica file {}", path.display());
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn reopen_after_corruption(&self) -> Result<bool> {
-        let Some(db_path) = self.db_path.clone() else {
-            return Ok(false);
-        };
-
-        if let Some(parent) = db_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        tracing::warn!(
-            "Detected invalid local DB file; attempting to reopen connection at {}",
-            db_path.display()
-        );
-
-        // Replace with an in-memory placeholder first so the old file handle is released on
-        // Windows before we move corrupted files out of the way.
-        {
-            let mut db = self.db.lock().await;
-            let placeholder = Database::open_in_memory().await?;
-            let _old = std::mem::replace(&mut *db, placeholder);
-        }
-
-        Self::quarantine_corrupted_db_files(&db_path)?;
-        let reopened = Self::open_database(db_path, self.sync_config.clone()).await?;
-        let mut db = self.db.lock().await;
-        *db = reopened;
-        Ok(true)
-    }
-
-    /// Get the default database path
     fn default_db_path() -> PathBuf {
-        dirs::data_dir()
+        dirs::data_local_dir()
+            .or_else(dirs::data_dir)
             .unwrap_or_else(|| PathBuf::from("."))
             .join("dirt")
             .join("dirt.db")
     }
 
-    /// Sync with remote database (if configured)
     pub async fn sync(&self) -> Result<()> {
-        let db = self.db.lock().await;
-        db.sync().await
+        self.inner.sync().await
     }
 
-    /// Check if sync is enabled
     pub async fn is_sync_enabled(&self) -> bool {
-        let db = self.db.lock().await;
-        db.is_sync_enabled()
+        self.inner.is_sync_enabled().await
     }
 
-    /// List all notes
     pub async fn list_notes(&self, limit: usize, offset: usize) -> Result<Vec<Note>> {
-        let db = self.db.lock().await;
-        let repo = LibSqlNoteRepository::new(db.connection());
-        repo.list(limit, offset).await
+        self.inner.list_notes(limit, offset).await
     }
 
-    /// Get a note by ID
     pub async fn get_note(&self, id: &NoteId) -> Result<Option<Note>> {
-        let db = self.db.lock().await;
-        let repo = LibSqlNoteRepository::new(db.connection());
-        repo.get(id).await
+        self.inner.get_note(id).await
     }
 
-    /// Create a new note
     pub async fn create_note(&self, content: &str) -> Result<Note> {
-        let db = self.db.lock().await;
-        let repo = LibSqlNoteRepository::new(db.connection());
-        repo.create(content).await
+        self.inner.create_note(content).await
     }
 
-    /// Create a note with a pre-generated ID (for optimistic UI updates)
     pub async fn create_note_with_id(&self, note: &Note) -> Result<Note> {
-        let db = self.db.lock().await;
-        let repo = LibSqlNoteRepository::new(db.connection());
-        repo.create_with_note(note).await
+        self.inner.create_note_with_id(note).await
     }
 
-    /// Update a note
     pub async fn update_note(&self, id: &NoteId, content: &str) -> Result<Note> {
-        let db = self.db.lock().await;
-        let repo = LibSqlNoteRepository::new(db.connection());
-        repo.update(id, content).await
+        self.inner.update_note(id, content).await
     }
 
-    /// Delete a note (soft delete)
     pub async fn delete_note(&self, id: &NoteId) -> Result<()> {
-        let db = self.db.lock().await;
-        let repo = LibSqlNoteRepository::new(db.connection());
-        repo.delete(id).await
+        self.inner.delete_note(id).await
     }
 
-    /// Search notes
+    #[allow(dead_code)]
     pub async fn search_notes(&self, query: &str, limit: usize) -> Result<Vec<Note>> {
-        let db = self.db.lock().await;
-        let repo = LibSqlNoteRepository::new(db.connection());
-        repo.search(query, limit).await
+        self.inner.search_notes(query, limit).await
     }
 
-    /// List notes by tag
+    #[allow(dead_code)]
     pub async fn list_notes_by_tag(
         &self,
         tag: &str,
         limit: usize,
         offset: usize,
     ) -> Result<Vec<Note>> {
-        let db = self.db.lock().await;
-        let repo = LibSqlNoteRepository::new(db.connection());
-        repo.list_by_tag(tag, limit, offset).await
+        self.inner.list_notes_by_tag(tag, limit, offset).await
     }
 
-    /// Get all tags with counts
+    #[allow(dead_code)]
     pub async fn list_tags(&self) -> Result<Vec<(String, usize)>> {
-        let db = self.db.lock().await;
-        let repo = LibSqlNoteRepository::new(db.connection());
-        repo.list_tags().await
+        self.inner.list_tags().await
     }
 
-    /// List recently resolved sync conflicts.
     pub async fn list_conflicts(&self, limit: usize) -> Result<Vec<SyncConflict>> {
-        let db = self.db.lock().await;
-        let repo = LibSqlNoteRepository::new(db.connection());
-        repo.list_conflicts(limit).await
+        self.inner.list_conflicts(limit).await
     }
 
-    /// Create attachment metadata for a note
     pub async fn create_attachment(
         &self,
         note_id: &NoteId,
@@ -330,70 +137,24 @@ impl DatabaseService {
         size_bytes: i64,
         r2_key: &str,
     ) -> Result<Attachment> {
-        let first_attempt = {
-            let db = self.db.lock().await;
-            let repo = LibSqlNoteRepository::new(db.connection());
-            repo.create_attachment(note_id, filename, mime_type, size_bytes, r2_key)
-                .await
-        };
-
-        match first_attempt {
-            Ok(attachment) => Ok(attachment),
-            Err(error) if Self::is_corrupted_db_error(&error) => {
-                if self.reopen_after_corruption().await? {
-                    let db = self.db.lock().await;
-                    let repo = LibSqlNoteRepository::new(db.connection());
-                    repo.create_attachment(note_id, filename, mime_type, size_bytes, r2_key)
-                        .await
-                } else {
-                    Err(error)
-                }
-            }
-            Err(error) => Err(error),
-        }
+        self.inner
+            .create_attachment(note_id, filename, mime_type, size_bytes, r2_key)
+            .await
     }
 
-    /// List non-deleted attachment metadata for a note
     pub async fn list_attachments(&self, note_id: &NoteId) -> Result<Vec<Attachment>> {
-        let first_attempt = {
-            let db = self.db.lock().await;
-            let repo = LibSqlNoteRepository::new(db.connection());
-            repo.list_attachments(note_id).await
-        };
-
-        match first_attempt {
-            Ok(attachments) => Ok(attachments),
-            Err(error) if Self::is_corrupted_db_error(&error) => {
-                if self.reopen_after_corruption().await? {
-                    let db = self.db.lock().await;
-                    let repo = LibSqlNoteRepository::new(db.connection());
-                    repo.list_attachments(note_id).await
-                } else {
-                    Err(error)
-                }
-            }
-            Err(error) => Err(error),
-        }
+        self.inner.list_attachments(note_id).await
     }
 
-    /// Soft delete attachment metadata by id
     pub async fn delete_attachment(&self, attachment_id: &AttachmentId) -> Result<()> {
-        let db = self.db.lock().await;
-        let repo = LibSqlNoteRepository::new(db.connection());
-        repo.delete_attachment(attachment_id).await
+        self.inner.delete_attachment(attachment_id).await
     }
 
-    /// Load settings from database
     pub async fn load_settings(&self) -> Result<Settings> {
-        let db = self.db.lock().await;
-        let repo = LibSqlSettingsRepository::new(db.connection());
-        repo.load().await
+        self.inner.load_settings().await
     }
 
-    /// Save settings to database
     pub async fn save_settings(&self, settings: &Settings) -> Result<()> {
-        let db = self.db.lock().await;
-        let repo = LibSqlSettingsRepository::new(db.connection());
-        repo.save(settings).await
+        self.inner.save_settings(settings).await
     }
 }

--- a/crates/dirt-desktop/src/services/media_api.rs
+++ b/crates/dirt-desktop/src/services/media_api.rs
@@ -1,15 +1,10 @@
 //! Backend media signing client for desktop attachment operations.
 
-use reqwest::Method;
-use serde::{Deserialize, Serialize};
-
 use crate::bootstrap_config::DesktopBootstrapConfig;
 
-/// HTTP client for managed media operations backed by the Dirt API service.
 #[derive(Debug, Clone)]
 pub struct MediaApiClient {
-    base_url: String,
-    client: reqwest::Client,
+    inner: dirt_core::media::MediaApiClient,
 }
 
 impl MediaApiClient {
@@ -25,14 +20,11 @@ impl MediaApiClient {
 
     /// Builds a client for an explicit API base URL.
     pub fn new(base_url: impl Into<String>) -> Result<Self, String> {
-        let base_url = normalize_base_url(base_url.into().as_str())?;
-        let client = reqwest::Client::builder()
-            .build()
-            .map_err(|error| format!("Failed to construct HTTP client: {error}"))?;
-        Ok(Self { base_url, client })
+        Ok(Self {
+            inner: dirt_core::media::MediaApiClient::new(base_url)?,
+        })
     }
 
-    /// Uploads attachment bytes using a backend-issued presigned operation.
     pub async fn upload(
         &self,
         access_token: &str,
@@ -40,221 +32,20 @@ impl MediaApiClient {
         content_type: &str,
         bytes: &[u8],
     ) -> Result<(), String> {
-        let operation = self
-            .request_presigned(
-                access_token,
-                "/v1/media/presign/upload",
-                &serde_json::json!({
-                    "object_key": object_key,
-                    "content_type": content_type,
-                }),
-            )
-            .await?;
-
-        let method = parse_method(&operation.method)?;
-        let mut request = self.client.request(method, &operation.url);
-        for (name, value) in operation.headers {
-            if name.eq_ignore_ascii_case("host") {
-                continue;
-            }
-            request = request.header(name, value);
-        }
-        let response = request
-            .body(bytes.to_vec())
-            .send()
+        self.inner
+            .upload(access_token, object_key, content_type, bytes)
             .await
-            .map_err(|error| format!("Upload request failed: {error}"))?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(format!(
-                "Upload request failed with HTTP {status}: {}",
-                compact_body(&body)
-            ));
-        }
-        Ok(())
     }
 
-    /// Downloads attachment bytes using a backend-issued presigned operation.
-    ///
-    /// Returns raw bytes and an optional content type returned by the storage backend.
     pub async fn download(
         &self,
         access_token: &str,
         object_key: &str,
     ) -> Result<(Vec<u8>, Option<String>), String> {
-        let encoded_object_key = urlencoding::encode(object_key);
-        let url = format!(
-            "{}/v1/media/presign/download?object_key={}",
-            self.base_url, encoded_object_key
-        );
-
-        let response = self
-            .client
-            .get(url)
-            .bearer_auth(access_token)
-            .header("Accept", "application/json")
-            .send()
-            .await
-            .map_err(|error| format!("Failed to request download URL: {error}"))?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(format!(
-                "Download URL request failed with HTTP {status}: {}",
-                compact_body(&body)
-            ));
-        }
-        let payload = response
-            .json::<PresignResponse>()
-            .await
-            .map_err(|error| format!("Failed to parse download URL response: {error}"))?;
-
-        let operation = payload.operation;
-        let method = parse_method(&operation.method)?;
-        let mut request = self.client.request(method, &operation.url);
-        for (name, value) in operation.headers {
-            if name.eq_ignore_ascii_case("host") {
-                continue;
-            }
-            request = request.header(name, value);
-        }
-        let response = request
-            .send()
-            .await
-            .map_err(|error| format!("Download request failed: {error}"))?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(format!(
-                "Download request failed with HTTP {status}: {}",
-                compact_body(&body)
-            ));
-        }
-        let content_type = response
-            .headers()
-            .get(reqwest::header::CONTENT_TYPE)
-            .and_then(|value| value.to_str().ok())
-            .map(ToString::to_string);
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|error| format!("Failed to read attachment bytes: {error}"))?;
-        Ok((bytes.to_vec(), content_type))
+        self.inner.download(access_token, object_key).await
     }
 
-    /// Deletes an attachment object using a backend-issued presigned operation.
     pub async fn delete(&self, access_token: &str, object_key: &str) -> Result<(), String> {
-        let operation = self
-            .request_presigned(
-                access_token,
-                "/v1/media/presign/delete",
-                &serde_json::json!({
-                    "object_key": object_key,
-                }),
-            )
-            .await?;
-
-        let method = parse_method(&operation.method)?;
-        let mut request = self.client.request(method, &operation.url);
-        for (name, value) in operation.headers {
-            if name.eq_ignore_ascii_case("host") {
-                continue;
-            }
-            request = request.header(name, value);
-        }
-        let response = request
-            .send()
-            .await
-            .map_err(|error| format!("Delete request failed: {error}"))?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(format!(
-                "Delete request failed with HTTP {status}: {}",
-                compact_body(&body)
-            ));
-        }
-        Ok(())
-    }
-
-    async fn request_presigned(
-        &self,
-        access_token: &str,
-        route: &str,
-        body: &serde_json::Value,
-    ) -> Result<PresignedOperation, String> {
-        let response = self
-            .client
-            .post(format!("{}{}", self.base_url, route))
-            .bearer_auth(access_token)
-            .header("Accept", "application/json")
-            .json(body)
-            .send()
-            .await
-            .map_err(|error| format!("Failed to request signed URL: {error}"))?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(format!(
-                "Signed URL request failed with HTTP {status}: {}",
-                compact_body(&body)
-            ));
-        }
-        let payload = response
-            .json::<PresignResponse>()
-            .await
-            .map_err(|error| format!("Failed to parse signed URL response: {error}"))?;
-        Ok(payload.operation)
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct PresignResponse {
-    operation: PresignedOperation,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct PresignedOperation {
-    method: String,
-    url: String,
-    headers: Vec<(String, String)>,
-}
-
-fn normalize_base_url(raw: &str) -> Result<String, String> {
-    let base = raw.trim().trim_end_matches('/').to_string();
-    if base.is_empty() {
-        return Err("DIRT_API_BASE_URL must not be empty".to_string());
-    }
-    if !(base.starts_with("https://") || base.starts_with("http://")) {
-        return Err("DIRT_API_BASE_URL must include http:// or https://".to_string());
-    }
-    Ok(base)
-}
-
-fn parse_method(raw: &str) -> Result<Method, String> {
-    Method::from_bytes(raw.as_bytes()).map_err(|error| format!("Unsupported HTTP method: {error}"))
-}
-
-fn compact_body(body: &str) -> String {
-    body.trim().chars().take(180).collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn normalize_base_url_rejects_invalid_values() {
-        assert!(normalize_base_url("").is_err());
-        assert!(normalize_base_url("example.com").is_err());
-    }
-
-    #[test]
-    fn normalize_base_url_trims_trailing_slash() {
-        assert_eq!(
-            normalize_base_url("https://api.example.com/").unwrap(),
-            "https://api.example.com"
-        );
+        self.inner.delete(access_token, object_key).await
     }
 }

--- a/crates/dirt-desktop/src/services/sync_auth.rs
+++ b/crates/dirt-desktop/src/services/sync_auth.rs
@@ -1,19 +1,13 @@
 //! Managed Turso sync token exchange client for desktop.
 
-use reqwest::Client;
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
-
 use crate::bootstrap_config::{normalize_text_option, DesktopBootstrapConfig};
 
-/// Short-lived Turso sync credentials minted by backend auth exchange.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub type SyncAuthError = dirt_core::sync::SyncAuthError;
+
+#[derive(Clone, PartialEq, Eq)]
 pub struct SyncToken {
-    /// Token to use as `TURSO_AUTH_TOKEN`.
     pub token: String,
-    /// Unix timestamp (seconds) when token expires.
     pub expires_at: i64,
-    /// Turso database URL to pair with the token.
     pub database_url: String,
 }
 
@@ -28,142 +22,50 @@ impl std::fmt::Debug for SyncToken {
     }
 }
 
-/// Errors returned by managed sync auth client.
-#[derive(Debug, Error)]
-pub enum SyncAuthError {
-    #[error("Invalid sync auth configuration: {0}")]
-    InvalidConfiguration(String),
-    #[error("HTTP request failed: {0}")]
-    Request(#[from] reqwest::Error),
-    #[error("Sync API error: {0}")]
-    Api(String),
-    #[error("Invalid sync token payload: {0}")]
-    InvalidPayload(String),
-}
-
-type SyncAuthResult<T> = Result<T, SyncAuthError>;
-
-/// Backend token exchange client.
 #[derive(Clone)]
 pub struct TursoSyncAuthClient {
-    endpoint: String,
-    client: Client,
+    inner: dirt_core::sync::TursoSyncAuthClient,
 }
 
 impl TursoSyncAuthClient {
-    /// Creates a client from desktop bootstrap configuration.
-    pub fn new_from_bootstrap(config: &DesktopBootstrapConfig) -> SyncAuthResult<Option<Self>> {
+    pub fn new_from_bootstrap(
+        config: &DesktopBootstrapConfig,
+    ) -> Result<Option<Self>, SyncAuthError> {
         let Some(endpoint) = config.turso_sync_token_endpoint.clone() else {
             return Ok(None);
         };
         Ok(Some(Self::new(endpoint)?))
     }
 
-    /// Creates a client with explicit endpoint URL.
-    pub fn new(endpoint: impl Into<String>) -> SyncAuthResult<Self> {
-        let endpoint = normalize_endpoint(endpoint.into())?;
+    pub fn new(endpoint: impl Into<String>) -> Result<Self, SyncAuthError> {
+        let endpoint = normalize_text_option(Some(endpoint.into())).ok_or_else(|| {
+            SyncAuthError::InvalidConfiguration("endpoint must not be empty".to_string())
+        })?;
         Ok(Self {
-            endpoint,
-            client: Client::new(),
+            inner: dirt_core::sync::TursoSyncAuthClient::new(endpoint)?,
         })
     }
 
-    /// Exchanges Supabase access token for short-lived Turso credentials.
-    pub async fn exchange_token(&self, supabase_access_token: &str) -> SyncAuthResult<SyncToken> {
-        let access_token = supabase_access_token.trim();
-        if access_token.is_empty() {
-            return Err(SyncAuthError::InvalidConfiguration(
-                "Supabase access token must not be empty".to_string(),
-            ));
-        }
-
-        let response = self
-            .client
-            .post(&self.endpoint)
-            .bearer_auth(access_token)
-            .header("Accept", "application/json")
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(SyncAuthError::Api(format!(
-                "HTTP {status}: {}",
-                compact_body(&body)
-            )));
-        }
-
-        let payload = response.json::<SyncTokenResponse>().await?;
-        payload.try_into()
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct SyncTokenResponse {
-    auth_token: Option<String>,
-    token: Option<String>,
-    expires_at: Option<i64>,
-    database_url: Option<String>,
-}
-
-impl TryFrom<SyncTokenResponse> for SyncToken {
-    type Error = SyncAuthError;
-
-    fn try_from(value: SyncTokenResponse) -> SyncAuthResult<Self> {
-        let token = value
-            .auth_token
-            .or(value.token)
-            .map(|token| token.trim().to_string())
-            .filter(|token| !token.is_empty())
-            .ok_or_else(|| {
-                SyncAuthError::InvalidPayload(
-                    "response did not include auth_token/token".to_string(),
-                )
-            })?;
-
-        let expires_at = value.expires_at.ok_or_else(|| {
-            SyncAuthError::InvalidPayload("response did not include expires_at".to_string())
-        })?;
-
-        let database_url = normalize_text_option(value.database_url).ok_or_else(|| {
+    pub async fn exchange_token(
+        &self,
+        supabase_access_token: &str,
+    ) -> Result<SyncToken, SyncAuthError> {
+        let token = self.inner.exchange_token(supabase_access_token).await?;
+        let database_url = normalize_text_option(token.database_url).ok_or_else(|| {
             SyncAuthError::InvalidPayload("response did not include database_url".to_string())
         })?;
 
-        Ok(Self {
-            token,
-            expires_at,
+        Ok(SyncToken {
+            token: token.token,
+            expires_at: token.expires_at,
             database_url,
         })
     }
 }
 
-fn normalize_endpoint(raw: String) -> SyncAuthResult<String> {
-    let normalized = normalize_text_option(Some(raw)).ok_or_else(|| {
-        SyncAuthError::InvalidConfiguration("endpoint must not be empty".to_string())
-    })?;
-    if normalized.starts_with("http://") || normalized.starts_with("https://") {
-        Ok(normalized.trim_end_matches('/').to_string())
-    } else {
-        Err(SyncAuthError::InvalidConfiguration(
-            "endpoint must include http:// or https://".to_string(),
-        ))
-    }
-}
-
-fn compact_body(body: &str) -> String {
-    body.trim().chars().take(180).collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn normalize_endpoint_rejects_invalid_values() {
-        assert!(normalize_endpoint(String::new()).is_err());
-        assert!(normalize_endpoint("api.example.com".to_string()).is_err());
-    }
 
     #[test]
     fn sync_token_debug_redacts_token() {

--- a/crates/dirt-mobile/android/res/xml/network_security_config.xml
+++ b/crates/dirt-mobile/android/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Dev emulator access to host machine backend -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">10.0.3.2</domain>
+        <domain includeSubdomains="true">127.0.0.1</domain>
+        <domain includeSubdomains="true">localhost</domain>
+    </domain-config>
+</network-security-config>

--- a/crates/dirt-mobile/src/auth.rs
+++ b/crates/dirt-mobile/src/auth.rs
@@ -1,506 +1,105 @@
-//! Supabase authentication service for mobile.
+//! Supabase authentication service with secure session storage for mobile.
 #![cfg_attr(not(target_os = "android"), allow(dead_code))]
-
-use std::fmt;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use reqwest::{Client, RequestBuilder, StatusCode};
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
 
 use crate::bootstrap_config::MobileBootstrapConfig;
 use crate::secret_store;
 
-const EXPIRY_SKEW_SECONDS: i64 = 60;
-
-/// Authenticated user metadata.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AuthUser {
-    /// Provider user id.
-    pub id: String,
-    /// Optional user email.
-    pub email: Option<String>,
-}
-
-/// Persisted auth session used for API authorization.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AuthSession {
-    /// Short-lived access token.
-    pub access_token: String,
-    /// Refresh token for obtaining new access tokens.
-    pub refresh_token: String,
-    /// Unix timestamp (seconds) when access token expires.
-    pub expires_at: i64,
-    /// Authenticated user profile.
-    pub user: AuthUser,
-}
-
-impl AuthSession {
-    /// Return whether the access token should be treated as expired.
-    #[must_use]
-    pub fn is_expired(&self) -> bool {
-        self.is_expired_at(unix_timestamp_now())
-    }
-
-    #[must_use]
-    const fn is_expired_at(&self, now_secs: i64) -> bool {
-        self.expires_at <= now_secs + EXPIRY_SKEW_SECONDS
-    }
-}
-
-impl fmt::Debug for AuthSession {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("AuthSession")
-            .field("access_token", &"[REDACTED]")
-            .field("refresh_token", &"[REDACTED]")
-            .field("expires_at", &self.expires_at)
-            .field("user", &self.user)
-            .finish()
-    }
-}
-
-/// Sign-up result from provider.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SignUpOutcome {
-    /// Account created and session started immediately.
-    SignedIn(AuthSession),
-    /// Account created but provider requires email confirmation.
-    ConfirmationRequired,
-}
-
-/// Auth configuration status returned from Supabase settings endpoint.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(clippy::struct_excessive_bools)]
-pub struct AuthConfigStatus {
-    /// Whether email auth provider is enabled.
-    pub email_enabled: bool,
-    /// Whether sign-ups are allowed.
-    pub signup_enabled: bool,
-    /// Whether sign-ups are auto-confirmed without email delivery.
-    pub mailer_autoconfirm: bool,
-    /// Whether custom SMTP credentials are configured.
-    pub smtp_configured: bool,
-    /// Current Supabase email send rate limit (requests/hour).
-    pub rate_limit_email_sent: Option<i64>,
-}
-
-/// Errors from authentication and secure storage flows.
-#[derive(Debug, Error)]
-pub enum AuthError {
-    #[error(
-        "Supabase auth is not configured. Provide SUPABASE_URL and SUPABASE_ANON_KEY at build time."
-    )]
-    NotConfigured,
-    #[error("Invalid auth configuration: {0}")]
-    InvalidConfiguration(&'static str),
-    #[error("HTTP request failed: {0}")]
-    Http(#[from] reqwest::Error),
-    #[error("Failed to parse JSON payload: {0}")]
-    Json(#[from] serde_json::Error),
-    #[error("Auth API error: {0}")]
-    Api(String),
-    #[error("Secure storage error: {0}")]
-    SecureStorage(String),
-}
-
-type AuthResult<T> = Result<T, AuthError>;
+use dirt_core::auth::{
+    resolve_optional_supabase_config, AuthResult, SessionPersistence, SupabaseAuthClient,
+};
+#[allow(unused_imports)]
+pub use dirt_core::auth::{AuthConfigStatus, AuthError, AuthSession, AuthUser, SignUpOutcome};
 
 #[derive(Debug, Clone, Copy, Default)]
 struct SessionStore;
 
-impl SessionStore {
-    fn load_session() -> AuthResult<Option<AuthSession>> {
+impl SessionPersistence for SessionStore {
+    fn load_session(&self) -> AuthResult<Option<AuthSession>> {
         match secret_store::read_secret(secret_store::SECRET_SUPABASE_SESSION) {
-            Ok(Some(raw)) => Ok(Some(serde_json::from_str(&raw)?)),
+            Ok(Some(value)) => Ok(Some(serde_json::from_str(&value)?)),
             Ok(None) => Ok(None),
             Err(error) => Err(AuthError::SecureStorage(error)),
         }
     }
 
-    fn save_session(session: &AuthSession) -> AuthResult<()> {
+    fn save_session(&self, session: &AuthSession) -> AuthResult<()> {
         let serialized = serde_json::to_string(session)?;
         secret_store::write_secret(secret_store::SECRET_SUPABASE_SESSION, &serialized)
             .map_err(AuthError::SecureStorage)
     }
 
-    fn clear_session() -> AuthResult<()> {
+    fn clear_session(&self) -> AuthResult<()> {
         secret_store::delete_secret(secret_store::SECRET_SUPABASE_SESSION)
             .map_err(AuthError::SecureStorage)
     }
 }
 
-/// Supabase auth API client for mobile settings flows.
 #[derive(Clone)]
 pub struct SupabaseAuthService {
-    auth_url: String,
-    anon_key: String,
-    client: Client,
+    inner: SupabaseAuthClient<SessionStore>,
 }
 
 impl SupabaseAuthService {
-    /// Create a service from build-time bootstrap config values.
     pub fn new_from_bootstrap(config: &MobileBootstrapConfig) -> AuthResult<Option<Self>> {
-        Self::new_from_sources(
+        let Some((url, anon_key)) = resolve_optional_supabase_config(
             config.supabase_url.clone(),
             config.supabase_anon_key.clone(),
-        )
-    }
-
-    /// Create a service from `SUPABASE_URL` and `SUPABASE_ANON_KEY`.
-    pub fn new_from_env() -> AuthResult<Option<Self>> {
-        Self::new_from_sources(
-            std::env::var("SUPABASE_URL").ok(),
-            std::env::var("SUPABASE_ANON_KEY").ok(),
-        )
-    }
-
-    fn new_from_sources(url: Option<String>, anon_key: Option<String>) -> AuthResult<Option<Self>> {
-        match (url, anon_key) {
-            (None, None) => Ok(None),
-            (Some(url), Some(anon_key)) => Ok(Some(Self::new(url, anon_key)?)),
-            _ => Err(AuthError::NotConfigured),
-        }
-    }
-
-    /// Create a service with explicit Supabase project URL and anon key.
-    pub fn new(url: impl AsRef<str>, anon_key: impl Into<String>) -> AuthResult<Self> {
-        let auth_url = normalize_auth_url(url.as_ref())?;
-        let anon_key = anon_key.into().trim().to_string();
-        if anon_key.is_empty() {
-            return Err(AuthError::InvalidConfiguration(
-                "SUPABASE_ANON_KEY must not be empty",
-            ));
-        }
-
-        let client = Client::builder().build()?;
-
-        Ok(Self {
-            auth_url,
-            anon_key,
-            client,
-        })
-    }
-
-    /// Restore session from secure storage. If expired, refresh automatically.
-    pub async fn restore_session(&self) -> AuthResult<Option<AuthSession>> {
-        let Some(stored_session) = SessionStore::load_session()? else {
+        )?
+        else {
             return Ok(None);
         };
 
-        if !stored_session.is_expired() {
-            return Ok(Some(stored_session));
-        }
-
-        match self.refresh_session(&stored_session.refresh_token).await {
-            Ok(refreshed) => {
-                SessionStore::save_session(&refreshed)?;
-                Ok(Some(refreshed))
-            }
-            Err(error) => {
-                tracing::warn!("Failed to refresh persisted session: {}", error);
-                SessionStore::clear_session()?;
-                Ok(None)
-            }
-        }
+        Ok(Some(Self::new(url, anon_key)?))
     }
 
-    /// Sign up a user by email/password.
+    pub fn new_from_env() -> AuthResult<Option<Self>> {
+        let Some((url, anon_key)) = resolve_optional_supabase_config(
+            std::env::var("SUPABASE_URL").ok(),
+            std::env::var("SUPABASE_ANON_KEY").ok(),
+        )?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(Self::new(url, anon_key)?))
+    }
+
+    pub fn new(url: impl AsRef<str>, anon_key: impl Into<String>) -> AuthResult<Self> {
+        Ok(Self {
+            inner: SupabaseAuthClient::new(url, anon_key, SessionStore)?,
+        })
+    }
+
+    pub async fn restore_session(&self) -> AuthResult<Option<AuthSession>> {
+        self.inner.restore_session().await
+    }
+
     pub async fn sign_up(&self, email: &str, password: &str) -> AuthResult<SignUpOutcome> {
-        validate_credentials(email, password)?;
-
-        let payload = serde_json::json!({
-            "email": email,
-            "password": password,
-        });
-        let request = self.public_request(
-            self.client
-                .post(format!("{}/signup", self.auth_url))
-                .json(&payload),
-        );
-        let response = self.send_auth_request(request).await?;
-        match response.into_session()? {
-            Some(session) => {
-                SessionStore::save_session(&session)?;
-                Ok(SignUpOutcome::SignedIn(session))
-            }
-            None => Ok(SignUpOutcome::ConfirmationRequired),
-        }
+        self.inner.sign_up(email, password).await
     }
 
-    /// Sign in an existing user by email/password.
     pub async fn sign_in(&self, email: &str, password: &str) -> AuthResult<AuthSession> {
-        validate_credentials(email, password)?;
-
-        let payload = serde_json::json!({
-            "email": email,
-            "password": password,
-        });
-        let request = self.public_request(
-            self.client
-                .post(format!("{}/token", self.auth_url))
-                .query(&[("grant_type", "password")])
-                .json(&payload),
-        );
-        let response = self.send_auth_request(request).await?;
-        let session = response.into_session()?.ok_or_else(|| {
-            AuthError::Api("Sign-in response did not include an active session".to_string())
-        })?;
-        SessionStore::save_session(&session)?;
-        Ok(session)
+        self.inner.sign_in(email, password).await
     }
 
-    /// Refresh an access token using the refresh token.
     pub async fn refresh_session(&self, refresh_token: &str) -> AuthResult<AuthSession> {
-        if refresh_token.trim().is_empty() {
-            return Err(AuthError::InvalidConfiguration(
-                "Refresh token must not be empty",
-            ));
-        }
-
-        let payload = serde_json::json!({
-            "refresh_token": refresh_token,
-        });
-        let request = self.public_request(
-            self.client
-                .post(format!("{}/token", self.auth_url))
-                .query(&[("grant_type", "refresh_token")])
-                .json(&payload),
-        );
-        let response = self.send_auth_request(request).await?;
-        let session = response.into_session()?.ok_or_else(|| {
-            AuthError::Api("Refresh response did not include an active session".to_string())
-        })?;
-        SessionStore::save_session(&session)?;
-        Ok(session)
+        self.inner.refresh_session(refresh_token).await
     }
 
-    /// Sign out and clear local session storage.
     pub async fn sign_out(&self, access_token: &str) -> AuthResult<()> {
-        let server_logout = async {
-            let request = self
-                .client
-                .post(format!("{}/logout", self.auth_url))
-                .header("apikey", &self.anon_key)
-                .bearer_auth(access_token);
-            let response = request.send().await?;
-            if response.status().is_success() || response.status() == StatusCode::UNAUTHORIZED {
-                Ok(())
-            } else {
-                let status = response.status();
-                let body = response.text().await.unwrap_or_default();
-                Err(AuthError::Api(parse_api_error(status, &body)))
-            }
-        }
-        .await;
-
-        SessionStore::clear_session()?;
-
-        if let Err(error) = server_logout {
-            tracing::warn!(
-                "Server logout failed after clearing local session: {}",
-                error
-            );
-        }
-
-        Ok(())
+        self.inner.sign_out(access_token).await
     }
 
-    /// Verify Supabase auth configuration and return a summary for UI diagnostics.
     pub async fn verify_configuration(&self) -> AuthResult<AuthConfigStatus> {
-        let request = self.public_request(self.client.get(format!("{}/settings", self.auth_url)));
-        let response = request.send().await?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AuthError::Api(parse_api_error(status, &body)));
-        }
-
-        let payload = response.json::<SupabaseAuthSettings>().await?;
-        Ok(AuthConfigStatus {
-            email_enabled: payload.external.email,
-            signup_enabled: !payload.disable_signup,
-            mailer_autoconfirm: payload.mailer_autoconfirm,
-            smtp_configured: payload.smtp_host.is_some(),
-            rate_limit_email_sent: payload.rate_limit_email_sent,
-        })
+        self.inner.verify_configuration().await
     }
-
-    fn public_request(&self, request: RequestBuilder) -> RequestBuilder {
-        request
-            .header("apikey", &self.anon_key)
-            .header("Authorization", format!("Bearer {}", self.anon_key))
-    }
-
-    async fn send_auth_request(&self, request: RequestBuilder) -> AuthResult<SupabaseAuthResponse> {
-        let response = request.send().await?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AuthError::Api(parse_api_error(status, &body)));
-        }
-
-        Ok(response.json::<SupabaseAuthResponse>().await?)
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseAuthResponse {
-    access_token: Option<String>,
-    refresh_token: Option<String>,
-    expires_at: Option<i64>,
-    expires_in: Option<i64>,
-    user: Option<SupabaseUser>,
-    session: Option<SupabaseAuthResponseSession>,
-}
-
-impl SupabaseAuthResponse {
-    fn into_session(self) -> AuthResult<Option<AuthSession>> {
-        let session = self.session;
-        let access_token = self
-            .access_token
-            .or_else(|| session.as_ref().and_then(|s| s.access_token.clone()));
-        let refresh_token = self
-            .refresh_token
-            .or_else(|| session.as_ref().and_then(|s| s.refresh_token.clone()));
-        let expires_at = self
-            .expires_at
-            .or_else(|| session.as_ref().and_then(|s| s.expires_at))
-            .or_else(|| {
-                self.expires_in
-                    .or_else(|| session.as_ref().and_then(|s| s.expires_in))
-                    .map(|expires_in| unix_timestamp_now().saturating_add(expires_in))
-            });
-        let user = self
-            .user
-            .or_else(|| session.and_then(|s| s.user))
-            .map(Into::into);
-
-        match (access_token, refresh_token, expires_at, user) {
-            (Some(access_token), Some(refresh_token), Some(expires_at), Some(user)) => {
-                Ok(Some(AuthSession {
-                    access_token,
-                    refresh_token,
-                    expires_at,
-                    user,
-                }))
-            }
-            (None, None, None, Some(_)) => Ok(None),
-            _ => Err(AuthError::Api(
-                "Auth response did not include enough session fields".to_string(),
-            )),
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseAuthResponseSession {
-    access_token: Option<String>,
-    refresh_token: Option<String>,
-    expires_at: Option<i64>,
-    expires_in: Option<i64>,
-    user: Option<SupabaseUser>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseUser {
-    id: String,
-    email: Option<String>,
-}
-
-impl From<SupabaseUser> for AuthUser {
-    fn from(value: SupabaseUser) -> Self {
-        Self {
-            id: value.id,
-            email: value.email,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseErrorResponse {
-    error: Option<String>,
-    error_description: Option<String>,
-    message: Option<String>,
-    msg: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseAuthSettings {
-    external: SupabaseExternalSettings,
-    disable_signup: bool,
-    mailer_autoconfirm: bool,
-    smtp_host: Option<String>,
-    rate_limit_email_sent: Option<i64>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseExternalSettings {
-    email: bool,
-}
-
-fn parse_api_error(status: StatusCode, body: &str) -> String {
-    if let Ok(payload) = serde_json::from_str::<SupabaseErrorResponse>(body) {
-        if let Some(message) = payload
-            .message
-            .or(payload.msg)
-            .or(payload.error_description)
-            .or(payload.error)
-        {
-            return format!("{} ({})", message.trim(), status.as_u16());
-        }
-    }
-
-    let trimmed = body.trim();
-    if trimmed.is_empty() {
-        format!("HTTP {}", status.as_u16())
-    } else {
-        format!("{} ({})", trimmed, status.as_u16())
-    }
-}
-
-fn normalize_auth_url(url: &str) -> AuthResult<String> {
-    let trimmed = url.trim().trim_end_matches('/');
-    if trimmed.is_empty() {
-        return Err(AuthError::InvalidConfiguration(
-            "SUPABASE_URL must not be empty",
-        ));
-    }
-    if !(trimmed.starts_with("https://") || trimmed.starts_with("http://")) {
-        return Err(AuthError::InvalidConfiguration(
-            "SUPABASE_URL must include http:// or https://",
-        ));
-    }
-
-    if trimmed.ends_with("/auth/v1") {
-        Ok(trimmed.to_string())
-    } else {
-        Ok(format!("{trimmed}/auth/v1"))
-    }
-}
-
-fn validate_credentials(email: &str, password: &str) -> AuthResult<()> {
-    if email.trim().is_empty() {
-        return Err(AuthError::Api("Email is required".to_string()));
-    }
-    if password.trim().is_empty() {
-        return Err(AuthError::Api("Password is required".to_string()));
-    }
-    Ok(())
-}
-
-fn unix_timestamp_now() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| {
-            i64::try_from(duration.as_secs()).unwrap_or(i64::MAX)
-        })
 }
 
 #[cfg(test)]
 mod tests {
+    use dirt_core::auth::normalize_auth_url;
+
     use super::*;
-    use crate::bootstrap_config::MobileBootstrapConfig;
 
     #[test]
     fn normalize_auth_url_appends_auth_path() {
@@ -520,23 +119,5 @@ mod tests {
         assert!(SupabaseAuthService::new_from_bootstrap(&config)
             .unwrap()
             .is_none());
-    }
-
-    #[test]
-    fn response_without_session_fields_means_confirmation_required() {
-        let response = SupabaseAuthResponse {
-            access_token: None,
-            refresh_token: None,
-            expires_at: None,
-            expires_in: None,
-            user: Some(SupabaseUser {
-                id: "user-id".to_string(),
-                email: Some("test@example.com".to_string()),
-            }),
-            session: None,
-        };
-
-        let session = response.into_session().unwrap();
-        assert!(session.is_none());
     }
 }

--- a/crates/dirt-mobile/src/bootstrap_config.rs
+++ b/crates/dirt-mobile/src/bootstrap_config.rs
@@ -1,57 +1,14 @@
 //! Mobile bootstrap configuration loaded from build-time generated JSON.
 #![cfg_attr(not(target_os = "android"), allow(dead_code))]
 
-use std::time::Duration;
+pub use dirt_core::config::normalize_text_option;
+use dirt_core::config::{
+    resolve_bootstrap_config as resolve_core_bootstrap_config, BootstrapConfig,
+};
 
-use serde::{Deserialize, Serialize};
-
-const BOOTSTRAP_SCHEMA_VERSION: u32 = 1;
-const BOOTSTRAP_HTTP_TIMEOUT_SECS: u64 = 4;
-
-/// Build-provisioned client configuration embedded into mobile binaries.
-///
-/// These values are safe-to-ship public endpoints/keys required to bootstrap
-/// auth and managed sync flows. Secret credentials must never be stored here.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct MobileBootstrapConfig {
-    #[serde(default)]
-    pub bootstrap_manifest_url: Option<String>,
-    #[serde(default)]
-    pub supabase_url: Option<String>,
-    #[serde(default)]
-    pub supabase_anon_key: Option<String>,
-    #[serde(default)]
-    pub turso_sync_token_endpoint: Option<String>,
-    /// Optional managed API base URL used for media presign operations.
-    #[serde(default)]
-    pub dirt_api_base_url: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct ManagedBootstrapManifest {
-    schema_version: u32,
-    manifest_version: String,
-    supabase_url: String,
-    supabase_anon_key: String,
-    api_base_url: String,
-    #[serde(default)]
-    turso_sync_token_endpoint: Option<String>,
-    feature_flags: ManagedFeatureFlags,
-}
-
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct ManagedFeatureFlags {
-    managed_sync: bool,
-    managed_media: bool,
-}
+pub type MobileBootstrapConfig = BootstrapConfig;
 
 /// Loads the generated mobile bootstrap JSON from `OUT_DIR`.
-///
-/// If parsing fails, this logs a warning and returns a default empty config so
-/// the app can continue running in local-only mode.
 pub fn load_bootstrap_config() -> MobileBootstrapConfig {
     let raw = include_str!(concat!(env!("OUT_DIR"), "/mobile-bootstrap.json"));
     serde_json::from_str(raw).unwrap_or_else(|error| {
@@ -60,160 +17,9 @@ pub fn load_bootstrap_config() -> MobileBootstrapConfig {
     })
 }
 
-/// Resolve runtime bootstrap config.
-///
-/// Attempts to fetch managed bootstrap manifest from `bootstrap_manifest_url`.
-/// When fetching/parsing/validation fails, this safely falls back to the
-/// embedded build-time config.
+/// Resolve runtime bootstrap config with managed manifest fallback.
 pub async fn resolve_bootstrap_config(fallback: MobileBootstrapConfig) -> MobileBootstrapConfig {
-    let Some(manifest_url) = normalize_text_option(fallback.bootstrap_manifest_url.clone()) else {
-        return fallback;
-    };
-
-    match fetch_bootstrap_manifest(&manifest_url).await {
-        Ok(config) => config,
-        Err(error) => {
-            tracing::warn!(
-                "Failed to resolve runtime mobile bootstrap from {}: {}. Falling back to embedded config.",
-                manifest_url,
-                error
-            );
-            fallback
-        }
-    }
-}
-
-/// Normalizes optional text config by trimming whitespace and removing empties.
-///
-/// Returns `None` when the input is `None` or the trimmed value is empty.
-pub fn normalize_text_option(value: Option<String>) -> Option<String> {
-    let value = value?;
-    let value = value.trim();
-    if value.is_empty() {
-        None
-    } else {
-        Some(value.to_string())
-    }
-}
-
-impl MobileBootstrapConfig {
-    /// Returns the managed API base URL for authenticated media operations.
-    ///
-    /// Prefers `dirt_api_base_url` when present; otherwise derives the base URL
-    /// from `turso_sync_token_endpoint` by stripping `/v1/sync/token`.
-    pub fn managed_api_base_url(&self) -> Option<String> {
-        if let Some(url) = normalize_text_option(self.dirt_api_base_url.clone()) {
-            return Some(url);
-        }
-
-        let endpoint = normalize_text_option(self.turso_sync_token_endpoint.clone())?;
-        endpoint
-            .strip_suffix("/v1/sync/token")
-            .map(std::string::ToString::to_string)
-    }
-}
-
-async fn fetch_bootstrap_manifest(url: &str) -> Result<MobileBootstrapConfig, String> {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(BOOTSTRAP_HTTP_TIMEOUT_SECS))
-        .build()
-        .map_err(|error| format!("failed to build bootstrap HTTP client: {error}"))?;
-
-    let response = client
-        .get(url)
-        .header(reqwest::header::ACCEPT, "application/json")
-        .send()
-        .await
-        .map_err(|error| format!("bootstrap request failed: {error}"))?;
-
-    if !response.status().is_success() {
-        let status = response.status().as_u16();
-        let body = response.text().await.unwrap_or_default();
-        return Err(format!(
-            "bootstrap endpoint returned HTTP {status}: {}",
-            compact_text(&body)
-        ));
-    }
-
-    let body = response
-        .text()
-        .await
-        .map_err(|error| format!("failed to read bootstrap response body: {error}"))?;
-    parse_bootstrap_manifest(&body, url)
-}
-
-fn parse_bootstrap_manifest(
-    payload: &str,
-    manifest_url: &str,
-) -> Result<MobileBootstrapConfig, String> {
-    let manifest: ManagedBootstrapManifest = serde_json::from_str(payload)
-        .map_err(|error| format!("invalid bootstrap manifest JSON: {error}"))?;
-    manifest.into_runtime_config(manifest_url)
-}
-
-impl ManagedBootstrapManifest {
-    fn into_runtime_config(self, manifest_url: &str) -> Result<MobileBootstrapConfig, String> {
-        if self.schema_version != BOOTSTRAP_SCHEMA_VERSION {
-            return Err(format!(
-                "unsupported bootstrap schema_version {} (expected {})",
-                self.schema_version, BOOTSTRAP_SCHEMA_VERSION
-            ));
-        }
-        if self.manifest_version.trim().is_empty() {
-            return Err("bootstrap manifest_version must not be empty".to_string());
-        }
-
-        let supabase_url = normalize_required_http_url(self.supabase_url, "supabase_url")?;
-        let supabase_anon_key =
-            normalize_required_value(self.supabase_anon_key, "supabase_anon_key")?;
-        let api_base_url = normalize_required_http_url(self.api_base_url, "api_base_url")?;
-
-        let sync_endpoint = if self.feature_flags.managed_sync {
-            match normalize_text_option(self.turso_sync_token_endpoint) {
-                Some(endpoint) => Some(normalize_required_http_url(
-                    endpoint,
-                    "turso_sync_token_endpoint",
-                )?),
-                None => Some(format!("{api_base_url}/v1/sync/token")),
-            }
-        } else {
-            None
-        };
-
-        let api_base_for_clients =
-            if self.feature_flags.managed_sync || self.feature_flags.managed_media {
-                Some(api_base_url)
-            } else {
-                None
-            };
-
-        Ok(MobileBootstrapConfig {
-            bootstrap_manifest_url: Some(manifest_url.to_string()),
-            supabase_url: Some(supabase_url),
-            supabase_anon_key: Some(supabase_anon_key),
-            turso_sync_token_endpoint: sync_endpoint,
-            dirt_api_base_url: api_base_for_clients,
-        })
-    }
-}
-
-fn normalize_required_value(raw: String, field: &str) -> Result<String, String> {
-    normalize_text_option(Some(raw)).ok_or_else(|| format!("bootstrap field '{field}' is required"))
-}
-
-fn normalize_required_http_url(raw: String, field: &str) -> Result<String, String> {
-    let value = normalize_required_value(raw, field)?;
-    if value.starts_with("http://") || value.starts_with("https://") {
-        Ok(value.trim_end_matches('/').to_string())
-    } else {
-        Err(format!(
-            "bootstrap field '{field}' must include http:// or https://"
-        ))
-    }
-}
-
-fn compact_text(value: &str) -> String {
-    value.trim().chars().take(180).collect()
+    resolve_core_bootstrap_config(fallback).await
 }
 
 #[cfg(test)]
@@ -242,77 +48,6 @@ mod tests {
         };
         assert_eq!(
             config.managed_api_base_url().as_deref(),
-            Some("https://api.example.com")
-        );
-    }
-
-    #[test]
-    fn parse_manifest_rejects_unknown_fields() {
-        let payload = r#"
-        {
-          "schema_version": 1,
-          "manifest_version": "v1",
-          "supabase_url": "https://project.supabase.co",
-          "supabase_anon_key": "anon",
-          "api_base_url": "https://api.example.com",
-          "feature_flags": {
-            "managed_sync": true,
-            "managed_media": true,
-            "unexpected": true
-          }
-        }
-        "#;
-
-        let error =
-            parse_bootstrap_manifest(payload, "https://api.example.com/v1/bootstrap").unwrap_err();
-        assert!(error.contains("unknown field"));
-    }
-
-    #[test]
-    fn parse_manifest_rejects_invalid_schema_version() {
-        let payload = r#"
-        {
-          "schema_version": 2,
-          "manifest_version": "v1",
-          "supabase_url": "https://project.supabase.co",
-          "supabase_anon_key": "anon",
-          "api_base_url": "https://api.example.com",
-          "feature_flags": {
-            "managed_sync": true,
-            "managed_media": true
-          }
-        }
-        "#;
-
-        let error =
-            parse_bootstrap_manifest(payload, "https://api.example.com/v1/bootstrap").unwrap_err();
-        assert!(error.contains("schema_version"));
-    }
-
-    #[test]
-    fn parse_manifest_derives_sync_endpoint_when_missing() {
-        let payload = r#"
-        {
-          "schema_version": 1,
-          "manifest_version": "v2",
-          "supabase_url": "https://project.supabase.co",
-          "supabase_anon_key": "anon",
-          "api_base_url": "https://api.example.com",
-          "feature_flags": {
-            "managed_sync": true,
-            "managed_media": false
-          }
-        }
-        "#;
-
-        let parsed = parse_bootstrap_manifest(payload, "https://api.example.com/v1/bootstrap")
-            .expect("manifest should parse");
-        assert_eq!(
-            parsed.turso_sync_token_endpoint.as_deref(),
-            Some("https://api.example.com/v1/sync/token")
-        );
-        assert_eq!(
-            parsed.dirt_api_base_url.as_deref(),
             Some("https://api.example.com")
         );
     }

--- a/crates/dirt-mobile/src/config.rs
+++ b/crates/dirt-mobile/src/config.rs
@@ -7,6 +7,7 @@ use dirt_core::db::SyncConfig;
 use dirt_core::Result;
 use serde::{Deserialize, Serialize};
 
+use crate::paths::dirt_data_dir;
 use crate::secret_store;
 
 const RUNTIME_CONFIG_FILE: &str = "mobile-config.json";
@@ -56,11 +57,7 @@ impl MobileRuntimeConfig {
 }
 
 pub fn default_runtime_config_path() -> PathBuf {
-    dirs::data_local_dir()
-        .or_else(dirs::data_dir)
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join("dirt")
-        .join(RUNTIME_CONFIG_FILE)
+    dirt_data_dir().join(RUNTIME_CONFIG_FILE)
 }
 
 pub fn load_runtime_config() -> MobileRuntimeConfig {

--- a/crates/dirt-mobile/src/export.rs
+++ b/crates/dirt-mobile/src/export.rs
@@ -8,6 +8,7 @@ use dirt_core::export::{render_json_export, render_markdown_export};
 use thiserror::Error;
 
 use crate::data::MobileNoteStore;
+use crate::paths::dirt_data_dir;
 
 const EXPORT_DIR_NAME: &str = "dirt-exports";
 
@@ -65,7 +66,7 @@ pub fn default_export_directory() -> PathBuf {
     dirs::download_dir()
         .or_else(dirs::document_dir)
         .or_else(dirs::data_local_dir)
-        .unwrap_or_else(|| PathBuf::from("."))
+        .unwrap_or_else(dirt_data_dir)
         .join(EXPORT_DIR_NAME)
 }
 

--- a/crates/dirt-mobile/src/main.rs
+++ b/crates/dirt-mobile/src/main.rs
@@ -23,6 +23,8 @@ mod launch;
 #[cfg(any(target_os = "android", test))]
 mod media_api;
 #[cfg(any(target_os = "android", test))]
+mod paths;
+#[cfg(any(target_os = "android", test))]
 mod secret_store;
 #[cfg(any(target_os = "android", test))]
 mod sync_auth;

--- a/crates/dirt-mobile/src/media_api.rs
+++ b/crates/dirt-mobile/src/media_api.rs
@@ -1,22 +1,14 @@
 //! Backend media signing client for mobile attachment operations.
 #![cfg_attr(not(target_os = "android"), allow(dead_code))]
 
-use reqwest::Method;
-use serde::{Deserialize, Serialize};
-
 use crate::bootstrap_config::MobileBootstrapConfig;
 
-/// HTTP client for managed media operations backed by the Dirt API service.
 #[derive(Debug, Clone)]
 pub struct MediaApiClient {
-    base_url: String,
-    client: reqwest::Client,
+    inner: dirt_core::media::MediaApiClient,
 }
 
 impl MediaApiClient {
-    /// Builds a client from mobile bootstrap configuration.
-    ///
-    /// Returns `Ok(None)` when managed media is not configured.
     pub fn new_from_bootstrap(config: &MobileBootstrapConfig) -> Result<Option<Self>, String> {
         let Some(base_url) = config.managed_api_base_url() else {
             return Ok(None);
@@ -24,21 +16,12 @@ impl MediaApiClient {
         Ok(Some(Self::new(base_url)?))
     }
 
-    /// Builds a client for an explicit API base URL.
     pub fn new(base_url: impl Into<String>) -> Result<Self, String> {
-        let base_url = normalize_base_url(base_url.into().as_str())?;
-        let client = reqwest::Client::builder()
-            .build()
-            .map_err(|error| format!("Failed to construct HTTP client: {error}"))?;
-        Ok(Self { base_url, client })
+        Ok(Self {
+            inner: dirt_core::media::MediaApiClient::new(base_url)?,
+        })
     }
 
-    /// Returns the normalized API base URL used by this client.
-    pub fn base_url(&self) -> &str {
-        &self.base_url
-    }
-
-    /// Uploads attachment bytes using a backend-issued presigned operation.
     pub async fn upload(
         &self,
         access_token: &str,
@@ -46,204 +29,22 @@ impl MediaApiClient {
         content_type: &str,
         bytes: &[u8],
     ) -> Result<(), String> {
-        let operation = self
-            .request_presigned(
-                access_token,
-                "/v1/media/presign/upload",
-                &serde_json::json!({
-                    "object_key": object_key,
-                    "content_type": content_type,
-                }),
-            )
-            .await?;
-
-        let method = parse_method(&operation.method)?;
-        let mut request = self.client.request(method, &operation.url);
-        for (name, value) in operation.headers {
-            if name.eq_ignore_ascii_case("host") {
-                continue;
-            }
-            request = request.header(name, value);
-        }
-        let response = request
-            .body(bytes.to_vec())
-            .send()
+        self.inner
+            .upload(access_token, object_key, content_type, bytes)
             .await
-            .map_err(|error| format!("Upload request failed: {error}"))?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(format!(
-                "Upload request failed with HTTP {status}: {}",
-                compact_body(&body)
-            ));
-        }
-        Ok(())
     }
 
-    /// Downloads attachment bytes using a backend-issued presigned operation.
-    ///
-    /// Returns raw bytes and an optional content type returned by the storage backend.
     pub async fn download(
         &self,
         access_token: &str,
         object_key: &str,
     ) -> Result<(Vec<u8>, Option<String>), String> {
-        let encoded_object_key = urlencoding::encode(object_key);
-        let url = format!(
-            "{}/v1/media/presign/download?object_key={}",
-            self.base_url, encoded_object_key
-        );
-
-        let response = self
-            .client
-            .get(url)
-            .bearer_auth(access_token)
-            .header("Accept", "application/json")
-            .send()
-            .await
-            .map_err(|error| format!("Failed to request download URL: {error}"))?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(format!(
-                "Download URL request failed with HTTP {status}: {}",
-                compact_body(&body)
-            ));
-        }
-        let payload = response
-            .json::<PresignResponse>()
-            .await
-            .map_err(|error| format!("Failed to parse download URL response: {error}"))?;
-
-        let operation = payload.operation;
-        let method = parse_method(&operation.method)?;
-        let mut request = self.client.request(method, &operation.url);
-        for (name, value) in operation.headers {
-            if name.eq_ignore_ascii_case("host") {
-                continue;
-            }
-            request = request.header(name, value);
-        }
-        let response = request
-            .send()
-            .await
-            .map_err(|error| format!("Download request failed: {error}"))?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(format!(
-                "Download request failed with HTTP {status}: {}",
-                compact_body(&body)
-            ));
-        }
-        let content_type = response
-            .headers()
-            .get(reqwest::header::CONTENT_TYPE)
-            .and_then(|value| value.to_str().ok())
-            .map(ToString::to_string);
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|error| format!("Failed to read attachment bytes: {error}"))?;
-        Ok((bytes.to_vec(), content_type))
+        self.inner.download(access_token, object_key).await
     }
 
-    /// Deletes an attachment object using a backend-issued presigned operation.
     pub async fn delete(&self, access_token: &str, object_key: &str) -> Result<(), String> {
-        let operation = self
-            .request_presigned(
-                access_token,
-                "/v1/media/presign/delete",
-                &serde_json::json!({
-                    "object_key": object_key,
-                }),
-            )
-            .await?;
-
-        let method = parse_method(&operation.method)?;
-        let mut request = self.client.request(method, &operation.url);
-        for (name, value) in operation.headers {
-            if name.eq_ignore_ascii_case("host") {
-                continue;
-            }
-            request = request.header(name, value);
-        }
-        let response = request
-            .send()
-            .await
-            .map_err(|error| format!("Delete request failed: {error}"))?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(format!(
-                "Delete request failed with HTTP {status}: {}",
-                compact_body(&body)
-            ));
-        }
-        Ok(())
+        self.inner.delete(access_token, object_key).await
     }
-
-    async fn request_presigned(
-        &self,
-        access_token: &str,
-        route: &str,
-        body: &serde_json::Value,
-    ) -> Result<PresignedOperation, String> {
-        let response = self
-            .client
-            .post(format!("{}{}", self.base_url, route))
-            .bearer_auth(access_token)
-            .header("Accept", "application/json")
-            .json(body)
-            .send()
-            .await
-            .map_err(|error| format!("Failed to request signed URL: {error}"))?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(format!(
-                "Signed URL request failed with HTTP {status}: {}",
-                compact_body(&body)
-            ));
-        }
-        let payload = response
-            .json::<PresignResponse>()
-            .await
-            .map_err(|error| format!("Failed to parse signed URL response: {error}"))?;
-        Ok(payload.operation)
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct PresignResponse {
-    operation: PresignedOperation,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct PresignedOperation {
-    method: String,
-    url: String,
-    headers: Vec<(String, String)>,
-}
-
-fn normalize_base_url(raw: &str) -> Result<String, String> {
-    let base = raw.trim().trim_end_matches('/').to_string();
-    if base.is_empty() {
-        return Err("DIRT_API_BASE_URL must not be empty".to_string());
-    }
-    if !(base.starts_with("https://") || base.starts_with("http://")) {
-        return Err("DIRT_API_BASE_URL must include http:// or https://".to_string());
-    }
-    Ok(base)
-}
-
-fn parse_method(raw: &str) -> Result<Method, String> {
-    Method::from_bytes(raw.as_bytes()).map_err(|error| format!("Unsupported HTTP method: {error}"))
-}
-
-fn compact_body(body: &str) -> String {
-    body.trim().chars().take(180).collect()
 }
 
 #[cfg(test)]
@@ -252,15 +53,15 @@ mod tests {
 
     #[test]
     fn normalize_base_url_rejects_invalid_values() {
-        assert!(normalize_base_url("").is_err());
-        assert!(normalize_base_url("example.com").is_err());
+        let err = MediaApiClient::new("   ").unwrap_err();
+        assert!(err.contains("must not be empty"));
+
+        let err = MediaApiClient::new("api.example.com").unwrap_err();
+        assert!(err.contains("http:// or https://"));
     }
 
     #[test]
     fn normalize_base_url_trims_trailing_slash() {
-        assert_eq!(
-            normalize_base_url("https://api.example.com/").unwrap(),
-            "https://api.example.com"
-        );
+        assert!(MediaApiClient::new("https://api.example.com/").is_ok());
     }
 }

--- a/crates/dirt-mobile/src/paths.rs
+++ b/crates/dirt-mobile/src/paths.rs
@@ -1,0 +1,98 @@
+//! Mobile filesystem path helpers.
+#![cfg_attr(not(target_os = "android"), allow(dead_code))]
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+static DIRT_DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
+
+/// Shared writable app data directory for Dirt mobile.
+#[must_use]
+pub fn dirt_data_dir() -> PathBuf {
+    DIRT_DATA_DIR.get_or_init(resolve_dirt_data_dir).clone()
+}
+
+fn resolve_dirt_data_dir() -> PathBuf {
+    let candidates = dirt_data_dir_candidates();
+    let selected = candidates
+        .first()
+        .cloned()
+        .unwrap_or_else(|| std::env::temp_dir().join("dirt"));
+
+    tracing::info!("Resolved mobile data directory: {}", selected.display());
+    selected
+}
+
+/// Returns all verified writable Dirt data directories in priority order.
+#[must_use]
+pub fn dirt_data_dir_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    for base in candidate_base_dirs() {
+        let candidate = base.join("dirt");
+        if ensure_writable_dir(&candidate) && !candidates.contains(&candidate) {
+            candidates.push(candidate);
+        }
+    }
+
+    candidates
+}
+
+fn candidate_base_dirs() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(path) = std::env::var_os("DIRT_DATA_DIR").map(PathBuf::from) {
+        candidates.push(path);
+    }
+    if let Some(path) = std::env::var_os("TMPDIR").map(PathBuf::from) {
+        candidates.push(path);
+    }
+    if let Some(path) = std::env::var_os("TEMP").map(PathBuf::from) {
+        candidates.push(path);
+    }
+    if let Some(path) = std::env::var_os("TMP").map(PathBuf::from) {
+        candidates.push(path);
+    }
+    if let Some(path) = std::env::var_os("HOME").map(PathBuf::from) {
+        candidates.push(path.clone());
+        candidates.push(path.join(".local").join("share"));
+    }
+    if let Some(path) = dirs::data_local_dir() {
+        candidates.push(path);
+    }
+    if let Some(path) = dirs::data_dir() {
+        candidates.push(path);
+    }
+    if let Some(path) = std::env::var_os("XDG_DATA_HOME").map(PathBuf::from) {
+        candidates.push(path);
+    }
+    candidates.push(std::env::temp_dir());
+    if let Ok(path) = std::env::current_dir() {
+        candidates.push(path);
+    }
+    candidates
+}
+
+fn ensure_writable_dir(path: &PathBuf) -> bool {
+    if std::fs::create_dir_all(path).is_err() {
+        return false;
+    }
+
+    let test_file = path.join(".dirt-write-test");
+    let Ok(mut file) = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&test_file)
+    else {
+        return false;
+    };
+
+    if file.write_all(b"ok").is_err() {
+        let _ = std::fs::remove_file(&test_file);
+        return false;
+    }
+
+    let _ = std::fs::remove_file(test_file);
+    true
+}


### PR DESCRIPTION
## Summary
- move duplicated auth/sync/media/bootstrap config logic into dirt-core
- add shared dirt_core::services::database::DatabaseService wrapper
- convert desktop/mobile/cli service modules to thin wrappers over dirt-core
- keep platform-specific session persistence and runtime path behavior in client crates
- keep local-only mobile mode non-blocking for managed token refresh

## Validation
- cargo check -p dirt-core
- cargo check -p dirt-desktop
- cargo check -p dirt-mobile
- cargo check -p dirt-cli
- cargo test -p dirt-core
- cargo test -p dirt-desktop
- cargo test -p dirt-mobile
- cargo test -p dirt-cli
- cargo clippy -p dirt-core --all-targets --all-features -- -D warnings
- cargo clippy -p dirt-desktop --all-targets --all-features -- -D warnings
- cargo clippy -p dirt-mobile --all-targets --all-features -- -D warnings
- cargo clippy -p dirt-cli --all-targets --all-features -- -D warnings

Closes #183