### PR TITLE
Migrate mobile service copies to dirt-core wrappers (phase 3)

### DIFF
--- a/crates/dirt-mobile/src/auth.rs
+++ b/crates/dirt-mobile/src/auth.rs
@@ -1,116 +1,19 @@
 //! Supabase authentication service for mobile.
 #![cfg_attr(not(target_os = "android"), allow(dead_code))]
 
-use std::fmt;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use reqwest::{Client, RequestBuilder, StatusCode};
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
+pub use dirt_core::auth::{
+    AuthConfigStatus, AuthError, AuthResult, AuthSession, AuthUser, SignUpOutcome,
+};
+use dirt_core::auth::{SessionPersistence, SupabaseAuthService as CoreSupabaseAuthService};
 
 use crate::bootstrap_config::MobileBootstrapConfig;
 use crate::secret_store;
 
-const EXPIRY_SKEW_SECONDS: i64 = 60;
-
-/// Authenticated user metadata.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AuthUser {
-    /// Provider user id.
-    pub id: String,
-    /// Optional user email.
-    pub email: Option<String>,
-}
-
-/// Persisted auth session used for API authorization.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AuthSession {
-    /// Short-lived access token.
-    pub access_token: String,
-    /// Refresh token for obtaining new access tokens.
-    pub refresh_token: String,
-    /// Unix timestamp (seconds) when access token expires.
-    pub expires_at: i64,
-    /// Authenticated user profile.
-    pub user: AuthUser,
-}
-
-impl AuthSession {
-    /// Return whether the access token should be treated as expired.
-    #[must_use]
-    pub fn is_expired(&self) -> bool {
-        self.is_expired_at(unix_timestamp_now())
-    }
-
-    #[must_use]
-    const fn is_expired_at(&self, now_secs: i64) -> bool {
-        self.expires_at <= now_secs + EXPIRY_SKEW_SECONDS
-    }
-}
-
-impl fmt::Debug for AuthSession {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("AuthSession")
-            .field("access_token", &"[REDACTED]")
-            .field("refresh_token", &"[REDACTED]")
-            .field("expires_at", &self.expires_at)
-            .field("user", &self.user)
-            .finish()
-    }
-}
-
-/// Sign-up result from provider.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SignUpOutcome {
-    /// Account created and session started immediately.
-    SignedIn(AuthSession),
-    /// Account created but provider requires email confirmation.
-    ConfirmationRequired,
-}
-
-/// Auth configuration status returned from Supabase settings endpoint.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(clippy::struct_excessive_bools)]
-pub struct AuthConfigStatus {
-    /// Whether email auth provider is enabled.
-    pub email_enabled: bool,
-    /// Whether sign-ups are allowed.
-    pub signup_enabled: bool,
-    /// Whether sign-ups are auto-confirmed without email delivery.
-    pub mailer_autoconfirm: bool,
-    /// Whether custom SMTP credentials are configured.
-    pub smtp_configured: bool,
-    /// Current Supabase email send rate limit (requests/hour).
-    pub rate_limit_email_sent: Option<i64>,
-}
-
-/// Errors from authentication and secure storage flows.
-#[derive(Debug, Error)]
-pub enum AuthError {
-    #[error(
-        "Supabase auth is not configured. Provide SUPABASE_URL and SUPABASE_ANON_KEY at build time."
-    )]
-    NotConfigured,
-    #[error("Invalid auth configuration: {0}")]
-    InvalidConfiguration(&'static str),
-    #[error("HTTP request failed: {0}")]
-    Http(#[from] reqwest::Error),
-    #[error("Failed to parse JSON payload: {0}")]
-    Json(#[from] serde_json::Error),
-    #[error("Auth API error: {0}")]
-    Api(String),
-    #[error("Secure storage error: {0}")]
-    SecureStorage(String),
-}
-
-type AuthResult<T> = Result<T, AuthError>;
-
 #[derive(Debug, Clone, Copy, Default)]
 struct SessionStore;
 
-impl SessionStore {
-    fn load_session() -> AuthResult<Option<AuthSession>> {
+impl SessionPersistence for SessionStore {
+    fn load(&self) -> AuthResult<Option<AuthSession>> {
         match secret_store::read_secret(secret_store::SECRET_SUPABASE_SESSION) {
             Ok(Some(raw)) => Ok(Some(serde_json::from_str(&raw)?)),
             Ok(None) => Ok(None),
@@ -118,24 +21,21 @@ impl SessionStore {
         }
     }
 
-    fn save_session(session: &AuthSession) -> AuthResult<()> {
+    fn save(&self, session: &AuthSession) -> AuthResult<()> {
         let serialized = serde_json::to_string(session)?;
         secret_store::write_secret(secret_store::SECRET_SUPABASE_SESSION, &serialized)
             .map_err(AuthError::SecureStorage)
     }
 
-    fn clear_session() -> AuthResult<()> {
+    fn clear(&self) -> AuthResult<()> {
         secret_store::delete_secret(secret_store::SECRET_SUPABASE_SESSION)
             .map_err(AuthError::SecureStorage)
     }
 }
 
 /// Supabase auth API client for mobile settings flows.
-#[derive(Clone)]
 pub struct SupabaseAuthService {
-    auth_url: String,
-    anon_key: String,
-    client: Client,
+    inner: CoreSupabaseAuthService<SessionStore>,
 }
 
 impl SupabaseAuthService {
@@ -157,354 +57,45 @@ impl SupabaseAuthService {
 
     /// Create a service with explicit Supabase project URL and anon key.
     pub fn new(url: impl AsRef<str>, anon_key: impl Into<String>) -> AuthResult<Self> {
-        let auth_url = normalize_auth_url(url.as_ref())?;
-        let anon_key = anon_key.into().trim().to_string();
-        if anon_key.is_empty() {
-            return Err(AuthError::InvalidConfiguration(
-                "SUPABASE_ANON_KEY must not be empty",
-            ));
-        }
-
-        let client = Client::builder().build()?;
-
-        Ok(Self {
-            auth_url,
-            anon_key,
-            client,
-        })
+        let inner = CoreSupabaseAuthService::with_session_store(url, anon_key, SessionStore)?;
+        Ok(Self { inner })
     }
 
     /// Restore session from secure storage. If expired, refresh automatically.
     pub async fn restore_session(&self) -> AuthResult<Option<AuthSession>> {
-        let Some(stored_session) = SessionStore::load_session()? else {
-            return Ok(None);
-        };
-
-        if !stored_session.is_expired() {
-            return Ok(Some(stored_session));
-        }
-
-        match self.refresh_session(&stored_session.refresh_token).await {
-            Ok(refreshed) => {
-                SessionStore::save_session(&refreshed)?;
-                Ok(Some(refreshed))
-            }
-            Err(error) => {
-                tracing::warn!("Failed to refresh persisted session: {}", error);
-                SessionStore::clear_session()?;
-                Ok(None)
-            }
-        }
+        self.inner.restore_session().await
     }
 
     /// Sign up a user by email/password.
     pub async fn sign_up(&self, email: &str, password: &str) -> AuthResult<SignUpOutcome> {
-        validate_credentials(email, password)?;
-
-        let payload = serde_json::json!({
-            "email": email,
-            "password": password,
-        });
-        let request = self.public_request(
-            self.client
-                .post(format!("{}/signup", self.auth_url))
-                .json(&payload),
-        );
-        let response = self.send_auth_request(request).await?;
-        match response.into_session()? {
-            Some(session) => {
-                SessionStore::save_session(&session)?;
-                Ok(SignUpOutcome::SignedIn(session))
-            }
-            None => Ok(SignUpOutcome::ConfirmationRequired),
-        }
+        self.inner.sign_up(email, password).await
     }
 
     /// Sign in an existing user by email/password.
     pub async fn sign_in(&self, email: &str, password: &str) -> AuthResult<AuthSession> {
-        validate_credentials(email, password)?;
-
-        let payload = serde_json::json!({
-            "email": email,
-            "password": password,
-        });
-        let request = self.public_request(
-            self.client
-                .post(format!("{}/token", self.auth_url))
-                .query(&[("grant_type", "password")])
-                .json(&payload),
-        );
-        let response = self.send_auth_request(request).await?;
-        let session = response.into_session()?.ok_or_else(|| {
-            AuthError::Api("Sign-in response did not include an active session".to_string())
-        })?;
-        SessionStore::save_session(&session)?;
-        Ok(session)
+        self.inner.sign_in(email, password).await
     }
 
     /// Refresh an access token using the refresh token.
     pub async fn refresh_session(&self, refresh_token: &str) -> AuthResult<AuthSession> {
-        if refresh_token.trim().is_empty() {
-            return Err(AuthError::InvalidConfiguration(
-                "Refresh token must not be empty",
-            ));
-        }
-
-        let payload = serde_json::json!({
-            "refresh_token": refresh_token,
-        });
-        let request = self.public_request(
-            self.client
-                .post(format!("{}/token", self.auth_url))
-                .query(&[("grant_type", "refresh_token")])
-                .json(&payload),
-        );
-        let response = self.send_auth_request(request).await?;
-        let session = response.into_session()?.ok_or_else(|| {
-            AuthError::Api("Refresh response did not include an active session".to_string())
-        })?;
-        SessionStore::save_session(&session)?;
-        Ok(session)
+        self.inner.refresh_session(refresh_token).await
     }
 
     /// Sign out and clear local session storage.
     pub async fn sign_out(&self, access_token: &str) -> AuthResult<()> {
-        let server_logout = async {
-            let request = self
-                .client
-                .post(format!("{}/logout", self.auth_url))
-                .header("apikey", &self.anon_key)
-                .bearer_auth(access_token);
-            let response = request.send().await?;
-            if response.status().is_success() || response.status() == StatusCode::UNAUTHORIZED {
-                Ok(())
-            } else {
-                let status = response.status();
-                let body = response.text().await.unwrap_or_default();
-                Err(AuthError::Api(parse_api_error(status, &body)))
-            }
-        }
-        .await;
-
-        SessionStore::clear_session()?;
-
-        if let Err(error) = server_logout {
-            tracing::warn!(
-                "Server logout failed after clearing local session: {}",
-                error
-            );
-        }
-
-        Ok(())
+        self.inner.sign_out(access_token).await
     }
 
     /// Verify Supabase auth configuration and return a summary for UI diagnostics.
     pub async fn verify_configuration(&self) -> AuthResult<AuthConfigStatus> {
-        let request = self.public_request(self.client.get(format!("{}/settings", self.auth_url)));
-        let response = request.send().await?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AuthError::Api(parse_api_error(status, &body)));
-        }
-
-        let payload = response.json::<SupabaseAuthSettings>().await?;
-        Ok(AuthConfigStatus {
-            email_enabled: payload.external.email,
-            signup_enabled: !payload.disable_signup,
-            mailer_autoconfirm: payload.mailer_autoconfirm,
-            smtp_configured: payload.smtp_host.is_some(),
-            rate_limit_email_sent: payload.rate_limit_email_sent,
-        })
+        self.inner.verify_configuration().await
     }
-
-    fn public_request(&self, request: RequestBuilder) -> RequestBuilder {
-        request
-            .header("apikey", &self.anon_key)
-            .header("Authorization", format!("Bearer {}", self.anon_key))
-    }
-
-    async fn send_auth_request(&self, request: RequestBuilder) -> AuthResult<SupabaseAuthResponse> {
-        let response = request.send().await?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AuthError::Api(parse_api_error(status, &body)));
-        }
-
-        Ok(response.json::<SupabaseAuthResponse>().await?)
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseAuthResponse {
-    access_token: Option<String>,
-    refresh_token: Option<String>,
-    expires_at: Option<i64>,
-    expires_in: Option<i64>,
-    user: Option<SupabaseUser>,
-    session: Option<SupabaseAuthResponseSession>,
-}
-
-impl SupabaseAuthResponse {
-    fn into_session(self) -> AuthResult<Option<AuthSession>> {
-        let session = self.session;
-        let access_token = self
-            .access_token
-            .or_else(|| session.as_ref().and_then(|s| s.access_token.clone()));
-        let refresh_token = self
-            .refresh_token
-            .or_else(|| session.as_ref().and_then(|s| s.refresh_token.clone()));
-        let expires_at = self
-            .expires_at
-            .or_else(|| session.as_ref().and_then(|s| s.expires_at))
-            .or_else(|| {
-                self.expires_in
-                    .or_else(|| session.as_ref().and_then(|s| s.expires_in))
-                    .map(|expires_in| unix_timestamp_now().saturating_add(expires_in))
-            });
-        let user = self
-            .user
-            .or_else(|| session.and_then(|s| s.user))
-            .map(Into::into);
-
-        match (access_token, refresh_token, expires_at, user) {
-            (Some(access_token), Some(refresh_token), Some(expires_at), Some(user)) => {
-                Ok(Some(AuthSession {
-                    access_token,
-                    refresh_token,
-                    expires_at,
-                    user,
-                }))
-            }
-            (None, None, None, Some(_)) => Ok(None),
-            _ => Err(AuthError::Api(
-                "Auth response did not include enough session fields".to_string(),
-            )),
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseAuthResponseSession {
-    access_token: Option<String>,
-    refresh_token: Option<String>,
-    expires_at: Option<i64>,
-    expires_in: Option<i64>,
-    user: Option<SupabaseUser>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseUser {
-    id: String,
-    email: Option<String>,
-}
-
-impl From<SupabaseUser> for AuthUser {
-    fn from(value: SupabaseUser) -> Self {
-        Self {
-            id: value.id,
-            email: value.email,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseErrorResponse {
-    error: Option<String>,
-    error_description: Option<String>,
-    message: Option<String>,
-    msg: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseAuthSettings {
-    external: SupabaseExternalSettings,
-    disable_signup: bool,
-    mailer_autoconfirm: bool,
-    smtp_host: Option<String>,
-    rate_limit_email_sent: Option<i64>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SupabaseExternalSettings {
-    email: bool,
-}
-
-fn parse_api_error(status: StatusCode, body: &str) -> String {
-    if let Ok(payload) = serde_json::from_str::<SupabaseErrorResponse>(body) {
-        if let Some(message) = payload
-            .message
-            .or(payload.msg)
-            .or(payload.error_description)
-            .or(payload.error)
-        {
-            return format!("{} ({})", message.trim(), status.as_u16());
-        }
-    }
-
-    let trimmed = body.trim();
-    if trimmed.is_empty() {
-        format!("HTTP {}", status.as_u16())
-    } else {
-        format!("{} ({})", trimmed, status.as_u16())
-    }
-}
-
-fn normalize_auth_url(url: &str) -> AuthResult<String> {
-    let trimmed = url.trim().trim_end_matches('/');
-    if trimmed.is_empty() {
-        return Err(AuthError::InvalidConfiguration(
-            "SUPABASE_URL must not be empty",
-        ));
-    }
-    if !(trimmed.starts_with("https://") || trimmed.starts_with("http://")) {
-        return Err(AuthError::InvalidConfiguration(
-            "SUPABASE_URL must include http:// or https://",
-        ));
-    }
-
-    if trimmed.ends_with("/auth/v1") {
-        Ok(trimmed.to_string())
-    } else {
-        Ok(format!("{trimmed}/auth/v1"))
-    }
-}
-
-fn validate_credentials(email: &str, password: &str) -> AuthResult<()> {
-    if email.trim().is_empty() {
-        return Err(AuthError::Api("Email is required".to_string()));
-    }
-    if password.trim().is_empty() {
-        return Err(AuthError::Api("Password is required".to_string()));
-    }
-    Ok(())
-}
-
-fn unix_timestamp_now() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| {
-            i64::try_from(duration.as_secs()).unwrap_or(i64::MAX)
-        })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::bootstrap_config::MobileBootstrapConfig;
-
-    #[test]
-    fn normalize_auth_url_appends_auth_path() {
-        let normalized = normalize_auth_url("https://demo.supabase.co").unwrap();
-        assert_eq!(normalized, "https://demo.supabase.co/auth/v1");
-    }
-
-    #[test]
-    fn normalize_auth_url_keeps_existing_auth_path() {
-        let normalized = normalize_auth_url("https://demo.supabase.co/auth/v1").unwrap();
-        assert_eq!(normalized, "https://demo.supabase.co/auth/v1");
-    }
 
     #[test]
     fn new_from_bootstrap_returns_none_when_values_missing() {
@@ -515,20 +106,19 @@ mod tests {
     }
 
     #[test]
-    fn response_without_session_fields_means_confirmation_required() {
-        let response = SupabaseAuthResponse {
-            access_token: None,
-            refresh_token: None,
-            expires_at: None,
-            expires_in: None,
-            user: Some(SupabaseUser {
-                id: "user-id".to_string(),
-                email: Some("test@example.com".to_string()),
-            }),
-            session: None,
+    fn session_debug_redacts_tokens() {
+        let session = AuthSession {
+            access_token: "secret-access-token".to_string(),
+            refresh_token: "secret-refresh-token".to_string(),
+            expires_at: 1_700_000_000,
+            user: AuthUser {
+                id: "user".to_string(),
+                email: None,
+            },
         };
-
-        let session = response.into_session().unwrap();
-        assert!(session.is_none());
+        let rendered = format!("{session:?}");
+        assert!(!rendered.contains("secret-access-token"));
+        assert!(!rendered.contains("secret-refresh-token"));
+        assert!(rendered.contains("[REDACTED]"));
     }
 }

--- a/crates/dirt-mobile/src/bootstrap_config.rs
+++ b/crates/dirt-mobile/src/bootstrap_config.rs
@@ -1,57 +1,13 @@
-//! Mobile bootstrap configuration loaded from build-time generated JSON.
+//! Mobile bootstrap configuration loaded from generated JSON.
 #![cfg_attr(not(target_os = "android"), allow(dead_code))]
 
-use std::time::Duration;
-
-use serde::{Deserialize, Serialize};
-
-const BOOTSTRAP_SCHEMA_VERSION: u32 = 1;
-const BOOTSTRAP_HTTP_TIMEOUT_SECS: u64 = 4;
-
-/// Build-provisioned client configuration embedded into mobile binaries.
-///
-/// These values are safe-to-ship public endpoints/keys required to bootstrap
-/// auth and managed sync flows. Secret credentials must never be stored here.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct MobileBootstrapConfig {
-    #[serde(default)]
-    pub bootstrap_manifest_url: Option<String>,
-    #[serde(default)]
-    pub supabase_url: Option<String>,
-    #[serde(default)]
-    pub supabase_anon_key: Option<String>,
-    #[serde(default)]
-    pub turso_sync_token_endpoint: Option<String>,
-    /// Optional managed API base URL used for media presign operations.
-    #[serde(default)]
-    pub dirt_api_base_url: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct ManagedBootstrapManifest {
-    schema_version: u32,
-    manifest_version: String,
-    supabase_url: String,
-    supabase_anon_key: String,
-    api_base_url: String,
-    #[serde(default)]
-    turso_sync_token_endpoint: Option<String>,
-    feature_flags: ManagedFeatureFlags,
-}
-
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct ManagedFeatureFlags {
-    managed_sync: bool,
-    managed_media: bool,
-}
+pub use dirt_core::config::BootstrapConfig as MobileBootstrapConfig;
+pub use dirt_core::util::normalize_text_option;
 
 /// Loads the generated mobile bootstrap JSON from `OUT_DIR`.
 ///
-/// If parsing fails, this logs a warning and returns a default empty config so
-/// the app can continue running in local-only mode.
+/// Falls back to an empty config when parsing fails so the app can continue
+/// running in local-only mode.
 pub fn load_bootstrap_config() -> MobileBootstrapConfig {
     let raw = include_str!(concat!(env!("OUT_DIR"), "/mobile-bootstrap.json"));
     serde_json::from_str(raw).unwrap_or_else(|error| {
@@ -60,160 +16,9 @@ pub fn load_bootstrap_config() -> MobileBootstrapConfig {
     })
 }
 
-/// Resolve runtime bootstrap config.
-///
-/// Attempts to fetch managed bootstrap manifest from `bootstrap_manifest_url`.
-/// When fetching/parsing/validation fails, this safely falls back to the
-/// embedded build-time config.
+/// Resolves runtime bootstrap config, falling back to embedded values.
 pub async fn resolve_bootstrap_config(fallback: MobileBootstrapConfig) -> MobileBootstrapConfig {
-    let Some(manifest_url) = normalize_text_option(fallback.bootstrap_manifest_url.clone()) else {
-        return fallback;
-    };
-
-    match fetch_bootstrap_manifest(&manifest_url).await {
-        Ok(config) => config,
-        Err(error) => {
-            tracing::warn!(
-                "Failed to resolve runtime mobile bootstrap from {}: {}. Falling back to embedded config.",
-                manifest_url,
-                error
-            );
-            fallback
-        }
-    }
-}
-
-/// Normalizes optional text config by trimming whitespace and removing empties.
-///
-/// Returns `None` when the input is `None` or the trimmed value is empty.
-pub fn normalize_text_option(value: Option<String>) -> Option<String> {
-    let value = value?;
-    let value = value.trim();
-    if value.is_empty() {
-        None
-    } else {
-        Some(value.to_string())
-    }
-}
-
-impl MobileBootstrapConfig {
-    /// Returns the managed API base URL for authenticated media operations.
-    ///
-    /// Prefers `dirt_api_base_url` when present; otherwise derives the base URL
-    /// from `turso_sync_token_endpoint` by stripping `/v1/sync/token`.
-    pub fn managed_api_base_url(&self) -> Option<String> {
-        if let Some(url) = normalize_text_option(self.dirt_api_base_url.clone()) {
-            return Some(url);
-        }
-
-        let endpoint = normalize_text_option(self.turso_sync_token_endpoint.clone())?;
-        endpoint
-            .strip_suffix("/v1/sync/token")
-            .map(std::string::ToString::to_string)
-    }
-}
-
-async fn fetch_bootstrap_manifest(url: &str) -> Result<MobileBootstrapConfig, String> {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(BOOTSTRAP_HTTP_TIMEOUT_SECS))
-        .build()
-        .map_err(|error| format!("failed to build bootstrap HTTP client: {error}"))?;
-
-    let response = client
-        .get(url)
-        .header(reqwest::header::ACCEPT, "application/json")
-        .send()
-        .await
-        .map_err(|error| format!("bootstrap request failed: {error}"))?;
-
-    if !response.status().is_success() {
-        let status = response.status().as_u16();
-        let body = response.text().await.unwrap_or_default();
-        return Err(format!(
-            "bootstrap endpoint returned HTTP {status}: {}",
-            compact_text(&body)
-        ));
-    }
-
-    let body = response
-        .text()
-        .await
-        .map_err(|error| format!("failed to read bootstrap response body: {error}"))?;
-    parse_bootstrap_manifest(&body, url)
-}
-
-fn parse_bootstrap_manifest(
-    payload: &str,
-    manifest_url: &str,
-) -> Result<MobileBootstrapConfig, String> {
-    let manifest: ManagedBootstrapManifest = serde_json::from_str(payload)
-        .map_err(|error| format!("invalid bootstrap manifest JSON: {error}"))?;
-    manifest.into_runtime_config(manifest_url)
-}
-
-impl ManagedBootstrapManifest {
-    fn into_runtime_config(self, manifest_url: &str) -> Result<MobileBootstrapConfig, String> {
-        if self.schema_version != BOOTSTRAP_SCHEMA_VERSION {
-            return Err(format!(
-                "unsupported bootstrap schema_version {} (expected {})",
-                self.schema_version, BOOTSTRAP_SCHEMA_VERSION
-            ));
-        }
-        if self.manifest_version.trim().is_empty() {
-            return Err("bootstrap manifest_version must not be empty".to_string());
-        }
-
-        let supabase_url = normalize_required_http_url(self.supabase_url, "supabase_url")?;
-        let supabase_anon_key =
-            normalize_required_value(self.supabase_anon_key, "supabase_anon_key")?;
-        let api_base_url = normalize_required_http_url(self.api_base_url, "api_base_url")?;
-
-        let sync_endpoint = if self.feature_flags.managed_sync {
-            match normalize_text_option(self.turso_sync_token_endpoint) {
-                Some(endpoint) => Some(normalize_required_http_url(
-                    endpoint,
-                    "turso_sync_token_endpoint",
-                )?),
-                None => Some(format!("{api_base_url}/v1/sync/token")),
-            }
-        } else {
-            None
-        };
-
-        let api_base_for_clients =
-            if self.feature_flags.managed_sync || self.feature_flags.managed_media {
-                Some(api_base_url)
-            } else {
-                None
-            };
-
-        Ok(MobileBootstrapConfig {
-            bootstrap_manifest_url: Some(manifest_url.to_string()),
-            supabase_url: Some(supabase_url),
-            supabase_anon_key: Some(supabase_anon_key),
-            turso_sync_token_endpoint: sync_endpoint,
-            dirt_api_base_url: api_base_for_clients,
-        })
-    }
-}
-
-fn normalize_required_value(raw: String, field: &str) -> Result<String, String> {
-    normalize_text_option(Some(raw)).ok_or_else(|| format!("bootstrap field '{field}' is required"))
-}
-
-fn normalize_required_http_url(raw: String, field: &str) -> Result<String, String> {
-    let value = normalize_required_value(raw, field)?;
-    if value.starts_with("http://") || value.starts_with("https://") {
-        Ok(value.trim_end_matches('/').to_string())
-    } else {
-        Err(format!(
-            "bootstrap field '{field}' must include http:// or https://"
-        ))
-    }
-}
-
-fn compact_text(value: &str) -> String {
-    value.trim().chars().take(180).collect()
+    dirt_core::config::resolve_bootstrap_config(fallback).await
 }
 
 #[cfg(test)]
@@ -263,8 +68,11 @@ mod tests {
         }
         "#;
 
-        let error =
-            parse_bootstrap_manifest(payload, "https://api.example.com/v1/bootstrap").unwrap_err();
+        let error = dirt_core::config::parse_bootstrap_manifest(
+            payload,
+            "https://api.example.com/v1/bootstrap",
+        )
+        .unwrap_err();
         assert!(error.contains("unknown field"));
     }
 
@@ -284,8 +92,11 @@ mod tests {
         }
         "#;
 
-        let error =
-            parse_bootstrap_manifest(payload, "https://api.example.com/v1/bootstrap").unwrap_err();
+        let error = dirt_core::config::parse_bootstrap_manifest(
+            payload,
+            "https://api.example.com/v1/bootstrap",
+        )
+        .unwrap_err();
         assert!(error.contains("schema_version"));
     }
 
@@ -305,8 +116,11 @@ mod tests {
         }
         "#;
 
-        let parsed = parse_bootstrap_manifest(payload, "https://api.example.com/v1/bootstrap")
-            .expect("manifest should parse");
+        let parsed = dirt_core::config::parse_bootstrap_manifest(
+            payload,
+            "https://api.example.com/v1/bootstrap",
+        )
+        .expect("manifest should parse");
         assert_eq!(
             parsed.turso_sync_token_endpoint.as_deref(),
             Some("https://api.example.com/v1/sync/token")

--- a/crates/dirt-mobile/src/media_api.rs
+++ b/crates/dirt-mobile/src/media_api.rs
@@ -1,16 +1,16 @@
 //! Backend media signing client for mobile attachment operations.
 #![cfg_attr(not(target_os = "android"), allow(dead_code))]
 
-use reqwest::Method;
-use serde::{Deserialize, Serialize};
+use std::ops::Deref;
+
+use dirt_core::media::MediaApiClient as CoreMediaApiClient;
 
 use crate::bootstrap_config::MobileBootstrapConfig;
 
 /// HTTP client for managed media operations backed by the Dirt API service.
 #[derive(Debug, Clone)]
 pub struct MediaApiClient {
-    base_url: String,
-    client: reqwest::Client,
+    inner: CoreMediaApiClient,
 }
 
 impl MediaApiClient {
@@ -26,16 +26,13 @@ impl MediaApiClient {
 
     /// Builds a client for an explicit API base URL.
     pub fn new(base_url: impl Into<String>) -> Result<Self, String> {
-        let base_url = normalize_base_url(base_url.into().as_str())?;
-        let client = reqwest::Client::builder()
-            .build()
-            .map_err(|error| format!("Failed to construct HTTP client: {error}"))?;
-        Ok(Self { base_url, client })
+        let inner = CoreMediaApiClient::new(base_url.into())?;
+        Ok(Self { inner })
     }
 
     /// Returns the normalized API base URL used by this client.
     pub fn base_url(&self) -> &str {
-        &self.base_url
+        self.inner.base_url()
     }
 
     /// Uploads attachment bytes using a backend-issued presigned operation.
@@ -46,204 +43,32 @@ impl MediaApiClient {
         content_type: &str,
         bytes: &[u8],
     ) -> Result<(), String> {
-        let operation = self
-            .request_presigned(
-                access_token,
-                "/v1/media/presign/upload",
-                &serde_json::json!({
-                    "object_key": object_key,
-                    "content_type": content_type,
-                }),
-            )
-            .await?;
-
-        let method = parse_method(&operation.method)?;
-        let mut request = self.client.request(method, &operation.url);
-        for (name, value) in operation.headers {
-            if name.eq_ignore_ascii_case("host") {
-                continue;
-            }
-            request = request.header(name, value);
-        }
-        let response = request
-            .body(bytes.to_vec())
-            .send()
+        self.inner
+            .upload(access_token, object_key, content_type, bytes)
             .await
-            .map_err(|error| format!("Upload request failed: {error}"))?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(format!(
-                "Upload request failed with HTTP {status}: {}",
-                compact_body(&body)
-            ));
-        }
-        Ok(())
     }
 
     /// Downloads attachment bytes using a backend-issued presigned operation.
-    ///
-    /// Returns raw bytes and an optional content type returned by the storage backend.
     pub async fn download(
         &self,
         access_token: &str,
         object_key: &str,
     ) -> Result<(Vec<u8>, Option<String>), String> {
-        let encoded_object_key = urlencoding::encode(object_key);
-        let url = format!(
-            "{}/v1/media/presign/download?object_key={}",
-            self.base_url, encoded_object_key
-        );
-
-        let response = self
-            .client
-            .get(url)
-            .bearer_auth(access_token)
-            .header("Accept", "application/json")
-            .send()
-            .await
-            .map_err(|error| format!("Failed to request download URL: {error}"))?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(format!(
-                "Download URL request failed with HTTP {status}: {}",
-                compact_body(&body)
-            ));
-        }
-        let payload = response
-            .json::<PresignResponse>()
-            .await
-            .map_err(|error| format!("Failed to parse download URL response: {error}"))?;
-
-        let operation = payload.operation;
-        let method = parse_method(&operation.method)?;
-        let mut request = self.client.request(method, &operation.url);
-        for (name, value) in operation.headers {
-            if name.eq_ignore_ascii_case("host") {
-                continue;
-            }
-            request = request.header(name, value);
-        }
-        let response = request
-            .send()
-            .await
-            .map_err(|error| format!("Download request failed: {error}"))?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(format!(
-                "Download request failed with HTTP {status}: {}",
-                compact_body(&body)
-            ));
-        }
-        let content_type = response
-            .headers()
-            .get(reqwest::header::CONTENT_TYPE)
-            .and_then(|value| value.to_str().ok())
-            .map(ToString::to_string);
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|error| format!("Failed to read attachment bytes: {error}"))?;
-        Ok((bytes.to_vec(), content_type))
+        self.inner.download(access_token, object_key).await
     }
 
     /// Deletes an attachment object using a backend-issued presigned operation.
     pub async fn delete(&self, access_token: &str, object_key: &str) -> Result<(), String> {
-        let operation = self
-            .request_presigned(
-                access_token,
-                "/v1/media/presign/delete",
-                &serde_json::json!({
-                    "object_key": object_key,
-                }),
-            )
-            .await?;
-
-        let method = parse_method(&operation.method)?;
-        let mut request = self.client.request(method, &operation.url);
-        for (name, value) in operation.headers {
-            if name.eq_ignore_ascii_case("host") {
-                continue;
-            }
-            request = request.header(name, value);
-        }
-        let response = request
-            .send()
-            .await
-            .map_err(|error| format!("Delete request failed: {error}"))?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(format!(
-                "Delete request failed with HTTP {status}: {}",
-                compact_body(&body)
-            ));
-        }
-        Ok(())
-    }
-
-    async fn request_presigned(
-        &self,
-        access_token: &str,
-        route: &str,
-        body: &serde_json::Value,
-    ) -> Result<PresignedOperation, String> {
-        let response = self
-            .client
-            .post(format!("{}{}", self.base_url, route))
-            .bearer_auth(access_token)
-            .header("Accept", "application/json")
-            .json(body)
-            .send()
-            .await
-            .map_err(|error| format!("Failed to request signed URL: {error}"))?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(format!(
-                "Signed URL request failed with HTTP {status}: {}",
-                compact_body(&body)
-            ));
-        }
-        let payload = response
-            .json::<PresignResponse>()
-            .await
-            .map_err(|error| format!("Failed to parse signed URL response: {error}"))?;
-        Ok(payload.operation)
+        self.inner.delete(access_token, object_key).await
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct PresignResponse {
-    operation: PresignedOperation,
-}
+impl Deref for MediaApiClient {
+    type Target = CoreMediaApiClient;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct PresignedOperation {
-    method: String,
-    url: String,
-    headers: Vec<(String, String)>,
-}
-
-fn normalize_base_url(raw: &str) -> Result<String, String> {
-    let base = raw.trim().trim_end_matches('/').to_string();
-    if base.is_empty() {
-        return Err("DIRT_API_BASE_URL must not be empty".to_string());
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
-    if !(base.starts_with("https://") || base.starts_with("http://")) {
-        return Err("DIRT_API_BASE_URL must include http:// or https://".to_string());
-    }
-    Ok(base)
-}
-
-fn parse_method(raw: &str) -> Result<Method, String> {
-    Method::from_bytes(raw.as_bytes()).map_err(|error| format!("Unsupported HTTP method: {error}"))
-}
-
-fn compact_body(body: &str) -> String {
-    body.trim().chars().take(180).collect()
 }
 
 #[cfg(test)]
@@ -252,14 +77,16 @@ mod tests {
 
     #[test]
     fn normalize_base_url_rejects_invalid_values() {
-        assert!(normalize_base_url("").is_err());
-        assert!(normalize_base_url("example.com").is_err());
+        assert!(MediaApiClient::new("").is_err());
+        assert!(MediaApiClient::new("example.com").is_err());
     }
 
     #[test]
     fn normalize_base_url_trims_trailing_slash() {
         assert_eq!(
-            normalize_base_url("https://api.example.com/").unwrap(),
+            MediaApiClient::new("https://api.example.com/")
+                .unwrap()
+                .base_url(),
             "https://api.example.com"
         );
     }


### PR DESCRIPTION
## Summary
- replace mobile bootstrap config module with thin wrappers around dirt-core::config
- replace mobile sync auth client with a thin wrapper over dirt-core::sync::TursoSyncAuthClient
- replace mobile media API client with a thin wrapper over dirt-core::media::MediaApiClient
- replace mobile auth HTTP/session logic with a thin wrapper over dirt-core::auth::SupabaseAuthService + existing mobile secret-store persistence

## Validation
- cargo check -p dirt-core -p dirt-desktop -p dirt-mobile -p dirt-cli
- cargo test -p dirt-core -- --test-threads=1
- cargo test -p dirt-desktop -p dirt-mobile -p dirt-cli
- cargo clippy -p dirt-core -p dirt-desktop -p dirt-mobile -p dirt-cli --all-targets --all-features -- -D warnings

Refs #183