### PR TITLE
Use core DatabaseService in CLI command flow (phase 4)

### DIFF
--- a/crates/dirt-cli/src/commands/add.rs
+++ b/crates/dirt-cli/src/commands/add.rs
@@ -1,7 +1,5 @@
 use std::path::Path;
 
-use dirt_core::db::{LibSqlNoteRepository, NoteRepository};
-
 use crate::commands::common::{open_database, resolve_note_content};
 use crate::error::CliError;
 
@@ -9,8 +7,7 @@ pub async fn run_add(content_parts: &[String], db_path: &Path) -> Result<(), Cli
     let content = resolve_note_content(content_parts)?;
 
     let db = open_database(db_path).await?;
-    let repo = LibSqlNoteRepository::new(db.connection());
-    let note = repo.create(&content).await?;
+    let note = db.create_note(&content).await?;
 
     println!("{}", note.id);
     Ok(())

--- a/crates/dirt-cli/src/commands/delete.rs
+++ b/crates/dirt-cli/src/commands/delete.rs
@@ -1,17 +1,14 @@
 use std::path::Path;
 
-use dirt_core::db::{LibSqlNoteRepository, NoteRepository};
-
 use crate::commands::common::{normalize_note_identifier, open_database, resolve_note_for_edit};
 use crate::error::CliError;
 
 pub async fn run_delete(id: &str, db_path: &Path) -> Result<(), CliError> {
     let normalized_id = normalize_note_identifier(id)?;
     let db = open_database(db_path).await?;
-    let repo = LibSqlNoteRepository::new(db.connection());
     let note = resolve_note_for_edit(&normalized_id, &db).await?;
 
-    repo.delete(&note.id).await?;
+    db.delete_note(&note.id).await?;
     println!("{}", note.id);
     Ok(())
 }

--- a/crates/dirt-cli/src/commands/edit.rs
+++ b/crates/dirt-cli/src/commands/edit.rs
@@ -1,7 +1,5 @@
 use std::path::Path;
 
-use dirt_core::db::{LibSqlNoteRepository, NoteRepository};
-
 use crate::commands::common::{
     capture_editor_input_with_initial, normalize_note_identifier, open_database,
     resolve_note_for_edit,
@@ -22,8 +20,7 @@ pub async fn run_edit(id: &str, db_path: &Path) -> Result<(), CliError> {
         return Ok(());
     }
 
-    let repo = LibSqlNoteRepository::new(db.connection());
-    let updated = repo.update(&note.id, &edited_content).await?;
+    let updated = db.update_note(&note.id, &edited_content).await?;
     println!("{}", updated.id);
     Ok(())
 }

--- a/crates/dirt-cli/src/commands/sync.rs
+++ b/crates/dirt-cli/src/commands/sync.rs
@@ -8,7 +8,7 @@ use crate::error::CliError;
 
 pub async fn run_sync(db_path: &Path) -> Result<(), CliError> {
     let db = open_sync_database(db_path).await?;
-    if !db.is_sync_enabled() {
+    if !db.is_sync_enabled().await {
         return Err(CliError::SyncNotConfigured);
     }
 

--- a/crates/dirt-cli/src/config_profiles.rs
+++ b/crates/dirt-cli/src/config_profiles.rs
@@ -41,13 +41,7 @@ pub fn default_config_path() -> PathBuf {
 }
 
 pub fn normalize_text_option(value: Option<String>) -> Option<String> {
-    let value = value?;
-    let value = value.trim();
-    if value.is_empty() {
-        None
-    } else {
-        Some(value.to_string())
-    }
+    dirt_core::util::normalize_text_option(value)
 }
 
 pub fn normalize_profile_name(value: Option<&str>) -> Option<String> {

--- a/crates/dirt-cli/src/error.rs
+++ b/crates/dirt-cli/src/error.rs
@@ -26,8 +26,6 @@ pub enum CliError {
     AmbiguousNoteId(String),
     #[error("Editor command failed: {0}")]
     EditorFailed(String),
-    #[error("Database initialization failed: {0}")]
-    DatabaseInit(String),
     #[error("Configuration error: {0}")]
     Config(String),
     #[error("Authentication error: {0}")]

--- a/crates/dirt-mobile/src/config.rs
+++ b/crates/dirt-mobile/src/config.rs
@@ -4,6 +4,7 @@
 use std::path::{Path, PathBuf};
 
 use dirt_core::db::SyncConfig;
+use dirt_core::util::normalize_text_option;
 use dirt_core::Result;
 use serde::{Deserialize, Serialize};
 
@@ -167,16 +168,6 @@ pub fn parse_sync_config(url: Option<String>, auth_token: Option<String>) -> Opt
     let url = normalize_text_option(url)?;
     let auth_token = normalize_text_option(auth_token)?;
     Some(SyncConfig::new(url, auth_token))
-}
-
-fn normalize_text_option(value: Option<String>) -> Option<String> {
-    let value = value?;
-    let value = value.trim();
-    if value.is_empty() {
-        None
-    } else {
-        Some(value.to_string())
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add shared DatabaseService::list_note_ids_by_prefix helper in dirt-core
- migrate CLI command data path (list/search/add/edit/delete/sync) from raw Database + inline repositories to dirt-core::services::DatabaseService
- update CLI note-resolution flow to use the new shared core helper
- remove unused CLI DatabaseInit error variant
- switch remaining mobile runtime-config text normalization to shared dirt-core::util::normalize_text_option

## Validation
- cargo check -p dirt-core -p dirt-desktop -p dirt-mobile -p dirt-cli
- cargo test -p dirt-core -- --test-threads=1
- cargo test -p dirt-desktop -p dirt-mobile -p dirt-cli
- cargo clippy -p dirt-core -p dirt-desktop -p dirt-mobile -p dirt-cli --all-targets --all-features -- -D warnings

Refs #183