### PR TITLE
Share export format/render orchestration via dirt-core (phase 5)

### DIFF
--- a/crates/dirt-cli/src/commands/export.rs
+++ b/crates/dirt-cli/src/commands/export.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use dirt_core::export::{render_json_export, render_markdown_export};
+use dirt_core::export::{render_notes_export, ExportFormat as CoreExportFormat};
 
 use crate::cli::ExportFormat;
 use crate::commands::common::list_all_notes;
@@ -12,10 +12,11 @@ pub async fn run_export(
     db_path: &Path,
 ) -> Result<(), CliError> {
     let notes = list_all_notes(db_path).await?;
-    let rendered = match format {
-        ExportFormat::Json => render_json_export(&notes)?,
-        ExportFormat::Markdown => render_markdown_export(&notes),
+    let core_format = match format {
+        ExportFormat::Json => CoreExportFormat::Json,
+        ExportFormat::Markdown => CoreExportFormat::Markdown,
     };
+    let rendered = render_notes_export(&notes, core_format)?;
 
     if let Some(path) = output_path {
         std::fs::write(path, rendered)?;


### PR DESCRIPTION
## Summary
- add shared ExportFormat, ender_notes_export, and suggested_export_file_name to dirt-core::export
- migrate desktop export service to consume the shared core export orchestration
- migrate mobile export helpers to consume the shared core export orchestration
- migrate CLI export command rendering path to consume the shared core export orchestration

## Validation
- cargo check -p dirt-core -p dirt-desktop -p dirt-mobile -p dirt-cli
- cargo test -p dirt-core -- --test-threads=1
- cargo test -p dirt-desktop -p dirt-mobile -p dirt-cli
- cargo clippy -p dirt-core -p dirt-desktop -p dirt-mobile -p dirt-cli --all-targets --all-features -- -D warnings

Refs #183