### PR TITLE
Phase 2.1: magic-code auth schema and endpoints

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b88d6196-b532-4fdd-b798-ee53bf9af5d1","pid":60068,"acquiredAt":1778033328097}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"b88d6196-b532-4fdd-b798-ee53bf9af5d1","pid":60068,"acquiredAt":1778033328097}

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ dx.lock
 /docs/book/
 
 .vercel
+
+# Claude Code internal scheduling state
+.claude/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,8 +1790,10 @@ dependencies = [
  "dirt-core",
  "dotenvy",
  "libsql",
+ "rand 0.8.5",
  "serde",
  "serde_json",
+ "sha2",
  "subtle",
  "thiserror 2.0.18",
  "tokio",
@@ -1799,6 +1801,7 @@ dependencies = [
  "tower-http 0.6.8",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/api/axum.rs
+++ b/api/axum.rs
@@ -13,7 +13,7 @@
 
 use std::sync::Arc;
 
-use dirt_api::{build_router, AppConfig, AppState, TursoRepo};
+use dirt_api::{build_router, AppConfig, AppState, EmailSender, TursoRepo};
 use tower::ServiceBuilder;
 use vercel_runtime::axum::VercelLayer;
 use vercel_runtime::Error;
@@ -28,7 +28,8 @@ async fn main() -> Result<(), Error> {
             .await
             .map_err(|e| Error::from(format!("failed to connect to Turso: {e}")))?,
     );
-    let state = AppState::new(config, repo);
+    let email = Arc::new(EmailSender::from_env());
+    let state = AppState::new(config, repo, email);
     let router = build_router(state);
 
     let app = ServiceBuilder::new()

--- a/crates/dirt-api/Cargo.toml
+++ b/crates/dirt-api/Cargo.toml
@@ -37,6 +37,13 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 dotenvy = "0.15"
 base64 = "0.22"
 
+# Magic-link auth: cryptographically random codes/session tokens, plus
+# sha256 to hash them before storing in Turso. Hashing keeps a stolen DB
+# from immediately yielding active sessions.
+rand = "0.8"
+sha2 = "0.10"
+uuid.workspace = true
+
 [dev-dependencies]
 # `ServiceExt::oneshot` lets the auth-middleware tests drive the axum
 # Router in-process without spinning up a TCP listener.

--- a/crates/dirt-api/src/auth.rs
+++ b/crates/dirt-api/src/auth.rs
@@ -82,8 +82,9 @@ mod tests {
         };
         AppState {
             config: Arc::new(config),
-            // Repo is never touched by the middleware itself.
+            // Repo and email are never touched by the middleware itself.
             repo: Arc::new(TursoRepo::dangling()),
+            email: Arc::new(crate::email::EmailSender::log_only()),
         }
     }
 

--- a/crates/dirt-api/src/email.rs
+++ b/crates/dirt-api/src/email.rs
@@ -11,6 +11,9 @@
 
 use crate::error::AppError;
 
+#[cfg(test)]
+use std::sync::{Arc, Mutex};
+
 /// Sender mode picked at startup. Kept private — callers go through
 /// `EmailSender::send_magic_code`, not the variant directly.
 enum Mode {
@@ -18,7 +21,16 @@ enum Mode {
     /// The right default for `cargo run` and tests; explicit because
     /// "I'm not actually emailing this" should be a deliberate choice.
     Log,
+    /// Test-only: stash every (email, code) pair into a shared `Vec`
+    /// the test can inspect. Lets the round-trip test parse the actual
+    /// code that `/v1/auth/request` minted, instead of seeding a
+    /// parallel one and pretending.
+    #[cfg(test)]
+    Capture(CapturedSends),
 }
+
+#[cfg(test)]
+pub type CapturedSends = Arc<Mutex<Vec<(String, String)>>>;
 
 pub struct EmailSender {
     mode: Mode,
@@ -29,6 +41,19 @@ impl EmailSender {
     #[must_use]
     pub const fn log_only() -> Self {
         Self { mode: Mode::Log }
+    }
+
+    /// Test-only: build a sender that records every send into the
+    /// returned `Arc<Mutex<Vec>>`, alongside the sender itself.
+    #[cfg(test)]
+    pub fn capture() -> (Self, CapturedSends) {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                mode: Mode::Capture(captured.clone()),
+            },
+            captured,
+        )
     }
 
     /// Pick a mode from the process environment.
@@ -56,6 +81,14 @@ impl EmailSender {
         match &self.mode {
             Mode::Log => {
                 tracing::info!(target: "dirt_api::email", "[dev email] to={email} code={code}");
+                Ok(())
+            }
+            #[cfg(test)]
+            Mode::Capture(captured) => {
+                captured
+                    .lock()
+                    .expect("CapturedSends mutex poisoned")
+                    .push((email.to_string(), code.to_string()));
                 Ok(())
             }
         }

--- a/crates/dirt-api/src/email.rs
+++ b/crates/dirt-api/src/email.rs
@@ -80,7 +80,13 @@ impl EmailSender {
     pub async fn send_magic_code(&self, email: &str, code: &str) -> Result<(), AppError> {
         match &self.mode {
             Mode::Log => {
-                tracing::info!(target: "dirt_api::email", "[dev email] to={email} code={code}");
+                // The "we tried to email you" record stays at info for
+                // observability; the raw code drops to debug so a
+                // RUST_LOG=info deploy doesn't write live magic codes
+                // into a log aggregator. RUST_LOG=debug is the explicit
+                // opt-in for "I want to see codes in the dev console."
+                tracing::info!(target: "dirt_api::email", "[dev email] to={email}");
+                tracing::debug!(target: "dirt_api::email", "[dev email] to={email} code={code}");
                 Ok(())
             }
             #[cfg(test)]

--- a/crates/dirt-api/src/email.rs
+++ b/crates/dirt-api/src/email.rs
@@ -1,0 +1,83 @@
+//! Outbound email for the magic-code flow.
+//!
+//! Phase 2.1 ships only the `Log` mode: the magic code is written to
+//! `tracing::info!` and never leaves the process. This is enough for
+//! integration tests, local development, and the very first end-to-end
+//! mobile/desktop wiring runs without provisioning Resend.
+//!
+//! Phase 2.3 adds a `Resend` variant. The `EmailSender` struct is set up
+//! so that change is local — extend the inner enum, branch in
+//! `send_magic_code`, and update `from_env` to choose the right mode.
+
+use crate::error::AppError;
+
+/// Sender mode picked at startup. Kept private — callers go through
+/// `EmailSender::send_magic_code`, not the variant directly.
+enum Mode {
+    /// Print the code to the server log instead of sending email.
+    /// The right default for `cargo run` and tests; explicit because
+    /// "I'm not actually emailing this" should be a deliberate choice.
+    Log,
+}
+
+pub struct EmailSender {
+    mode: Mode,
+}
+
+impl EmailSender {
+    /// Always-log sender. The constructor every test reaches for.
+    #[must_use]
+    pub const fn log_only() -> Self {
+        Self { mode: Mode::Log }
+    }
+
+    /// Pick a mode from the process environment.
+    ///
+    /// Phase 2.1 only knows the `Log` mode. Phase 2.3 will look for
+    /// `RESEND_API_KEY` here and switch to a Resend HTTPS sender — at
+    /// which point this function reads the env, so the
+    /// `missing_const_for_fn` lint will resolve itself naturally.
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn from_env() -> Self {
+        Self::log_only()
+    }
+
+    /// Deliver a magic code to `email`. Errors here propagate as
+    /// `AppError::Internal` so the request handler maps them onto a 500
+    /// — the user can't fix a Resend outage themselves, retrying the
+    /// `/v1/auth/request` is the right user-facing prompt.
+    ///
+    /// `async` is kept on the signature even in pure-`Log` mode because
+    /// Phase 2.3 introduces an `await` on the Resend HTTPS call and we
+    /// don't want every caller to switch from sync to async then.
+    #[allow(clippy::unused_async)]
+    pub async fn send_magic_code(&self, email: &str, code: &str) -> Result<(), AppError> {
+        match &self.mode {
+            Mode::Log => {
+                tracing::info!(target: "dirt_api::email", "[dev email] to={email} code={code}");
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Default for EmailSender {
+    fn default() -> Self {
+        Self::log_only()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn log_mode_send_succeeds() {
+        let sender = EmailSender::log_only();
+        sender
+            .send_magic_code("user@example.com", "123456")
+            .await
+            .unwrap();
+    }
+}

--- a/crates/dirt-api/src/error.rs
+++ b/crates/dirt-api/src/error.rs
@@ -40,6 +40,14 @@ pub enum AppError {
     Internal(String),
 }
 
+// Phase 2 magic-link auth: distinct error codes so clients can tell
+// "wrong code" from "expired code" from "too many tries" without parsing
+// human-readable messages.
+//
+// `SESSION_EXPIRED` is a 401 (the session middleware peels it off the
+// Authorization header). The other three are 400s — they describe a
+// client-supplied request body that the server rejected.
+
 #[derive(Debug, Serialize)]
 struct ErrorEnvelope {
     error: ErrorBody,
@@ -63,9 +71,44 @@ impl AppError {
         }
     }
 
+    pub fn session_expired(message: impl Into<String>) -> Self {
+        Self::Unauthorized {
+            code: "SESSION_EXPIRED",
+            message: message.into(),
+        }
+    }
+
     pub fn bad_request(message: impl Into<String>) -> Self {
         Self::BadRequest {
             code: "BAD_REQUEST",
+            message: message.into(),
+        }
+    }
+
+    pub fn invalid_email(message: impl Into<String>) -> Self {
+        Self::BadRequest {
+            code: "INVALID_EMAIL",
+            message: message.into(),
+        }
+    }
+
+    pub fn invalid_code(message: impl Into<String>) -> Self {
+        Self::BadRequest {
+            code: "INVALID_CODE",
+            message: message.into(),
+        }
+    }
+
+    pub fn expired_code(message: impl Into<String>) -> Self {
+        Self::BadRequest {
+            code: "EXPIRED_CODE",
+            message: message.into(),
+        }
+    }
+
+    pub fn too_many_attempts(message: impl Into<String>) -> Self {
+        Self::BadRequest {
+            code: "TOO_MANY_ATTEMPTS",
             message: message.into(),
         }
     }
@@ -147,11 +190,28 @@ impl AppError {
 
     fn fix(&self) -> &'static str {
         match self {
-            Self::Unauthorized { .. } => {
-                "Include 'Authorization: Bearer <DIRT_CLIENT_TOKEN>' matching the server's DIRT_SERVER_TOKEN."
-            }
+            Self::Unauthorized { code, .. } => match *code {
+                "SESSION_EXPIRED" => {
+                    "Sign in again to obtain a fresh session token."
+                }
+                _ => {
+                    "Include 'Authorization: Bearer <session-token>' from the magic-code verify response."
+                }
+            },
             Self::BadRequest { code, .. } => match *code {
                 "BATCH_TOO_LARGE" => "Split the batch into groups of at most 500 notes and retry.",
+                "INVALID_EMAIL" => {
+                    "Send a syntactically valid email address (RFC-5322-ish)."
+                }
+                "INVALID_CODE" => {
+                    "Re-check the code from the email and retry; if it keeps failing, request a new one."
+                }
+                "EXPIRED_CODE" => {
+                    "Magic codes are valid for 15 minutes. Request a new code via /v1/auth/request."
+                }
+                "TOO_MANY_ATTEMPTS" => {
+                    "This request_id is locked. Request a fresh code via /v1/auth/request."
+                }
                 _ => "Fix the request body or parameters and retry.",
             },
             Self::PayloadTooLarge { .. } => {

--- a/crates/dirt-api/src/error.rs
+++ b/crates/dirt-api/src/error.rs
@@ -40,13 +40,14 @@ pub enum AppError {
     Internal(String),
 }
 
-// Phase 2 magic-link auth: distinct error codes so clients can tell
-// "wrong code" from "expired code" from "too many tries" without parsing
-// human-readable messages.
-//
-// `SESSION_EXPIRED` is a 401 (the session middleware peels it off the
-// Authorization header). The other three are 400s — they describe a
-// client-supplied request body that the server rejected.
+// Phase 2 magic-link auth error codes:
+//   - `SESSION_EXPIRED` (401) — peeled off by the session middleware;
+//     covers missing / malformed / revoked / expired bearer headers.
+//   - `INVALID_EMAIL`  (400) — the email shape is unparseable.
+//   - `INVALID_CODE`   (400) — catch-all for magic-code verification
+//     failure (wrong code, unknown / expired / consumed / locked
+//     request_id). Deliberately one signal so probing for live
+//     request_ids doesn't work.
 
 #[derive(Debug, Serialize)]
 struct ErrorEnvelope {
@@ -92,23 +93,13 @@ impl AppError {
         }
     }
 
+    /// Catch-all for every magic-code verification failure: wrong code,
+    /// unknown `request_id`, consumed-already, expired, or attempt-locked.
+    /// We deliberately don't distinguish them on the wire — see
+    /// `routes_auth::verify_magic_code` for the rationale.
     pub fn invalid_code(message: impl Into<String>) -> Self {
         Self::BadRequest {
             code: "INVALID_CODE",
-            message: message.into(),
-        }
-    }
-
-    pub fn expired_code(message: impl Into<String>) -> Self {
-        Self::BadRequest {
-            code: "EXPIRED_CODE",
-            message: message.into(),
-        }
-    }
-
-    pub fn too_many_attempts(message: impl Into<String>) -> Self {
-        Self::BadRequest {
-            code: "TOO_MANY_ATTEMPTS",
             message: message.into(),
         }
     }
@@ -204,13 +195,7 @@ impl AppError {
                     "Send a syntactically valid email address (RFC-5322-ish)."
                 }
                 "INVALID_CODE" => {
-                    "Re-check the code from the email and retry; if it keeps failing, request a new one."
-                }
-                "EXPIRED_CODE" => {
-                    "Magic codes are valid for 15 minutes. Request a new code via /v1/auth/request."
-                }
-                "TOO_MANY_ATTEMPTS" => {
-                    "This request_id is locked. Request a fresh code via /v1/auth/request."
+                    "Re-check the code; if it keeps failing, has been more than 15 minutes, or you've tried several times, request a new one via /v1/auth/request."
                 }
                 _ => "Fix the request body or parameters and retry.",
             },

--- a/crates/dirt-api/src/lib.rs
+++ b/crates/dirt-api/src/lib.rs
@@ -11,9 +11,11 @@
 
 pub mod auth;
 pub mod config;
+pub mod email;
 pub mod error;
 pub mod rate_limit;
 pub mod routes;
+pub mod routes_auth;
 pub mod turso;
 
 use std::sync::Arc;
@@ -27,6 +29,7 @@ use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 
 pub use config::AppConfig;
+pub use email::EmailSender;
 pub use error::AppError;
 pub use rate_limit::RateLimiter;
 pub use turso::TursoRepo;
@@ -44,12 +47,21 @@ pub const PUSH_BODY_LIMIT: usize = 8 * 1024 * 1024;
 pub struct AppState {
     pub config: Arc<AppConfig>,
     pub repo: Arc<TursoRepo>,
+    pub email: Arc<EmailSender>,
 }
 
 impl AppState {
     #[must_use]
-    pub const fn new(config: Arc<AppConfig>, repo: Arc<TursoRepo>) -> Self {
-        Self { config, repo }
+    pub const fn new(
+        config: Arc<AppConfig>,
+        repo: Arc<TursoRepo>,
+        email: Arc<EmailSender>,
+    ) -> Self {
+        Self {
+            config,
+            repo,
+            email,
+        }
     }
 }
 
@@ -71,7 +83,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/v1/notes/push", push)
         .route("/v1/notes/pull", get(routes::pull_notes))
         .layer(middleware::from_fn_with_state(
-            limiter,
+            limiter.clone(),
             rate_limit::enforce_rate_limit,
         ))
         .layer(middleware::from_fn_with_state(
@@ -79,9 +91,25 @@ pub fn build_router(state: AppState) -> Router {
             auth::require_bearer_token,
         ));
 
+    // Magic-code auth routes. `request` and `verify` are pre-auth (no
+    // session yet); `refresh` and `logout` consume a session token in
+    // their own handler-level extractor. All four go through the rate
+    // limiter so login-flood attempts get the same throttling as sync
+    // traffic.
+    let auth_routes = Router::new()
+        .route("/v1/auth/request", post(routes_auth::request_magic_code))
+        .route("/v1/auth/verify", post(routes_auth::verify_magic_code))
+        .route("/v1/auth/refresh", post(routes_auth::refresh_session))
+        .route("/v1/auth/logout", post(routes_auth::logout_session))
+        .layer(middleware::from_fn_with_state(
+            limiter,
+            rate_limit::enforce_rate_limit,
+        ));
+
     Router::new()
         .route("/healthz", get(routes::healthz))
         .merge(authed)
+        .merge(auth_routes)
         .layer(build_cors_layer())
         .layer(TraceLayer::new_for_http())
         .with_state(state)
@@ -132,6 +160,7 @@ mod tests {
         AppState {
             config: Arc::new(config),
             repo: Arc::new(TursoRepo::dangling()),
+            email: Arc::new(EmailSender::log_only()),
         }
     }
 

--- a/crates/dirt-api/src/lib.rs
+++ b/crates/dirt-api/src/lib.rs
@@ -74,16 +74,21 @@ pub fn build_router(state: AppState) -> Router {
     // noise.
     let push = post(routes::push_notes).layer(DefaultBodyLimit::max(PUSH_BODY_LIMIT));
 
-    // The rate limiter is per-process; it lives behind the auth layer so
-    // unauthenticated probes don't fill the window. Solo phase has a
-    // single shared bearer token so a global limiter is sufficient.
-    let limiter = RateLimiter::new();
+    // Two independent limiters: one for the authenticated /v1/notes/*
+    // routes, one for the publicly-reachable /v1/auth/* routes. Sharing
+    // a single window would let an unauthenticated attacker spend the
+    // whole 600/min budget on /v1/auth/request and force 429s on the
+    // owner's sync traffic — a free DOS vector. Splitting them means a
+    // login-flood can lock out further login attempts but cannot block
+    // the existing sessions' push/pull cycle.
+    let notes_limiter = RateLimiter::new();
+    let auth_limiter = RateLimiter::new();
 
     let authed = Router::new()
         .route("/v1/notes/push", push)
         .route("/v1/notes/pull", get(routes::pull_notes))
         .layer(middleware::from_fn_with_state(
-            limiter.clone(),
+            notes_limiter,
             rate_limit::enforce_rate_limit,
         ))
         .layer(middleware::from_fn_with_state(
@@ -93,16 +98,15 @@ pub fn build_router(state: AppState) -> Router {
 
     // Magic-code auth routes. `request` and `verify` are pre-auth (no
     // session yet); `refresh` and `logout` consume a session token in
-    // their own handler-level extractor. All four go through the rate
-    // limiter so login-flood attempts get the same throttling as sync
-    // traffic.
+    // their own handler-level extractor. All four share a dedicated
+    // limiter so a login-flood doesn't exhaust the sync budget.
     let auth_routes = Router::new()
         .route("/v1/auth/request", post(routes_auth::request_magic_code))
         .route("/v1/auth/verify", post(routes_auth::verify_magic_code))
         .route("/v1/auth/refresh", post(routes_auth::refresh_session))
         .route("/v1/auth/logout", post(routes_auth::logout_session))
         .layer(middleware::from_fn_with_state(
-            limiter,
+            auth_limiter,
             rate_limit::enforce_rate_limit,
         ));
 

--- a/crates/dirt-api/src/main.rs
+++ b/crates/dirt-api/src/main.rs
@@ -11,7 +11,7 @@
 
 use std::sync::Arc;
 
-use dirt_api::{build_router, AppConfig, AppState, TursoRepo};
+use dirt_api::{build_router, AppConfig, AppState, EmailSender, TursoRepo};
 
 const STACK_SIZE: usize = 8 * 1024 * 1024;
 
@@ -55,7 +55,8 @@ fn run_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let repo = Arc::new(
             TursoRepo::connect(&config.turso_database_url, &config.turso_auth_token).await?,
         );
-        let state = AppState::new(config.clone(), repo);
+        let email = Arc::new(EmailSender::from_env());
+        let state = AppState::new(config.clone(), repo, email);
 
         let bind_addr = config.bind_addr.clone();
         let router = build_router(state);

--- a/crates/dirt-api/src/routes_auth.rs
+++ b/crates/dirt-api/src/routes_auth.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::error::AppError;
-use crate::turso::SessionRow;
+use crate::turso::{InsertMagicCodeOutcome, SessionRow};
 use crate::AppState;
 
 /// Magic-code lifetime. 15 minutes is long enough to switch tabs, deal
@@ -68,20 +68,39 @@ pub async fn request_magic_code(
 ) -> Result<Json<RequestResponse>, AppError> {
     let email = normalize_email(&body.email)?;
     let now_ms = now_ms();
+    let request_id = uuid::Uuid::now_v7().to_string();
+    let code = generate_six_digit_code();
+    let code_hash = hash_code(&request_id, &code);
+    let expires_at_ms = now_ms + CODE_TTL_MS;
 
-    // Per-email cooldown. The global auth_limiter caps total /v1/auth
-    // call volume (600/min); on its own that doesn't stop an attacker
-    // from spending the whole budget against one victim's inbox. Reject
-    // a re-request if we already have a live unconsumed code for this
-    // email that's less than REQUEST_COOLDOWN_MS old.
-    if let Some(last_created_ms) = state
+    // Per-email cooldown gate is folded into the repo method so the
+    // SELECT, reap, and INSERT all run inside a single
+    // `BEGIN IMMEDIATE` / `COMMIT` transaction — without that, two
+    // concurrent `/v1/auth/request` for the same email can both pass
+    // a separate-conn cooldown SELECT, both insert, and (post-Resend)
+    // both email the victim. Locked codes (5+ failed attempts) do not
+    // count as "live" here, so a user who exhausted their attempts can
+    // immediately request a fresh code.
+    //
+    // NOTE: the limiter behind this is per-process. On a multi-instance
+    // deployment (e.g. Vercel scaling out), a determined attacker could
+    // amplify across instances. Solo-phase deploy is single-process per
+    // invocation; revisit when we move beyond that.
+    let outcome = state
         .repo
-        .last_live_magic_code_created_at(&email, now_ms)
-        .await?
-    {
-        let elapsed_ms = now_ms.saturating_sub(last_created_ms);
-        if elapsed_ms < REQUEST_COOLDOWN_MS {
-            let retry_after_ms = REQUEST_COOLDOWN_MS - elapsed_ms;
+        .try_insert_magic_code_with_cooldown(
+            &request_id,
+            &email,
+            &code_hash,
+            now_ms,
+            expires_at_ms,
+            REQUEST_COOLDOWN_MS,
+        )
+        .await?;
+
+    match outcome {
+        InsertMagicCodeOutcome::Inserted => {}
+        InsertMagicCodeOutcome::OnCooldown { retry_after_ms } => {
             // Round up to the nearest whole second — `(ms + 999) / 1000`
             // — so a sub-1s wait doesn't round to 0 and look like
             // "retry immediately".
@@ -94,17 +113,6 @@ pub async fn request_magic_code(
             ));
         }
     }
-
-    let request_id = uuid::Uuid::now_v7().to_string();
-    let code = generate_six_digit_code();
-    let code_hash = hash_code(&request_id, &code);
-
-    let expires_at_ms = now_ms + CODE_TTL_MS;
-
-    state
-        .repo
-        .insert_magic_code(&request_id, &email, &code_hash, now_ms, expires_at_ms)
-        .await?;
 
     state.email.send_magic_code(&email, &code).await?;
 
@@ -834,6 +842,50 @@ mod tests {
         assert!(
             (1..=60).contains(&retry),
             "retry_after_secs out of range: {retry}"
+        );
+    }
+
+    /// A code that has been locked by 5 wrong guesses is functionally
+    /// dead, so the per-email cooldown must not treat it as a "live"
+    /// row — otherwise the user has to wait 60 s after lockout before
+    /// requesting a fresh code, which is confusing UX. The cooldown
+    /// SQL filters on `attempts < MAX_CODE_ATTEMPTS`; this test
+    /// verifies the route honours that.
+    #[tokio::test(flavor = "current_thread")]
+    async fn locked_code_does_not_block_immediate_re_request() {
+        let fx = build_test_router().await;
+        let email = "lock@example.com";
+        let request_id = seed_code(&fx.state, email, "111111").await;
+
+        // Exhaust the attempt cap with wrong codes.
+        for _ in 0..crate::turso::MAX_CODE_ATTEMPTS {
+            fx.router
+                .clone()
+                .oneshot(
+                    json_request(
+                        "POST",
+                        "/v1/auth/verify",
+                        json!({ "request_id": request_id, "code": "999999" }),
+                    )
+                    .await,
+                )
+                .await
+                .unwrap();
+        }
+
+        // The locked row's `consumed_at` is still NULL and `expires_at`
+        // is still in the future — but the cooldown query should skip
+        // it because `attempts >= MAX`. A fresh /v1/auth/request must
+        // succeed immediately rather than 429.
+        let resp = fx
+            .router
+            .oneshot(json_request("POST", "/v1/auth/request", json!({ "email": email })).await)
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "locked code blocked the re-request — cooldown SQL is missing the attempts filter"
         );
     }
 

--- a/crates/dirt-api/src/routes_auth.rs
+++ b/crates/dirt-api/src/routes_auth.rs
@@ -770,6 +770,51 @@ mod tests {
         assert_eq!(body["error"]["code"], "SESSION_EXPIRED");
     }
 
+    /// A session whose `expires_at` is in the past must come back as
+    /// `SESSION_EXPIRED` from `/v1/auth/refresh`. The lookup query
+    /// already filters `expires_at > ?`, so this is a regression
+    /// guard — collapsing the filter would silently let expired
+    /// sessions refresh themselves indefinitely.
+    #[tokio::test(flavor = "current_thread")]
+    async fn refresh_with_expired_session_returns_session_expired() {
+        let fx = build_test_router().await;
+
+        // Insert a session whose expires_at is way in the past, then
+        // forge an Authorization header for its token by hashing the
+        // raw token the way mint_session would.
+        let now = now_ms();
+        let user_id = fx
+            .state
+            .repo
+            .upsert_user_by_email("expired@example.com", now)
+            .await
+            .unwrap();
+        let raw_token = generate_session_token();
+        let token_hash = sha256_b64url(raw_token.as_bytes());
+        let _ = fx
+            .state
+            .repo
+            .insert_auth_session(&user_id, &token_hash, now - 1_000_000, now - 100)
+            .await
+            .unwrap();
+
+        let resp = fx
+            .router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/auth/refresh")
+                    .header("authorization", format!("Bearer {raw_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body["error"]["code"], "SESSION_EXPIRED");
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn refresh_without_authorization_header_returns_session_expired() {
         let fx = build_test_router().await;
@@ -812,7 +857,9 @@ mod tests {
     /// Two `/v1/auth/request` calls in quick succession against the
     /// same email must rate-limit the second. Without this guard a
     /// 600/min global budget could be spent entirely against one
-    /// victim's inbox once Resend lands.
+    /// victim's inbox once Resend lands. Also checks that the standard
+    /// `Retry-After` HTTP header is set (RFC 7231 §7.1.3) — proxies and
+    /// off-the-shelf retry libraries read the header, not the JSON.
     #[tokio::test(flavor = "current_thread")]
     async fn request_within_cooldown_returns_rate_limited() {
         let fx = build_test_router().await;
@@ -829,19 +876,32 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
 
         // Immediate second request must be rate-limited with a usable
-        // retry_after_secs.
+        // retry_after_secs in BOTH the body and the `Retry-After` header.
         let resp = fx
             .router
             .oneshot(json_request("POST", "/v1/auth/request", body).await)
             .await
             .unwrap();
-        let (status, body) = read_json(resp).await;
-        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
-        assert_eq!(body["error"]["code"], "RATE_LIMITED");
-        let retry = body["error"]["retry_after_secs"].as_u64().unwrap();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        let header_retry = resp
+            .headers()
+            .get("retry-after")
+            .expect("Retry-After header must be present on 429")
+            .to_str()
+            .unwrap()
+            .parse::<u64>()
+            .expect("Retry-After must be a number of seconds");
         assert!(
-            (1..=60).contains(&retry),
-            "retry_after_secs out of range: {retry}"
+            (1..=60).contains(&header_retry),
+            "Retry-After header out of range: {header_retry}"
+        );
+
+        let (_, body) = read_json(resp).await;
+        assert_eq!(body["error"]["code"], "RATE_LIMITED");
+        let body_retry = body["error"]["retry_after_secs"].as_u64().unwrap();
+        assert_eq!(
+            body_retry, header_retry,
+            "body and header must agree on retry-after"
         );
     }
 

--- a/crates/dirt-api/src/routes_auth.rs
+++ b/crates/dirt-api/src/routes_auth.rs
@@ -34,6 +34,14 @@ use crate::AppState;
 /// stolen email doesn't sit indefinitely as a usable login.
 const CODE_TTL_MS: i64 = 15 * 60 * 1000;
 
+/// Per-email cooldown between successful `/v1/auth/request` calls.
+/// Stops an attacker from email-flooding a victim's inbox once Resend
+/// is wired in P2.3. The cooldown is shorter than the code TTL because
+/// a legit user who fat-fingered their email needs to be able to
+/// re-request soon, and the existing 5-attempt cap already covers the
+/// typed-code-wrong case without a fresh send.
+const REQUEST_COOLDOWN_MS: i64 = 60 * 1000;
+
 /// Session lifetime. 30 days matches typical "stay signed in" UX. The
 /// session row's `last_used_at` rolls forward on every authed request,
 /// but `expires_at` only moves on an explicit refresh.
@@ -59,12 +67,38 @@ pub async fn request_magic_code(
     Json(body): Json<RequestBody>,
 ) -> Result<Json<RequestResponse>, AppError> {
     let email = normalize_email(&body.email)?;
+    let now_ms = now_ms();
+
+    // Per-email cooldown. The global auth_limiter caps total /v1/auth
+    // call volume (600/min); on its own that doesn't stop an attacker
+    // from spending the whole budget against one victim's inbox. Reject
+    // a re-request if we already have a live unconsumed code for this
+    // email that's less than REQUEST_COOLDOWN_MS old.
+    if let Some(last_created_ms) = state
+        .repo
+        .last_live_magic_code_created_at(&email, now_ms)
+        .await?
+    {
+        let elapsed_ms = now_ms.saturating_sub(last_created_ms);
+        if elapsed_ms < REQUEST_COOLDOWN_MS {
+            let retry_after_ms = REQUEST_COOLDOWN_MS - elapsed_ms;
+            // Round up to the nearest whole second — `(ms + 999) / 1000`
+            // — so a sub-1s wait doesn't round to 0 and look like
+            // "retry immediately".
+            let retry_after_secs = u64::try_from((retry_after_ms + 999) / 1000)
+                .unwrap_or(1)
+                .max(1);
+            return Err(AppError::rate_limited(
+                "a magic code was already sent to this email recently; wait before requesting another",
+                retry_after_secs,
+            ));
+        }
+    }
 
     let request_id = uuid::Uuid::now_v7().to_string();
     let code = generate_six_digit_code();
     let code_hash = hash_code(&request_id, &code);
 
-    let now_ms = now_ms();
     let expires_at_ms = now_ms + CODE_TTL_MS;
 
     state
@@ -163,7 +197,22 @@ pub async fn refresh_session(
     let now_ms = now_ms();
     let session = require_authed_session(&state, &headers, now_ms).await?;
 
-    state.repo.revoke_session(&session.id, now_ms).await?;
+    // Concurrent-refresh guard. Two clients carrying the same token
+    // can both pass the lookup above (revoked_at is still NULL on the
+    // shared row), then both call revoke_session, then both call
+    // mint_session — yielding two diverged live sessions. Make the
+    // revoke the synchronization point: only the caller whose UPDATE
+    // actually flipped revoked_at gets to mint. The loser sees
+    // SESSION_EXPIRED and re-logs-in (or, if a real client, retries
+    // the request and receives the winner's new token via whatever
+    // higher-level coordination it has).
+    let did_revoke = state.repo.revoke_session(&session.id, now_ms).await?;
+    if !did_revoke {
+        return Err(AppError::session_expired(
+            "session was concurrently refreshed by another caller",
+        ));
+    }
+
     let (session_token, session_id, expires_at_ms) =
         mint_session(&state, &session.user_id, now_ms).await?;
 
@@ -182,7 +231,10 @@ pub async fn logout_session(
 ) -> Result<Response, AppError> {
     let now_ms = now_ms();
     let session = require_authed_session(&state, &headers, now_ms).await?;
-    state.repo.revoke_session(&session.id, now_ms).await?;
+    // Idempotent: we're fine if a concurrent logout/refresh already
+    // flipped revoked_at — the user's intent ("I want this token dead")
+    // is satisfied either way.
+    let _ = state.repo.revoke_session(&session.id, now_ms).await?;
     Ok((StatusCode::NO_CONTENT, ()).into_response())
 }
 
@@ -749,6 +801,135 @@ mod tests {
         assert_eq!(body["error"]["code"], "INVALID_EMAIL");
     }
 
+    /// Two `/v1/auth/request` calls in quick succession against the
+    /// same email must rate-limit the second. Without this guard a
+    /// 600/min global budget could be spent entirely against one
+    /// victim's inbox once Resend lands.
+    #[tokio::test(flavor = "current_thread")]
+    async fn request_within_cooldown_returns_rate_limited() {
+        let fx = build_test_router().await;
+
+        let body = json!({ "email": "cooldown@example.com" });
+
+        // First request succeeds.
+        let resp = fx
+            .router
+            .clone()
+            .oneshot(json_request("POST", "/v1/auth/request", body.clone()).await)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Immediate second request must be rate-limited with a usable
+        // retry_after_secs.
+        let resp = fx
+            .router
+            .oneshot(json_request("POST", "/v1/auth/request", body).await)
+            .await
+            .unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(body["error"]["code"], "RATE_LIMITED");
+        let retry = body["error"]["retry_after_secs"].as_u64().unwrap();
+        assert!(
+            (1..=60).contains(&retry),
+            "retry_after_secs out of range: {retry}"
+        );
+    }
+
+    /// `revoke_session` must be the synchronization point for
+    /// concurrent refresh: the first call wins, every subsequent call
+    /// for the same `session_id` returns false. Direct repo test (a
+    /// router-level test would need real concurrency to trigger).
+    #[tokio::test(flavor = "current_thread")]
+    async fn revoke_session_returns_true_only_for_the_first_caller() {
+        let fx = build_test_router().await;
+        let now = now_ms();
+        let user_id = fx
+            .state
+            .repo
+            .upsert_user_by_email("race@example.com", now)
+            .await
+            .unwrap();
+        let session_id = fx
+            .state
+            .repo
+            .insert_auth_session(&user_id, "fake-hash", now, now + 1_000_000)
+            .await
+            .unwrap();
+
+        assert!(fx
+            .state
+            .repo
+            .revoke_session(&session_id, now)
+            .await
+            .unwrap());
+        assert!(!fx
+            .state
+            .repo
+            .revoke_session(&session_id, now + 1)
+            .await
+            .unwrap());
+    }
+
+    /// `insert_magic_code` opportunistically reaps expired or consumed
+    /// rows for the same email. Without this the table grows without
+    /// bound for any active address.
+    #[tokio::test(flavor = "current_thread")]
+    async fn insert_magic_code_reaps_dead_rows_for_same_email() {
+        let fx = build_test_router().await;
+        let email = "reap@example.com";
+
+        // An expired row.
+        let stale_request_id = uuid::Uuid::now_v7().to_string();
+        fx.state
+            .repo
+            .insert_magic_code(
+                &stale_request_id,
+                email,
+                &hash_code(&stale_request_id, "111111"),
+                0,
+                1, // already past
+            )
+            .await
+            .unwrap();
+
+        // A second insert for the same email at "now" should reap the
+        // stale row before inserting the new one.
+        let fresh_request_id = uuid::Uuid::now_v7().to_string();
+        let now = now_ms();
+        fx.state
+            .repo
+            .insert_magic_code(
+                &fresh_request_id,
+                email,
+                &hash_code(&fresh_request_id, "222222"),
+                now,
+                now + CODE_TTL_MS,
+            )
+            .await
+            .unwrap();
+
+        // Verify the stale row no longer matches by trying to consume
+        // it — this also exercises the route layer's collapse-into-
+        // INVALID_CODE behaviour.
+        let resp = fx
+            .router
+            .oneshot(
+                json_request(
+                    "POST",
+                    "/v1/auth/verify",
+                    json!({ "request_id": stale_request_id, "code": "111111" }),
+                )
+                .await,
+            )
+            .await
+            .unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["code"], "INVALID_CODE");
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn verify_with_malformed_code_returns_invalid_code() {
         let fx = build_test_router().await;
@@ -788,6 +969,20 @@ mod tests {
         assert!(normalize_email("nodomain@").is_err());
         assert!(normalize_email("two@@signs.com").is_err());
         assert!(normalize_email("nodot@localhost").is_err());
+    }
+
+    #[test]
+    fn normalize_email_rejects_over_254_chars() {
+        // RFC 5321 caps total email length at 254 octets — anything
+        // longer is automatically invalid.
+        let local = "a".repeat(243);
+        let too_long = format!("{local}@example.com"); // 243 + 1 + 11 = 255
+        assert_eq!(too_long.len(), 255);
+        assert!(normalize_email(&too_long).is_err());
+
+        let exactly_254 = format!("{}@example.com", "a".repeat(242));
+        assert_eq!(exactly_254.len(), 254);
+        assert!(normalize_email(&exactly_254).is_ok());
     }
 
     #[test]

--- a/crates/dirt-api/src/routes_auth.rs
+++ b/crates/dirt-api/src/routes_auth.rs
@@ -20,12 +20,13 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
+use rand::rngs::OsRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::error::AppError;
-use crate::turso::{ConsumeFailure, SessionRow};
+use crate::turso::SessionRow;
 use crate::AppState;
 
 /// Magic-code lifetime. 15 minutes is long enough to switch tabs, deal
@@ -111,25 +112,25 @@ pub async fn verify_magic_code(
     let code_hash = hash_code(request_id, &body.code);
     let now_ms = now_ms();
 
+    // Every failure mode collapses to INVALID_CODE on the wire.
+    // Distinct error codes (EXPIRED / TOO_MANY_ATTEMPTS) would let a
+    // probing attacker tell "this request_id never existed" from "this
+    // request_id existed but expired/locked" — which is exactly the
+    // signal the catch-all is meant to deny.
+    //
+    // The repo still distinguishes these for server-side log
+    // diagnostics, but the user-facing error is one shape with a fix
+    // message that covers all three branches.
     let email = match state
         .repo
         .consume_magic_code(request_id, &code_hash, now_ms)
         .await?
     {
         Ok(email) => email,
-        Err(ConsumeFailure::InvalidCode) => {
+        Err(failure) => {
+            tracing::debug!(target: "dirt_api::auth", "consume_magic_code failed: {failure:?}");
             return Err(AppError::invalid_code(
-                "request_id and code do not match an outstanding magic code",
-            ));
-        }
-        Err(ConsumeFailure::Expired) => {
-            return Err(AppError::expired_code(
-                "this magic code has expired; request a new one",
-            ));
-        }
-        Err(ConsumeFailure::TooManyAttempts) => {
-            return Err(AppError::too_many_attempts(
-                "this request_id is locked after too many failed attempts; request a new code",
+                "request_id + code do not match a usable magic code (it may be wrong, expired, or locked after too many attempts)",
             ));
         }
     };
@@ -271,7 +272,15 @@ fn normalize_email(raw: &str) -> Result<String, AppError> {
 }
 
 fn generate_six_digit_code() -> String {
-    let n = rand::Rng::gen_range(&mut rand::thread_rng(), 0..1_000_000);
+    // OsRng for auth-critical randomness — explicit about going to the
+    // OS CSPRNG rather than relying on `thread_rng`'s seeding being
+    // cryptographically secure on every target.
+    //
+    // `next_u32() % 1_000_000` has a small modulo bias (about 0.024%)
+    // since 2^32 isn't a multiple of 1e6. For a 6-digit auth code the
+    // bias is well below the 1-in-200,000 floor that the 5-attempt cap
+    // already enforces, so it's not worth a rejection-sampling loop.
+    let n = OsRng.next_u32() % 1_000_000;
     format!("{n:06}")
 }
 
@@ -281,7 +290,7 @@ fn is_six_digit_code(s: &str) -> bool {
 
 fn generate_session_token() -> String {
     let mut bytes = [0u8; 32];
-    rand::thread_rng().fill_bytes(&mut bytes);
+    OsRng.fill_bytes(&mut bytes);
     URL_SAFE_NO_PAD.encode(bytes)
 }
 
@@ -310,21 +319,36 @@ mod tests {
 
     use super::*;
     use crate::config::{AppConfig, ServerToken};
-    use crate::email::EmailSender;
+    use crate::email::{CapturedSends, EmailSender};
+    use crate::turso::TempDb;
     use crate::TursoRepo;
 
-    async fn build_test_router() -> (Router, AppState) {
+    /// Test fixture. Holds the `TempDb` guard so the scratch DB file is
+    /// removed when the test scope exits.
+    struct Fixture {
+        router: Router,
+        state: AppState,
+        captured: CapturedSends,
+        _temp_db: TempDb,
+    }
+
+    async fn build_test_router() -> Fixture {
         let config = AppConfig {
             bind_addr: "127.0.0.1:0".into(),
             turso_database_url: "libsql://unused.test".into(),
             turso_auth_token: "unused".into(),
             server_token: ServerToken(b"unused-32-byte-server-token-abcdef".to_vec()),
         };
-        let repo = Arc::new(TursoRepo::connect_in_memory().await.unwrap());
-        let email = Arc::new(EmailSender::log_only());
-        let state = AppState::new(Arc::new(config), repo, email);
+        let temp_db = TursoRepo::connect_temp_db().await.unwrap();
+        let (sender, captured) = EmailSender::capture();
+        let state = AppState::new(Arc::new(config), temp_db.repo.clone(), Arc::new(sender));
         let router = crate::build_router(state.clone());
-        (router, state)
+        Fixture {
+            router,
+            state,
+            captured,
+            _temp_db: temp_db,
+        }
     }
 
     // Kept `async` even though the body never awaits, so the call sites
@@ -367,12 +391,14 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn request_then_verify_round_trip() {
-        let (router, state) = build_test_router().await;
+        let fx = build_test_router().await;
 
-        // Step 1: client requests a code. Response carries an opaque
-        // request_id and an expiry; the actual code is in the email
-        // (here: tracing log). We seed via repo for the verify step.
-        let resp = router
+        // Step 1: client requests a code. The capture-mode EmailSender
+        // stashes the (email, code) pair for us so we can submit the
+        // *real* code that /v1/auth/request minted, instead of seeding
+        // a parallel one.
+        let resp = fx
+            .router
             .clone()
             .oneshot(
                 json_request(
@@ -386,18 +412,25 @@ mod tests {
             .unwrap();
         let (status, body) = read_json(resp).await;
         assert_eq!(status, StatusCode::OK);
-        assert!(body.get("request_id").and_then(Value::as_str).is_some());
+        let request_id = body["request_id"].as_str().unwrap().to_string();
+        assert!(uuid::Uuid::parse_str(&request_id).is_ok());
         assert!(body.get("expires_at_ms").and_then(Value::as_i64).is_some());
 
-        // Step 2: seed a known code and verify with it.
-        let request_id = seed_code(&state, "user@example.com", "424242").await;
-        let resp = router
+        let captured = fx.captured.lock().unwrap().clone();
+        assert_eq!(captured.len(), 1, "expected exactly one captured send");
+        let (sent_to, code) = captured.into_iter().next().unwrap();
+        assert_eq!(sent_to, "user@example.com");
+        assert!(is_six_digit_code(&code), "captured code wasn't 6 digits");
+
+        // Step 2: verify with the actual minted code.
+        let resp = fx
+            .router
             .clone()
             .oneshot(
                 json_request(
                     "POST",
                     "/v1/auth/verify",
-                    json!({ "request_id": request_id, "code": "424242" }),
+                    json!({ "request_id": request_id, "code": code }),
                 )
                 .await,
             )
@@ -406,17 +439,18 @@ mod tests {
         let (status, body) = read_json(resp).await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body["email"], "user@example.com");
-        assert!(body["session_token"].as_str().unwrap().len() == 43);
+        assert_eq!(body["session_token"].as_str().unwrap().len(), 43);
         assert!(uuid::Uuid::parse_str(body["user_id"].as_str().unwrap()).is_ok());
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn verify_with_wrong_code_returns_invalid_code_and_locks_after_max_attempts() {
-        let (router, state) = build_test_router().await;
-        let request_id = seed_code(&state, "user@example.com", "111111").await;
+        let fx = build_test_router().await;
+        let request_id = seed_code(&fx.state, "user@example.com", "111111").await;
 
         for _ in 0..crate::turso::MAX_CODE_ATTEMPTS {
-            let resp = router
+            let resp = fx
+                .router
                 .clone()
                 .oneshot(
                     json_request(
@@ -433,9 +467,13 @@ mod tests {
             assert_eq!(body["error"]["code"], "INVALID_CODE");
         }
 
-        // Sixth try (with the now-correct code) fails with TOO_MANY_ATTEMPTS,
-        // proving the attempts counter actually locked the row.
-        let resp = router
+        // Sixth try (with the now-correct code) still fails — the
+        // INVALID_CODE catch-all now covers "locked after too many
+        // attempts" too, so the attacker can't tell why their code
+        // didn't work. The row IS locked: the only way out is a fresh
+        // /v1/auth/request.
+        let resp = fx
+            .router
             .clone()
             .oneshot(
                 json_request(
@@ -449,23 +487,24 @@ mod tests {
             .unwrap();
         let (status, body) = read_json(resp).await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
-        assert_eq!(body["error"]["code"], "TOO_MANY_ATTEMPTS");
+        assert_eq!(body["error"]["code"], "INVALID_CODE");
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn verify_expired_code_returns_expired_code() {
-        let (router, state) = build_test_router().await;
+    async fn verify_expired_code_returns_invalid_code() {
+        let fx = build_test_router().await;
         // Seed a row with expires_at already past.
         let request_id = uuid::Uuid::now_v7().to_string();
         let code = "222222";
         let code_hash = hash_code(&request_id, code);
-        state
+        fx.state
             .repo
             .insert_magic_code(&request_id, "user@example.com", &code_hash, 0, 1)
             .await
             .unwrap();
 
-        let resp = router
+        let resp = fx
+            .router
             .oneshot(
                 json_request(
                     "POST",
@@ -478,16 +517,79 @@ mod tests {
             .unwrap();
         let (status, body) = read_json(resp).await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
-        assert_eq!(body["error"]["code"], "EXPIRED_CODE");
+        // Expired collapses to INVALID_CODE so an attacker can't
+        // distinguish "this request_id never existed" from "it existed
+        // but expired".
+        assert_eq!(body["error"]["code"], "INVALID_CODE");
+    }
+
+    /// Replaying a successfully-consumed code on the same `request_id`
+    /// must come back as `INVALID_CODE`. The `consumed_at` guard in the
+    /// success-path UPDATE is what enforces this.
+    #[tokio::test(flavor = "current_thread")]
+    async fn verify_replay_after_success_returns_invalid_code() {
+        let fx = build_test_router().await;
+        let request_id = seed_code(&fx.state, "user@example.com", "555555").await;
+
+        let body = json!({ "request_id": request_id, "code": "555555" });
+
+        let resp = fx
+            .router
+            .clone()
+            .oneshot(json_request("POST", "/v1/auth/verify", body.clone()).await)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let resp = fx
+            .router
+            .oneshot(json_request("POST", "/v1/auth/verify", body).await)
+            .await
+            .unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["code"], "INVALID_CODE");
+    }
+
+    /// Logging in twice with the same email must return the same
+    /// `user_id`. Guards the `ON CONFLICT(email)` path on the users
+    /// upsert from a regression that minted a fresh user per login.
+    #[tokio::test(flavor = "current_thread")]
+    async fn upsert_user_by_email_is_idempotent_across_logins() {
+        let fx = build_test_router().await;
+
+        let mut user_ids = Vec::new();
+        for code in ["666666", "777777"] {
+            let request_id = seed_code(&fx.state, "twice@example.com", code).await;
+            let resp = fx
+                .router
+                .clone()
+                .oneshot(
+                    json_request(
+                        "POST",
+                        "/v1/auth/verify",
+                        json!({ "request_id": request_id, "code": code }),
+                    )
+                    .await,
+                )
+                .await
+                .unwrap();
+            let (status, body) = read_json(resp).await;
+            assert_eq!(status, StatusCode::OK);
+            user_ids.push(body["user_id"].as_str().unwrap().to_string());
+        }
+
+        assert_eq!(user_ids[0], user_ids[1], "same email yielded a new user_id");
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn refresh_rotates_session_and_revokes_old_token() {
-        let (router, state) = build_test_router().await;
-        let request_id = seed_code(&state, "user@example.com", "333333").await;
+        let fx = build_test_router().await;
+        let request_id = seed_code(&fx.state, "user@example.com", "333333").await;
 
         // verify → first session token
-        let resp = router
+        let resp = fx
+            .router
             .clone()
             .oneshot(
                 json_request(
@@ -503,7 +605,8 @@ mod tests {
         let token_a = body["session_token"].as_str().unwrap().to_string();
 
         // refresh → second session token
-        let resp = router
+        let resp = fx
+            .router
             .clone()
             .oneshot(
                 Request::builder()
@@ -521,7 +624,8 @@ mod tests {
         assert_ne!(token_a, token_b);
 
         // The old token should now be SESSION_EXPIRED on logout.
-        let resp = router
+        let resp = fx
+            .router
             .clone()
             .oneshot(
                 Request::builder()
@@ -538,7 +642,8 @@ mod tests {
         assert_eq!(body["error"]["code"], "SESSION_EXPIRED");
 
         // The new token still works (logout it).
-        let resp = router
+        let resp = fx
+            .router
             .oneshot(
                 Request::builder()
                     .method("POST")
@@ -554,10 +659,11 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn logout_then_reuse_returns_session_expired() {
-        let (router, state) = build_test_router().await;
-        let request_id = seed_code(&state, "user@example.com", "444444").await;
+        let fx = build_test_router().await;
+        let request_id = seed_code(&fx.state, "user@example.com", "444444").await;
 
-        let resp = router
+        let resp = fx
+            .router
             .clone()
             .oneshot(
                 json_request(
@@ -572,7 +678,8 @@ mod tests {
         let (_, body) = read_json(resp).await;
         let token = body["session_token"].as_str().unwrap().to_string();
 
-        let resp = router
+        let resp = fx
+            .router
             .clone()
             .oneshot(
                 Request::builder()
@@ -586,7 +693,8 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NO_CONTENT);
 
-        let resp = router
+        let resp = fx
+            .router
             .oneshot(
                 Request::builder()
                     .method("POST")
@@ -604,8 +712,9 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn refresh_without_authorization_header_returns_session_expired() {
-        let (router, _) = build_test_router().await;
-        let resp = router
+        let fx = build_test_router().await;
+        let resp = fx
+            .router
             .oneshot(
                 Request::builder()
                     .method("POST")
@@ -622,8 +731,9 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn request_with_garbage_email_returns_invalid_email() {
-        let (router, _) = build_test_router().await;
-        let resp = router
+        let fx = build_test_router().await;
+        let resp = fx
+            .router
             .oneshot(
                 json_request(
                     "POST",
@@ -641,9 +751,10 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn verify_with_malformed_code_returns_invalid_code() {
-        let (router, _) = build_test_router().await;
+        let fx = build_test_router().await;
         let request_id = uuid::Uuid::now_v7().to_string();
-        let resp = router
+        let resp = fx
+            .router
             .oneshot(
                 json_request(
                     "POST",

--- a/crates/dirt-api/src/routes_auth.rs
+++ b/crates/dirt-api/src/routes_auth.rs
@@ -924,6 +924,83 @@ mod tests {
             .unwrap());
     }
 
+    /// Exercises the production transactional path
+    /// (`try_insert_magic_code_with_cooldown`) end-to-end on the repo.
+    /// Seeds an expired row, then calls the production method with the
+    /// cooldown disabled, and verifies (a) the new row is in place and
+    /// (b) the stale row was reaped — proving the reaper runs inside
+    /// the transaction the route relies on, not just in the test-only
+    /// `insert_magic_code` primitive.
+    #[tokio::test(flavor = "current_thread")]
+    async fn try_insert_with_cooldown_reaps_inside_transaction() {
+        let fx = build_test_router().await;
+        let email = "txn-reap@example.com";
+
+        // Stale row: expired.
+        let stale_id = uuid::Uuid::now_v7().to_string();
+        fx.state
+            .repo
+            .insert_magic_code(
+                &stale_id,
+                email,
+                &hash_code(&stale_id, "111111"),
+                0,
+                1, // expires_at way in the past
+            )
+            .await
+            .unwrap();
+
+        // Production path with cooldown=0 so the cooldown gate is a
+        // no-op; we only care about the reap+insert atomic block.
+        let now = now_ms();
+        let fresh_id = uuid::Uuid::now_v7().to_string();
+        let outcome = fx
+            .state
+            .repo
+            .try_insert_magic_code_with_cooldown(
+                &fresh_id,
+                email,
+                &hash_code(&fresh_id, "222222"),
+                now,
+                now + CODE_TTL_MS,
+                0,
+            )
+            .await
+            .unwrap();
+        assert_eq!(outcome, crate::turso::InsertMagicCodeOutcome::Inserted);
+
+        // Stale row must be gone (consume returns InvalidCode); fresh
+        // row is consumable.
+        let resp = fx
+            .router
+            .clone()
+            .oneshot(
+                json_request(
+                    "POST",
+                    "/v1/auth/verify",
+                    json!({ "request_id": stale_id, "code": "111111" }),
+                )
+                .await,
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let resp = fx
+            .router
+            .oneshot(
+                json_request(
+                    "POST",
+                    "/v1/auth/verify",
+                    json!({ "request_id": fresh_id, "code": "222222" }),
+                )
+                .await,
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
     /// `insert_magic_code` opportunistically reaps expired or consumed
     /// rows for the same email. Without this the table grows without
     /// bound for any active address.

--- a/crates/dirt-api/src/routes_auth.rs
+++ b/crates/dirt-api/src/routes_auth.rs
@@ -1,0 +1,718 @@
+//! Magic-code auth endpoints.
+//!
+//! Four routes wired under `/v1/auth/*`:
+//!
+//!   - `POST /v1/auth/request`  — start a login by emailing a code.
+//!   - `POST /v1/auth/verify`   — exchange (`request_id`, code) for a session.
+//!   - `POST /v1/auth/refresh`  — rotate a session token (revokes the old).
+//!   - `POST /v1/auth/logout`   — revoke the current session.
+//!
+//! The first two are public; rate limiting on `/v1/*` keeps them honest.
+//! `refresh` and `logout` consume `Authorization: Bearer <session-token>`
+//! and resolve it via `TursoRepo::lookup_session_by_token_hash`.
+//!
+//! All on-the-wire secrets (codes, session tokens) live only in the
+//! response of the route that mints them. The DB stores sha256 hashes.
+
+use axum::extract::State;
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::error::AppError;
+use crate::turso::{ConsumeFailure, SessionRow};
+use crate::AppState;
+
+/// Magic-code lifetime. 15 minutes is long enough to switch tabs, deal
+/// with a phone unlock, retype a typo'd code; short enough that a
+/// stolen email doesn't sit indefinitely as a usable login.
+const CODE_TTL_MS: i64 = 15 * 60 * 1000;
+
+/// Session lifetime. 30 days matches typical "stay signed in" UX. The
+/// session row's `last_used_at` rolls forward on every authed request,
+/// but `expires_at` only moves on an explicit refresh.
+const SESSION_TTL_MS: i64 = 30 * 24 * 60 * 60 * 1000;
+
+const BEARER_PREFIX_LEN: usize = "Bearer ".len();
+
+// ---- POST /v1/auth/request ----
+
+#[derive(Debug, Deserialize)]
+pub struct RequestBody {
+    pub email: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RequestResponse {
+    pub request_id: String,
+    pub expires_at_ms: i64,
+}
+
+pub async fn request_magic_code(
+    State(state): State<AppState>,
+    Json(body): Json<RequestBody>,
+) -> Result<Json<RequestResponse>, AppError> {
+    let email = normalize_email(&body.email)?;
+
+    let request_id = uuid::Uuid::now_v7().to_string();
+    let code = generate_six_digit_code();
+    let code_hash = hash_code(&request_id, &code);
+
+    let now_ms = now_ms();
+    let expires_at_ms = now_ms + CODE_TTL_MS;
+
+    state
+        .repo
+        .insert_magic_code(&request_id, &email, &code_hash, now_ms, expires_at_ms)
+        .await?;
+
+    state.email.send_magic_code(&email, &code).await?;
+
+    Ok(Json(RequestResponse {
+        request_id,
+        expires_at_ms,
+    }))
+}
+
+// ---- POST /v1/auth/verify ----
+
+#[derive(Debug, Deserialize)]
+pub struct VerifyBody {
+    pub request_id: String,
+    pub code: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct VerifyResponse {
+    pub session_token: String,
+    pub session_id: String,
+    pub user_id: String,
+    pub email: String,
+    pub expires_at_ms: i64,
+}
+
+pub async fn verify_magic_code(
+    State(state): State<AppState>,
+    Json(body): Json<VerifyBody>,
+) -> Result<Json<VerifyResponse>, AppError> {
+    if !is_six_digit_code(&body.code) {
+        return Err(AppError::invalid_code("code must be exactly 6 digits"));
+    }
+    if uuid::Uuid::parse_str(body.request_id.trim()).is_err() {
+        return Err(AppError::invalid_code("request_id is not a valid UUID"));
+    }
+
+    let request_id = body.request_id.trim();
+    let code_hash = hash_code(request_id, &body.code);
+    let now_ms = now_ms();
+
+    let email = match state
+        .repo
+        .consume_magic_code(request_id, &code_hash, now_ms)
+        .await?
+    {
+        Ok(email) => email,
+        Err(ConsumeFailure::InvalidCode) => {
+            return Err(AppError::invalid_code(
+                "request_id and code do not match an outstanding magic code",
+            ));
+        }
+        Err(ConsumeFailure::Expired) => {
+            return Err(AppError::expired_code(
+                "this magic code has expired; request a new one",
+            ));
+        }
+        Err(ConsumeFailure::TooManyAttempts) => {
+            return Err(AppError::too_many_attempts(
+                "this request_id is locked after too many failed attempts; request a new code",
+            ));
+        }
+    };
+
+    let user_id = state.repo.upsert_user_by_email(&email, now_ms).await?;
+    let (session_token, session_id, expires_at_ms) = mint_session(&state, &user_id, now_ms).await?;
+
+    Ok(Json(VerifyResponse {
+        session_token,
+        session_id,
+        user_id,
+        email,
+        expires_at_ms,
+    }))
+}
+
+// ---- POST /v1/auth/refresh ----
+
+#[derive(Debug, Serialize)]
+pub struct RefreshResponse {
+    pub session_token: String,
+    pub session_id: String,
+    pub expires_at_ms: i64,
+}
+
+pub async fn refresh_session(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<RefreshResponse>, AppError> {
+    let now_ms = now_ms();
+    let session = require_authed_session(&state, &headers, now_ms).await?;
+
+    state.repo.revoke_session(&session.id, now_ms).await?;
+    let (session_token, session_id, expires_at_ms) =
+        mint_session(&state, &session.user_id, now_ms).await?;
+
+    Ok(Json(RefreshResponse {
+        session_token,
+        session_id,
+        expires_at_ms,
+    }))
+}
+
+// ---- POST /v1/auth/logout ----
+
+pub async fn logout_session(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Response, AppError> {
+    let now_ms = now_ms();
+    let session = require_authed_session(&state, &headers, now_ms).await?;
+    state.repo.revoke_session(&session.id, now_ms).await?;
+    Ok((StatusCode::NO_CONTENT, ()).into_response())
+}
+
+// ---- helpers ----
+
+async fn mint_session(
+    state: &AppState,
+    user_id: &str,
+    now_ms: i64,
+) -> Result<(String, String, i64), AppError> {
+    let session_token = generate_session_token();
+    let token_hash = sha256_b64url(session_token.as_bytes());
+    let expires_at_ms = now_ms + SESSION_TTL_MS;
+    let session_id = state
+        .repo
+        .insert_auth_session(user_id, &token_hash, now_ms, expires_at_ms)
+        .await?;
+    Ok((session_token, session_id, expires_at_ms))
+}
+
+/// Pull a session token off the request and resolve it. Returns
+/// `SESSION_EXPIRED` (401) for every "no good session" condition so the
+/// client treats them all as "go log in again".
+async fn require_authed_session(
+    state: &AppState,
+    headers: &HeaderMap,
+    now_ms: i64,
+) -> Result<SessionRow, AppError> {
+    let token = extract_bearer(headers)?;
+    let token_hash = sha256_b64url(token.as_bytes());
+    state
+        .repo
+        .lookup_session_by_token_hash(&token_hash, now_ms)
+        .await?
+        .ok_or_else(|| AppError::session_expired("session token is invalid or expired"))
+}
+
+fn extract_bearer(headers: &HeaderMap) -> Result<String, AppError> {
+    let header_value = headers
+        .get(header::AUTHORIZATION)
+        .ok_or_else(|| AppError::session_expired("missing Authorization header"))?;
+    let header_str = header_value
+        .to_str()
+        .map_err(|_| AppError::session_expired("Authorization header is not valid UTF-8"))?;
+    if header_str.len() < BEARER_PREFIX_LEN
+        || !header_str[..BEARER_PREFIX_LEN].eq_ignore_ascii_case("Bearer ")
+    {
+        return Err(AppError::session_expired(
+            "Authorization header must start with 'Bearer '",
+        ));
+    }
+    Ok(header_str[BEARER_PREFIX_LEN..].to_string())
+}
+
+fn normalize_email(raw: &str) -> Result<String, AppError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::invalid_email("email is empty"));
+    }
+    // We don't try to be RFC 5322 compliant — the magic-code round-trip
+    // is the actual liveness check. Just rule out obvious garbage:
+    // - exactly one '@'
+    // - non-empty local + domain parts
+    // - domain contains a '.'
+    if trimmed.bytes().filter(|&b| b == b'@').count() != 1 {
+        return Err(AppError::invalid_email(
+            "email must contain exactly one '@'",
+        ));
+    }
+    let (local, domain) = trimmed
+        .split_once('@')
+        .ok_or_else(|| AppError::invalid_email("email must contain '@'"))?;
+    if local.is_empty() || domain.is_empty() {
+        return Err(AppError::invalid_email(
+            "email local and domain parts must be non-empty",
+        ));
+    }
+    if !domain.contains('.') {
+        return Err(AppError::invalid_email("email domain must contain a '.'"));
+    }
+    if trimmed.len() > 254 {
+        return Err(AppError::invalid_email(
+            "email exceeds 254 characters (RFC 5321 max)",
+        ));
+    }
+    Ok(trimmed.to_ascii_lowercase())
+}
+
+fn generate_six_digit_code() -> String {
+    let n = rand::Rng::gen_range(&mut rand::thread_rng(), 0..1_000_000);
+    format!("{n:06}")
+}
+
+fn is_six_digit_code(s: &str) -> bool {
+    s.len() == 6 && s.bytes().all(|b| b.is_ascii_digit())
+}
+
+fn generate_session_token() -> String {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn hash_code(request_id: &str, code: &str) -> String {
+    sha256_b64url(format!("{request_id}:{code}").as_bytes())
+}
+
+fn sha256_b64url(input: &[u8]) -> String {
+    let digest = Sha256::digest(input);
+    URL_SAFE_NO_PAD.encode(digest)
+}
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::body::{to_bytes, Body};
+    use axum::http::{Request, StatusCode};
+    use axum::Router;
+    use serde_json::{json, Value};
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::config::{AppConfig, ServerToken};
+    use crate::email::EmailSender;
+    use crate::TursoRepo;
+
+    async fn build_test_router() -> (Router, AppState) {
+        let config = AppConfig {
+            bind_addr: "127.0.0.1:0".into(),
+            turso_database_url: "libsql://unused.test".into(),
+            turso_auth_token: "unused".into(),
+            server_token: ServerToken(b"unused-32-byte-server-token-abcdef".to_vec()),
+        };
+        let repo = Arc::new(TursoRepo::connect_in_memory().await.unwrap());
+        let email = Arc::new(EmailSender::log_only());
+        let state = AppState::new(Arc::new(config), repo, email);
+        let router = crate::build_router(state.clone());
+        (router, state)
+    }
+
+    // Kept `async` even though the body never awaits, so the call sites
+    // can stay in `.oneshot(json_request(...).await,)` form alongside
+    // their genuinely-async neighbours without churn.
+    #[allow(clippy::unused_async)]
+    async fn json_request(method: &str, uri: &str, body: Value) -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap()
+    }
+
+    async fn read_json(resp: axum::response::Response) -> (StatusCode, Value) {
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+        let value: Value = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+        };
+        (status, value)
+    }
+
+    /// Seed a known magic code straight via the repo so tests can
+    /// exercise `/v1/auth/verify` without parsing log output.
+    async fn seed_code(state: &AppState, email: &str, code: &str) -> String {
+        let request_id = uuid::Uuid::now_v7().to_string();
+        let code_hash = hash_code(&request_id, code);
+        let now = now_ms();
+        state
+            .repo
+            .insert_magic_code(&request_id, email, &code_hash, now, now + CODE_TTL_MS)
+            .await
+            .unwrap();
+        request_id
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn request_then_verify_round_trip() {
+        let (router, state) = build_test_router().await;
+
+        // Step 1: client requests a code. Response carries an opaque
+        // request_id and an expiry; the actual code is in the email
+        // (here: tracing log). We seed via repo for the verify step.
+        let resp = router
+            .clone()
+            .oneshot(
+                json_request(
+                    "POST",
+                    "/v1/auth/request",
+                    json!({ "email": "user@example.com" }),
+                )
+                .await,
+            )
+            .await
+            .unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.get("request_id").and_then(Value::as_str).is_some());
+        assert!(body.get("expires_at_ms").and_then(Value::as_i64).is_some());
+
+        // Step 2: seed a known code and verify with it.
+        let request_id = seed_code(&state, "user@example.com", "424242").await;
+        let resp = router
+            .clone()
+            .oneshot(
+                json_request(
+                    "POST",
+                    "/v1/auth/verify",
+                    json!({ "request_id": request_id, "code": "424242" }),
+                )
+                .await,
+            )
+            .await
+            .unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["email"], "user@example.com");
+        assert!(body["session_token"].as_str().unwrap().len() == 43);
+        assert!(uuid::Uuid::parse_str(body["user_id"].as_str().unwrap()).is_ok());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn verify_with_wrong_code_returns_invalid_code_and_locks_after_max_attempts() {
+        let (router, state) = build_test_router().await;
+        let request_id = seed_code(&state, "user@example.com", "111111").await;
+
+        for _ in 0..crate::turso::MAX_CODE_ATTEMPTS {
+            let resp = router
+                .clone()
+                .oneshot(
+                    json_request(
+                        "POST",
+                        "/v1/auth/verify",
+                        json!({ "request_id": request_id, "code": "999999" }),
+                    )
+                    .await,
+                )
+                .await
+                .unwrap();
+            let (status, body) = read_json(resp).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            assert_eq!(body["error"]["code"], "INVALID_CODE");
+        }
+
+        // Sixth try (with the now-correct code) fails with TOO_MANY_ATTEMPTS,
+        // proving the attempts counter actually locked the row.
+        let resp = router
+            .clone()
+            .oneshot(
+                json_request(
+                    "POST",
+                    "/v1/auth/verify",
+                    json!({ "request_id": request_id, "code": "111111" }),
+                )
+                .await,
+            )
+            .await
+            .unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["code"], "TOO_MANY_ATTEMPTS");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn verify_expired_code_returns_expired_code() {
+        let (router, state) = build_test_router().await;
+        // Seed a row with expires_at already past.
+        let request_id = uuid::Uuid::now_v7().to_string();
+        let code = "222222";
+        let code_hash = hash_code(&request_id, code);
+        state
+            .repo
+            .insert_magic_code(&request_id, "user@example.com", &code_hash, 0, 1)
+            .await
+            .unwrap();
+
+        let resp = router
+            .oneshot(
+                json_request(
+                    "POST",
+                    "/v1/auth/verify",
+                    json!({ "request_id": request_id, "code": code }),
+                )
+                .await,
+            )
+            .await
+            .unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["code"], "EXPIRED_CODE");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn refresh_rotates_session_and_revokes_old_token() {
+        let (router, state) = build_test_router().await;
+        let request_id = seed_code(&state, "user@example.com", "333333").await;
+
+        // verify → first session token
+        let resp = router
+            .clone()
+            .oneshot(
+                json_request(
+                    "POST",
+                    "/v1/auth/verify",
+                    json!({ "request_id": request_id, "code": "333333" }),
+                )
+                .await,
+            )
+            .await
+            .unwrap();
+        let (_, body) = read_json(resp).await;
+        let token_a = body["session_token"].as_str().unwrap().to_string();
+
+        // refresh → second session token
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/auth/refresh")
+                    .header("authorization", format!("Bearer {token_a}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::OK);
+        let token_b = body["session_token"].as_str().unwrap().to_string();
+        assert_ne!(token_a, token_b);
+
+        // The old token should now be SESSION_EXPIRED on logout.
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/auth/logout")
+                    .header("authorization", format!("Bearer {token_a}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body["error"]["code"], "SESSION_EXPIRED");
+
+        // The new token still works (logout it).
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/auth/logout")
+                    .header("authorization", format!("Bearer {token_b}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn logout_then_reuse_returns_session_expired() {
+        let (router, state) = build_test_router().await;
+        let request_id = seed_code(&state, "user@example.com", "444444").await;
+
+        let resp = router
+            .clone()
+            .oneshot(
+                json_request(
+                    "POST",
+                    "/v1/auth/verify",
+                    json!({ "request_id": request_id, "code": "444444" }),
+                )
+                .await,
+            )
+            .await
+            .unwrap();
+        let (_, body) = read_json(resp).await;
+        let token = body["session_token"].as_str().unwrap().to_string();
+
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/auth/logout")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/auth/logout")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body["error"]["code"], "SESSION_EXPIRED");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn refresh_without_authorization_header_returns_session_expired() {
+        let (router, _) = build_test_router().await;
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/auth/refresh")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body["error"]["code"], "SESSION_EXPIRED");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn request_with_garbage_email_returns_invalid_email() {
+        let (router, _) = build_test_router().await;
+        let resp = router
+            .oneshot(
+                json_request(
+                    "POST",
+                    "/v1/auth/request",
+                    json!({ "email": "not-an-email" }),
+                )
+                .await,
+            )
+            .await
+            .unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["code"], "INVALID_EMAIL");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn verify_with_malformed_code_returns_invalid_code() {
+        let (router, _) = build_test_router().await;
+        let request_id = uuid::Uuid::now_v7().to_string();
+        let resp = router
+            .oneshot(
+                json_request(
+                    "POST",
+                    "/v1/auth/verify",
+                    json!({ "request_id": request_id, "code": "abc" }),
+                )
+                .await,
+            )
+            .await
+            .unwrap();
+        let (status, body) = read_json(resp).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["code"], "INVALID_CODE");
+    }
+
+    // ---- pure-function tests preserved from before ----
+
+    #[test]
+    fn normalize_email_lowercases_and_trims() {
+        assert_eq!(
+            normalize_email("  Hello@Example.COM ").unwrap(),
+            "hello@example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_email_rejects_garbage() {
+        assert!(normalize_email("").is_err());
+        assert!(normalize_email("no-at-sign").is_err());
+        assert!(normalize_email("@nolocal.com").is_err());
+        assert!(normalize_email("nodomain@").is_err());
+        assert!(normalize_email("two@@signs.com").is_err());
+        assert!(normalize_email("nodot@localhost").is_err());
+    }
+
+    #[test]
+    fn six_digit_code_round_trip() {
+        for _ in 0..100 {
+            let c = generate_six_digit_code();
+            assert!(is_six_digit_code(&c), "rejected own output: {c}");
+        }
+    }
+
+    #[test]
+    fn six_digit_code_validation() {
+        assert!(is_six_digit_code("000000"));
+        assert!(is_six_digit_code("123456"));
+        assert!(!is_six_digit_code("12345"));
+        assert!(!is_six_digit_code("1234567"));
+        assert!(!is_six_digit_code("12345a"));
+        assert!(!is_six_digit_code("      "));
+    }
+
+    #[test]
+    fn hash_binds_code_to_request_id() {
+        // Same code under different request_ids must hash to different
+        // values — otherwise a code from one request could authenticate
+        // against another.
+        let a = hash_code("req-a", "123456");
+        let b = hash_code("req-b", "123456");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn session_token_is_43_url_safe_chars() {
+        let t = generate_session_token();
+        assert_eq!(t.len(), 43);
+        assert!(t
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_'));
+    }
+}

--- a/crates/dirt-api/src/turso.rs
+++ b/crates/dirt-api/src/turso.rs
@@ -54,19 +54,26 @@ impl TursoRepo {
     /// in-memory backend gives each new `connect()` a fresh, empty
     /// schema; `TursoRepo::conn()` opens a new connection per query,
     /// which would mean every query after `bootstrap` saw an empty DB.
+    ///
+    /// Wrapped by `TempDb` so the file is cleaned up on drop — without
+    /// the guard, every `cargo test` invocation litters `$TMPDIR` with
+    /// `.db` and `.db-wal` files.
     #[cfg(test)]
-    pub async fn connect_in_memory() -> Result<Self, AppError> {
+    pub async fn connect_temp_db() -> Result<TempDb, AppError> {
         let path = std::env::temp_dir().join(format!(
             "dirt-api-test-{}.db",
             uuid::Uuid::now_v7().simple()
         ));
-        let db = Builder::new_local(path)
+        let db = Builder::new_local(&path)
             .build()
             .await
             .map_err(|e| AppError::config(format!("failed to build local libsql: {e}")))?;
         let conn = db.connect()?;
         bootstrap(&conn).await?;
-        Ok(Self { db: Some(db) })
+        Ok(TempDb {
+            repo: std::sync::Arc::new(Self { db: Some(db) }),
+            path,
+        })
     }
 
     fn conn(&self) -> Result<Connection, AppError> {
@@ -271,7 +278,38 @@ impl TursoRepo {
             return Ok(Ok(email));
         }
 
-        // Failure path: figure out *why* the UPDATE missed.
+        // Failure path. Bump the attempt counter atomically *before*
+        // diagnosing why the success UPDATE missed — folding the
+        // "is the row still live?" predicate and the "did we fit
+        // under the cap?" predicate into one statement so two
+        // concurrent wrong-code requests can't both slip past the
+        // attempts cap. SQLite-flavored libsql serializes write
+        // statements on the same row, so the atomic predicate
+        // `attempts < MAX_CODE_ATTEMPTS` is honoured exactly once
+        // even under concurrent attempts.
+        //
+        // `affected_increment > 0` ⇒ the row was live (not consumed,
+        //   not expired) and under the cap; the only way the success
+        //   UPDATE could miss while this one hits is a wrong code.
+        // `affected_increment == 0` ⇒ the row is in some terminal
+        //   state — fall through to a SELECT to disambiguate.
+        let affected_increment = conn
+            .execute(
+                "UPDATE magic_codes
+                    SET attempts = attempts + 1
+                  WHERE request_id = ?
+                    AND consumed_at IS NULL
+                    AND expires_at >= ?
+                    AND attempts < ?",
+                libsql::params![request_id, now_ms, MAX_CODE_ATTEMPTS],
+            )
+            .await?;
+
+        if affected_increment > 0 {
+            return Ok(Err(ConsumeFailure::InvalidCode));
+        }
+
+        // Increment missed → row is missing, consumed, expired, or locked.
         let mut rows = conn
             .query(
                 "SELECT consumed_at, expires_at, attempts FROM magic_codes WHERE request_id = ?",
@@ -294,13 +332,10 @@ impl TursoRepo {
         if attempts >= MAX_CODE_ATTEMPTS {
             return Ok(Err(ConsumeFailure::TooManyAttempts));
         }
-        // Reaching here means the code itself was wrong. Bump the
-        // attempt counter so repeated guesses lock out the row.
-        conn.execute(
-            "UPDATE magic_codes SET attempts = attempts + 1 WHERE request_id = ? AND consumed_at IS NULL",
-            libsql::params![request_id],
-        )
-        .await?;
+        // Should be unreachable: increment missed for a row that's
+        // live and under the cap implies a libsql transactional
+        // inconsistency. Treat as an invalid code rather than
+        // silently leaking a 500.
         Ok(Err(ConsumeFailure::InvalidCode))
     }
 
@@ -413,6 +448,34 @@ pub struct SessionRow {
     pub id: String,
     pub user_id: String,
     pub expires_at_ms: i64,
+}
+
+/// Test-only RAII handle around a tempfile-backed `TursoRepo`. Removes
+/// the file (and libsql's `-shm` / `-wal` siblings, if any) on drop so
+/// `cargo test` doesn't accumulate scratch DBs in `$TMPDIR`.
+#[cfg(test)]
+pub struct TempDb {
+    pub repo: std::sync::Arc<TursoRepo>,
+    path: std::path::PathBuf,
+}
+
+#[cfg(test)]
+impl Drop for TempDb {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+        let mut shm = self.path.clone();
+        shm.set_file_name(format!(
+            "{}-shm",
+            self.path.file_name().unwrap_or_default().to_string_lossy()
+        ));
+        let _ = std::fs::remove_file(&shm);
+        let mut wal = self.path.clone();
+        wal.set_file_name(format!(
+            "{}-wal",
+            self.path.file_name().unwrap_or_default().to_string_lossy()
+        ));
+        let _ = std::fs::remove_file(&wal);
+    }
 }
 
 fn parse_pulled_note(row: &libsql::Row) -> Result<Note, AppError> {

--- a/crates/dirt-api/src/turso.rs
+++ b/crates/dirt-api/src/turso.rs
@@ -247,8 +247,8 @@ impl TursoRepo {
         conn.execute(
             "DELETE FROM magic_codes
               WHERE email = ?
-                AND (expires_at < ? OR consumed_at IS NOT NULL)",
-            libsql::params![email, created_at_ms],
+                AND (expires_at < ? OR consumed_at IS NOT NULL OR attempts >= ?)",
+            libsql::params![email, created_at_ms, MAX_CODE_ATTEMPTS],
         )
         .await?;
         conn.execute(
@@ -323,25 +323,48 @@ impl TursoRepo {
             });
         }
 
-        // Reap expired and consumed rows for this email so the table
-        // doesn't grow without bound for any active address.
-        conn.execute(
-            "DELETE FROM magic_codes
-              WHERE email = ?
-                AND (expires_at < ? OR consumed_at IS NOT NULL)",
-            libsql::params![email, created_at_ms],
-        )
-        .await?;
+        // Wrap the post-cooldown DML in a closure-style block so a
+        // failure on DELETE / INSERT doesn't leave the transaction
+        // dangling. libsql remote (Turso WebSocket) doesn't auto-rollback
+        // on connection drop the way local file libsql does, so a stuck
+        // transaction can hold a write lock indefinitely.
+        //
+        // Reaper predicate also picks up locked rows
+        // (`attempts >= MAX_CODE_ATTEMPTS`) — a code that's been brute-
+        // forced into lockout is functionally dead, no point keeping it
+        // around for the rest of its 15-minute TTL.
+        let dml: Result<(), AppError> = async {
+            conn.execute(
+                "DELETE FROM magic_codes
+                  WHERE email = ?
+                    AND (expires_at < ? OR consumed_at IS NOT NULL OR attempts >= ?)",
+                libsql::params![email, created_at_ms, MAX_CODE_ATTEMPTS],
+            )
+            .await?;
 
-        conn.execute(
-            "INSERT INTO magic_codes (request_id, email, code_hash, created_at, expires_at, consumed_at, attempts)
-             VALUES (?, ?, ?, ?, ?, NULL, 0)",
-            libsql::params![request_id, email, code_hash, created_at_ms, expires_at_ms],
-        )
-        .await?;
+            conn.execute(
+                "INSERT INTO magic_codes (request_id, email, code_hash, created_at, expires_at, consumed_at, attempts)
+                 VALUES (?, ?, ?, ?, ?, NULL, 0)",
+                libsql::params![request_id, email, code_hash, created_at_ms, expires_at_ms],
+            )
+            .await?;
 
-        conn.execute("COMMIT", ()).await?;
-        Ok(InsertMagicCodeOutcome::Inserted)
+            conn.execute("COMMIT", ()).await?;
+            Ok(())
+        }
+        .await;
+
+        match dml {
+            Ok(()) => Ok(InsertMagicCodeOutcome::Inserted),
+            Err(err) => {
+                // Best-effort rollback. If ROLLBACK itself fails we
+                // still surface the original error — the connection is
+                // about to drop anyway and SQLite will tear down the
+                // transaction.
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(err)
+            }
+        }
     }
 
     /// Atomically check + consume a magic code. On success returns the
@@ -359,16 +382,24 @@ impl TursoRepo {
     ) -> Result<Result<String, ConsumeFailure>, AppError> {
         let conn = self.conn().await?;
 
-        // Fast path: a single conditional UPDATE guards every check at once.
-        let affected = conn
-            .execute(
+        // Fast path: a single conditional UPDATE guards every check at once
+        // and pulls out the email atomically with `RETURNING`. A separate
+        // SELECT after the UPDATE used to race with the per-email reaper
+        // in `try_insert_magic_code_with_cooldown` — a concurrent
+        // `/v1/auth/request` could delete the just-consumed row (the
+        // reaper targets `consumed_at IS NOT NULL`) before the SELECT,
+        // turning a legitimate verify into a 500. Folding into one
+        // `UPDATE … RETURNING` statement closes that window.
+        let mut rows = conn
+            .query(
                 "UPDATE magic_codes
                     SET consumed_at = ?
                   WHERE request_id = ?
                     AND consumed_at IS NULL
                     AND expires_at >= ?
                     AND code_hash = ?
-                    AND attempts < ?",
+                    AND attempts < ?
+                  RETURNING email",
                 libsql::params![
                     now_ms,
                     request_id,
@@ -379,21 +410,11 @@ impl TursoRepo {
             )
             .await?;
 
-        if affected > 0 {
-            let mut rows = conn
-                .query(
-                    "SELECT email FROM magic_codes WHERE request_id = ?",
-                    libsql::params![request_id],
-                )
-                .await?;
-            let Some(row) = rows.next().await? else {
-                return Err(AppError::internal(
-                    "magic code row vanished between consume and email lookup",
-                ));
-            };
+        if let Some(row) = rows.next().await? {
             let email: String = row.get(0)?;
             return Ok(Ok(email));
         }
+        drop(rows);
 
         // Failure path. Bump the attempt counter atomically *before*
         // diagnosing why the success UPDATE missed — folding the

--- a/crates/dirt-api/src/turso.rs
+++ b/crates/dirt-api/src/turso.rs
@@ -76,12 +76,21 @@ impl TursoRepo {
         })
     }
 
-    fn conn(&self) -> Result<Connection, AppError> {
+    /// Open a connection and turn on FK enforcement on it before
+    /// handing it back. `SQLite` (and libsql) default `foreign_keys`
+    /// to OFF — without this pragma the
+    /// `auth_sessions.user_id ... ON DELETE CASCADE` declaration is
+    /// silently ignored, leaving orphaned session rows when a user is
+    /// deleted. The pragma is per-connection, so since we open a fresh
+    /// connection per query, we re-arm it here every time.
+    async fn conn(&self) -> Result<Connection, AppError> {
         let db = self
             .db
             .as_ref()
             .ok_or_else(|| AppError::internal("TursoRepo used without a live connection"))?;
-        db.connect().map_err(Into::into)
+        let conn = db.connect()?;
+        conn.execute("PRAGMA foreign_keys = ON", ()).await?;
+        Ok(conn)
     }
 
     /// Upsert one note and stamp `server_updated_at` on the server clock.
@@ -95,7 +104,7 @@ impl TursoRepo {
         note: &PushNote<'_>,
         server_now_ms: i64,
     ) -> Result<i64, AppError> {
-        let conn = self.conn()?;
+        let conn = self.conn().await?;
         conn.execute(
             "INSERT INTO notes (id, user_id, content, created_at, client_updated_at, server_updated_at, deleted_at)
              VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -130,7 +139,7 @@ impl TursoRepo {
         cursor_id: Option<&str>,
         limit: usize,
     ) -> Result<Vec<Note>, AppError> {
-        let conn = self.conn()?;
+        let conn = self.conn().await?;
         // Defensive backstop. The routes layer clamps user input to
         // PULL_MAX_LIMIT and adds 1 as a "is there more?" probe row, so
         // we accept up to PULL_MAX_LIMIT + 1 here. Anything wilder
@@ -207,8 +216,9 @@ pub enum ConsumeFailure {
 pub const MAX_CODE_ATTEMPTS: i64 = 5;
 
 impl TursoRepo {
-    /// Insert a fresh magic-code row. `code_hash` is the sha256 hex of
-    /// `format!("{request_id}:{code}")` — never the raw code.
+    /// Insert a fresh magic-code row. `code_hash` is the sha256
+    /// base64url (no padding) of `format!("{request_id}:{code}")` —
+    /// never the raw code.
     pub async fn insert_magic_code(
         &self,
         request_id: &str,
@@ -217,7 +227,7 @@ impl TursoRepo {
         created_at_ms: i64,
         expires_at_ms: i64,
     ) -> Result<(), AppError> {
-        let conn = self.conn()?;
+        let conn = self.conn().await?;
         conn.execute(
             "INSERT INTO magic_codes (request_id, email, code_hash, created_at, expires_at, consumed_at, attempts)
              VALUES (?, ?, ?, ?, ?, NULL, 0)",
@@ -240,7 +250,7 @@ impl TursoRepo {
         expected_code_hash: &str,
         now_ms: i64,
     ) -> Result<Result<String, ConsumeFailure>, AppError> {
-        let conn = self.conn()?;
+        let conn = self.conn().await?;
 
         // Fast path: a single conditional UPDATE guards every check at once.
         let affected = conn
@@ -342,7 +352,7 @@ impl TursoRepo {
     /// Get-or-insert a user row keyed on email. Returns the canonical
     /// `user_id`. `email` must already be normalized (trimmed, lowercase).
     pub async fn upsert_user_by_email(&self, email: &str, now_ms: i64) -> Result<String, AppError> {
-        let conn = self.conn()?;
+        let conn = self.conn().await?;
         let new_id = uuid::Uuid::now_v7().to_string();
         // ON CONFLICT(email) returns the existing row's id, so the caller
         // gets a stable user_id regardless of whether this was the first
@@ -371,7 +381,7 @@ impl TursoRepo {
         created_at_ms: i64,
         expires_at_ms: i64,
     ) -> Result<String, AppError> {
-        let conn = self.conn()?;
+        let conn = self.conn().await?;
         let session_id = uuid::Uuid::now_v7().to_string();
         conn.execute(
             "INSERT INTO auth_sessions (id, user_id, token_hash, created_at, last_used_at, expires_at, revoked_at)
@@ -393,15 +403,26 @@ impl TursoRepo {
     /// Returns None when the session is missing, revoked, or past
     /// `expires_at`.
     ///
-    /// Bumps `last_used_at` as a side effect so the session-token TTL
-    /// rolls forward with use; the row's `expires_at` is *not* touched
-    /// here — refresh is the explicit way to extend a session.
+    /// **Write side-effect:** bumps `last_used_at` on every successful
+    /// lookup so the session's "actively used" telemetry stays current.
+    /// The row's `expires_at` is *not* touched here — `/v1/auth/refresh`
+    /// is the explicit way to extend a session.
+    ///
+    /// In P2.1 only `/v1/auth/refresh` and `/v1/auth/logout` call this,
+    /// so the write-per-call cost is trivial. P2.2 will wire this into
+    /// the `push`/`pull` middleware on every authenticated sync request,
+    /// and at that point the unconditional `last_used_at` UPDATE becomes
+    /// a hot-path write. The P2.2 author should decide whether to
+    /// (a) drop the touch, (b) only update once per N seconds via a
+    /// guarded UPDATE, or (c) batch via a worker task — anything is
+    /// fine, but blindly enabling this on push/pull is not.
+    #[allow(clippy::doc_markdown)]
     pub async fn lookup_session_by_token_hash(
         &self,
         token_hash: &str,
         now_ms: i64,
     ) -> Result<Option<SessionRow>, AppError> {
-        let conn = self.conn()?;
+        let conn = self.conn().await?;
         let mut rows = conn
             .query(
                 "SELECT id, user_id, expires_at FROM auth_sessions
@@ -431,7 +452,7 @@ impl TursoRepo {
 
     /// Mark a session row revoked. Idempotent — re-revoking is fine.
     pub async fn revoke_session(&self, session_id: &str, now_ms: i64) -> Result<(), AppError> {
-        let conn = self.conn()?;
+        let conn = self.conn().await?;
         conn.execute(
             "UPDATE auth_sessions SET revoked_at = ?
               WHERE id = ? AND revoked_at IS NULL",
@@ -518,9 +539,9 @@ async fn bootstrap(conn: &Connection) -> Result<(), AppError> {
              last_login_at INTEGER
          )",
         // One row per outstanding magic-code request. `code_hash` is
-        // sha256(request_id || ':' || code) hex — binding the code to its
-        // request_id stops a code from one request being replayed against
-        // another.
+        // sha256(request_id || ':' || code), encoded as base64url with
+        // no padding — binding the code to its request_id stops a code
+        // from one request being replayed against another.
         "CREATE TABLE IF NOT EXISTS magic_codes (
              request_id TEXT PRIMARY KEY,
              email TEXT NOT NULL,
@@ -532,8 +553,9 @@ async fn bootstrap(conn: &Connection) -> Result<(), AppError> {
          )",
         "CREATE INDEX IF NOT EXISTS idx_magic_codes_email_active
              ON magic_codes(email, consumed_at, expires_at)",
-        // `token_hash` is sha256 of the random session token. We never
-        // store the raw token. `revoked_at` doubles as the logout marker.
+        // `token_hash` is sha256 of the random session token, encoded
+        // as base64url with no padding. We never store the raw token.
+        // `revoked_at` doubles as the logout marker.
         "CREATE TABLE IF NOT EXISTS auth_sessions (
              id TEXT PRIMARY KEY,
              user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -559,4 +581,74 @@ async fn bootstrap(conn: &Connection) -> Result<(), AppError> {
 #[must_use]
 pub fn arc(repo: TursoRepo) -> Arc<TursoRepo> {
     Arc::new(repo)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Foreign-key enforcement is OFF by default in SQLite/libsql; the
+    /// `auth_sessions.user_id ... ON DELETE CASCADE` declaration only
+    /// fires when `PRAGMA foreign_keys = ON` is set on the connection
+    /// running the DELETE. `conn()` arms it on every connection — this
+    /// test proves that's wired correctly. Without the pragma a `DELETE
+    /// FROM users` would silently leave orphaned `auth_sessions` rows.
+    #[tokio::test(flavor = "current_thread")]
+    async fn deleting_a_user_cascades_to_their_auth_sessions() {
+        let temp_db = TursoRepo::connect_temp_db().await.unwrap();
+        let repo = &temp_db.repo;
+
+        let now = chrono::Utc::now().timestamp_millis();
+        let user_id = repo
+            .upsert_user_by_email("cascade@example.com", now)
+            .await
+            .unwrap();
+        let session_id = repo
+            .insert_auth_session(&user_id, "fake-token-hash", now, now + 1_000_000)
+            .await
+            .unwrap();
+
+        // Single connection for the rest of the test so SQLite WAL
+        // locking doesn't trip on multiple in-flight reader/writer
+        // connections to the same scratch DB. `conn()` already armed
+        // `PRAGMA foreign_keys = ON` on this one, which is what we're
+        // verifying.
+        let conn = repo.conn().await.unwrap();
+
+        // Sanity: session row exists before the delete.
+        let session_count_before = count(
+            &conn,
+            "SELECT COUNT(*) FROM auth_sessions WHERE id = ?",
+            &session_id,
+        )
+        .await;
+        assert_eq!(session_count_before, 1);
+
+        conn.execute(
+            "DELETE FROM users WHERE id = ?",
+            libsql::params![user_id.clone()],
+        )
+        .await
+        .unwrap();
+
+        let session_count_after = count(
+            &conn,
+            "SELECT COUNT(*) FROM auth_sessions WHERE id = ?",
+            &session_id,
+        )
+        .await;
+        assert_eq!(
+            session_count_after, 0,
+            "auth_sessions row was not cascaded — FK enforcement is off"
+        );
+    }
+
+    async fn count(conn: &Connection, sql: &str, param: &str) -> i64 {
+        let mut rows = conn
+            .query(sql, libsql::params![param.to_string()])
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        row.get::<i64>(0).unwrap()
+    }
 }

--- a/crates/dirt-api/src/turso.rs
+++ b/crates/dirt-api/src/turso.rs
@@ -47,6 +47,28 @@ impl TursoRepo {
         Self { db: None }
     }
 
+    /// Test-only constructor backed by an in-process libSQL database so
+    /// route + repo logic can be exercised without a real Turso target.
+    ///
+    /// Uses a per-test tempfile rather than `:memory:` because libsql's
+    /// in-memory backend gives each new `connect()` a fresh, empty
+    /// schema; `TursoRepo::conn()` opens a new connection per query,
+    /// which would mean every query after `bootstrap` saw an empty DB.
+    #[cfg(test)]
+    pub async fn connect_in_memory() -> Result<Self, AppError> {
+        let path = std::env::temp_dir().join(format!(
+            "dirt-api-test-{}.db",
+            uuid::Uuid::now_v7().simple()
+        ));
+        let db = Builder::new_local(path)
+            .build()
+            .await
+            .map_err(|e| AppError::config(format!("failed to build local libsql: {e}")))?;
+        let conn = db.connect()?;
+        bootstrap(&conn).await?;
+        Ok(Self { db: Some(db) })
+    }
+
     fn conn(&self) -> Result<Connection, AppError> {
         let db = self
             .db
@@ -152,6 +174,247 @@ pub struct PushNote<'a> {
     pub deleted_at_ms: Option<i64>,
 }
 
+// ---- Phase 2 magic-link auth repo methods ----
+
+/// Why a `consume_magic_code` call rejected the code. Routes layer maps
+/// these onto user-facing error codes.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ConsumeFailure {
+    /// No row for that `request_id`, or `request_id` + code don't match,
+    /// or the row has already been consumed. Treated identically by the
+    /// caller — distinguishing them would let an attacker probe for valid
+    /// `request_id`s.
+    InvalidCode,
+    /// Row exists but `expires_at` is past.
+    Expired,
+    /// `attempts >= MAX_CODE_ATTEMPTS`. The row stays in the table so a
+    /// fresh `auth/request` can replace it; we don't auto-revive.
+    TooManyAttempts,
+}
+
+/// Maximum failed verifications per magic-code row.
+///
+/// Five gives a fat-fingering user three real retries on a typo while
+/// making bruteforcing 6-digit codes hopeless (1e6 / 5 ≈ 200 000 fresh
+/// codes per success). Past this we stop accepting any code on the row.
+pub const MAX_CODE_ATTEMPTS: i64 = 5;
+
+impl TursoRepo {
+    /// Insert a fresh magic-code row. `code_hash` is the sha256 hex of
+    /// `format!("{request_id}:{code}")` — never the raw code.
+    pub async fn insert_magic_code(
+        &self,
+        request_id: &str,
+        email: &str,
+        code_hash: &str,
+        created_at_ms: i64,
+        expires_at_ms: i64,
+    ) -> Result<(), AppError> {
+        let conn = self.conn()?;
+        conn.execute(
+            "INSERT INTO magic_codes (request_id, email, code_hash, created_at, expires_at, consumed_at, attempts)
+             VALUES (?, ?, ?, ?, ?, NULL, 0)",
+            libsql::params![request_id, email, code_hash, created_at_ms, expires_at_ms],
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Atomically check + consume a magic code. On success returns the
+    /// email tied to the row (caller uses it to upsert the user). On
+    /// failure returns the structured `ConsumeFailure`.
+    ///
+    /// The success path is a single conditional UPDATE so two concurrent
+    /// verifies can't both win. The failure path issues a second SELECT
+    /// only to give the user a useful error.
+    pub async fn consume_magic_code(
+        &self,
+        request_id: &str,
+        expected_code_hash: &str,
+        now_ms: i64,
+    ) -> Result<Result<String, ConsumeFailure>, AppError> {
+        let conn = self.conn()?;
+
+        // Fast path: a single conditional UPDATE guards every check at once.
+        let affected = conn
+            .execute(
+                "UPDATE magic_codes
+                    SET consumed_at = ?
+                  WHERE request_id = ?
+                    AND consumed_at IS NULL
+                    AND expires_at >= ?
+                    AND code_hash = ?
+                    AND attempts < ?",
+                libsql::params![
+                    now_ms,
+                    request_id,
+                    now_ms,
+                    expected_code_hash,
+                    MAX_CODE_ATTEMPTS
+                ],
+            )
+            .await?;
+
+        if affected > 0 {
+            let mut rows = conn
+                .query(
+                    "SELECT email FROM magic_codes WHERE request_id = ?",
+                    libsql::params![request_id],
+                )
+                .await?;
+            let Some(row) = rows.next().await? else {
+                return Err(AppError::internal(
+                    "magic code row vanished between consume and email lookup",
+                ));
+            };
+            let email: String = row.get(0)?;
+            return Ok(Ok(email));
+        }
+
+        // Failure path: figure out *why* the UPDATE missed.
+        let mut rows = conn
+            .query(
+                "SELECT consumed_at, expires_at, attempts FROM magic_codes WHERE request_id = ?",
+                libsql::params![request_id],
+            )
+            .await?;
+        let Some(row) = rows.next().await? else {
+            return Ok(Err(ConsumeFailure::InvalidCode));
+        };
+        let consumed_at: Option<i64> = row.get(0)?;
+        let expires_at: i64 = row.get(1)?;
+        let attempts: i64 = row.get(2)?;
+
+        if consumed_at.is_some() {
+            return Ok(Err(ConsumeFailure::InvalidCode));
+        }
+        if expires_at < now_ms {
+            return Ok(Err(ConsumeFailure::Expired));
+        }
+        if attempts >= MAX_CODE_ATTEMPTS {
+            return Ok(Err(ConsumeFailure::TooManyAttempts));
+        }
+        // Reaching here means the code itself was wrong. Bump the
+        // attempt counter so repeated guesses lock out the row.
+        conn.execute(
+            "UPDATE magic_codes SET attempts = attempts + 1 WHERE request_id = ? AND consumed_at IS NULL",
+            libsql::params![request_id],
+        )
+        .await?;
+        Ok(Err(ConsumeFailure::InvalidCode))
+    }
+
+    /// Get-or-insert a user row keyed on email. Returns the canonical
+    /// `user_id`. `email` must already be normalized (trimmed, lowercase).
+    pub async fn upsert_user_by_email(&self, email: &str, now_ms: i64) -> Result<String, AppError> {
+        let conn = self.conn()?;
+        let new_id = uuid::Uuid::now_v7().to_string();
+        // ON CONFLICT(email) returns the existing row's id, so the caller
+        // gets a stable user_id regardless of whether this was the first
+        // login or the hundredth.
+        let mut rows = conn
+            .query(
+                "INSERT INTO users (id, email, created_at, last_login_at)
+                 VALUES (?, ?, ?, ?)
+                 ON CONFLICT(email) DO UPDATE SET last_login_at = excluded.last_login_at
+                 RETURNING id",
+                libsql::params![new_id, email, now_ms, now_ms],
+            )
+            .await?;
+        let Some(row) = rows.next().await? else {
+            return Err(AppError::internal("user upsert returned no row"));
+        };
+        Ok(row.get(0)?)
+    }
+
+    /// Insert a new session row and return its public `session_id` (the
+    /// caller owns the raw token).
+    pub async fn insert_auth_session(
+        &self,
+        user_id: &str,
+        token_hash: &str,
+        created_at_ms: i64,
+        expires_at_ms: i64,
+    ) -> Result<String, AppError> {
+        let conn = self.conn()?;
+        let session_id = uuid::Uuid::now_v7().to_string();
+        conn.execute(
+            "INSERT INTO auth_sessions (id, user_id, token_hash, created_at, last_used_at, expires_at, revoked_at)
+             VALUES (?, ?, ?, ?, ?, ?, NULL)",
+            libsql::params![
+                session_id.clone(),
+                user_id,
+                token_hash,
+                created_at_ms,
+                created_at_ms,
+                expires_at_ms,
+            ],
+        )
+        .await?;
+        Ok(session_id)
+    }
+
+    /// Resolve a session token (by its sha256 hash) to its session row.
+    /// Returns None when the session is missing, revoked, or past
+    /// `expires_at`.
+    ///
+    /// Bumps `last_used_at` as a side effect so the session-token TTL
+    /// rolls forward with use; the row's `expires_at` is *not* touched
+    /// here — refresh is the explicit way to extend a session.
+    pub async fn lookup_session_by_token_hash(
+        &self,
+        token_hash: &str,
+        now_ms: i64,
+    ) -> Result<Option<SessionRow>, AppError> {
+        let conn = self.conn()?;
+        let mut rows = conn
+            .query(
+                "SELECT id, user_id, expires_at FROM auth_sessions
+                  WHERE token_hash = ? AND revoked_at IS NULL AND expires_at > ?",
+                libsql::params![token_hash, now_ms],
+            )
+            .await?;
+        let Some(row) = rows.next().await? else {
+            return Ok(None);
+        };
+        let id: String = row.get(0)?;
+        let user_id: String = row.get(1)?;
+        let expires_at: i64 = row.get(2)?;
+
+        conn.execute(
+            "UPDATE auth_sessions SET last_used_at = ? WHERE id = ?",
+            libsql::params![now_ms, id.clone()],
+        )
+        .await?;
+
+        Ok(Some(SessionRow {
+            id,
+            user_id,
+            expires_at_ms: expires_at,
+        }))
+    }
+
+    /// Mark a session row revoked. Idempotent — re-revoking is fine.
+    pub async fn revoke_session(&self, session_id: &str, now_ms: i64) -> Result<(), AppError> {
+        let conn = self.conn()?;
+        conn.execute(
+            "UPDATE auth_sessions SET revoked_at = ?
+              WHERE id = ? AND revoked_at IS NULL",
+            libsql::params![now_ms, session_id],
+        )
+        .await?;
+        Ok(())
+    }
+}
+
+/// Session-row projection used by middleware + refresh handlers.
+#[derive(Debug, Clone)]
+pub struct SessionRow {
+    pub id: String,
+    pub user_id: String,
+    pub expires_at_ms: i64,
+}
+
 fn parse_pulled_note(row: &libsql::Row) -> Result<Note, AppError> {
     let id: String = row.get(0)?;
     let id = id
@@ -183,6 +446,44 @@ async fn bootstrap(conn: &Connection) -> Result<(), AppError> {
              deleted_at INTEGER
          )",
         "CREATE INDEX IF NOT EXISTS idx_notes_user_sua ON notes(user_id, server_updated_at, id)",
+        // Phase 2 magic-link auth: per-user identities replace the shared
+        // bearer token in Phase 1.
+        "CREATE TABLE IF NOT EXISTS users (
+             id TEXT PRIMARY KEY,
+             email TEXT NOT NULL UNIQUE,
+             created_at INTEGER NOT NULL,
+             last_login_at INTEGER
+         )",
+        // One row per outstanding magic-code request. `code_hash` is
+        // sha256(request_id || ':' || code) hex — binding the code to its
+        // request_id stops a code from one request being replayed against
+        // another.
+        "CREATE TABLE IF NOT EXISTS magic_codes (
+             request_id TEXT PRIMARY KEY,
+             email TEXT NOT NULL,
+             code_hash TEXT NOT NULL,
+             created_at INTEGER NOT NULL,
+             expires_at INTEGER NOT NULL,
+             consumed_at INTEGER,
+             attempts INTEGER NOT NULL DEFAULT 0
+         )",
+        "CREATE INDEX IF NOT EXISTS idx_magic_codes_email_active
+             ON magic_codes(email, consumed_at, expires_at)",
+        // `token_hash` is sha256 of the random session token. We never
+        // store the raw token. `revoked_at` doubles as the logout marker.
+        "CREATE TABLE IF NOT EXISTS auth_sessions (
+             id TEXT PRIMARY KEY,
+             user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+             token_hash TEXT NOT NULL UNIQUE,
+             created_at INTEGER NOT NULL,
+             last_used_at INTEGER NOT NULL,
+             expires_at INTEGER NOT NULL,
+             revoked_at INTEGER
+         )",
+        "CREATE INDEX IF NOT EXISTS idx_auth_sessions_user
+             ON auth_sessions(user_id, revoked_at, expires_at)",
+        "CREATE INDEX IF NOT EXISTS idx_auth_sessions_token
+             ON auth_sessions(token_hash)",
     ];
     for stmt in statements {
         conn.execute(stmt, ()).await?;

--- a/crates/dirt-api/src/turso.rs
+++ b/crates/dirt-api/src/turso.rs
@@ -8,7 +8,7 @@
 use std::sync::Arc;
 
 use dirt_core::models::{Note, NoteId};
-use libsql::{Builder, Connection, Database};
+use libsql::{Builder, Connection, Database, TransactionBehavior};
 
 use crate::error::AppError;
 
@@ -83,6 +83,18 @@ impl TursoRepo {
     /// silently ignored, leaving orphaned session rows when a user is
     /// deleted. The pragma is per-connection, so since we open a fresh
     /// connection per query, we re-arm it here every time.
+    ///
+    /// **P2.2 cost note:** the per-query PRAGMA is an extra Turso
+    /// WebSocket round-trip on remote; on the auth-only routes here it
+    /// barely matters, but P2.2 wires `lookup_session_by_token_hash`
+    /// into the push/pull hot path, where this would double effective
+    /// query latency. Before P2.2 ships, consider replacing this with
+    /// (a) a libsql connection-init hook if one is added upstream,
+    /// (b) a long-lived shared connection guarded by a
+    ///     `tokio::sync::Mutex` (one PRAGMA per process, not per query),
+    /// or (c) dropping FK enforcement and replacing the cascade with
+    ///     explicit `DELETE FROM auth_sessions WHERE user_id = ?` calls
+    ///     in whatever account-deletion path eventually exists.
     async fn conn(&self) -> Result<Connection, AppError> {
         let db = self
             .db
@@ -260,22 +272,31 @@ impl TursoRepo {
         Ok(())
     }
 
-    /// Atomically: check the per-email cooldown, reap expired/consumed
-    /// rows for this email, and insert the new row — all on one
-    /// connection inside a `BEGIN IMMEDIATE` / `COMMIT` transaction.
+    /// Atomically: check the per-email cooldown, reap expired /
+    /// consumed / locked rows for this email, and insert the new row
+    /// — all inside a `BEGIN IMMEDIATE` transaction obtained from
+    /// libsql's typed transaction API.
     ///
     /// Why a transaction: without it, two concurrent `/v1/auth/request`
     /// for the same email can both pass the cooldown SELECT, both reach
     /// the INSERT, and both produce a fresh magic code (and, once
     /// Resend ships in P2.3, two emails to the victim's inbox).
-    /// `BEGIN IMMEDIATE` takes a write lock at the start of the
-    /// transaction, so the second caller blocks behind the first and
-    /// then sees the freshly-inserted row when it runs its own SELECT.
+    /// `IMMEDIATE` takes a write lock at the start of the transaction,
+    /// so the second caller blocks behind the first and then sees the
+    /// freshly-inserted row when it runs its own SELECT.
+    ///
+    /// Why the typed `Transaction`: any error path on the DML below
+    /// causes `tx` to drop without commit, and libsql's `Transaction`
+    /// auto-rolls-back on drop on both backends — synchronously on
+    /// local, via a `tokio::spawn` rollback on Turso hrana — so a
+    /// `?`-propagated error can't leave the connection holding a
+    /// transaction open. (The Turso server also times out abandoned
+    /// transactions server-side as a backstop.)
     ///
     /// "Live" here means unconsumed AND unexpired AND **unlocked**
     /// (`attempts < MAX_CODE_ATTEMPTS`). A code that's been locked by
     /// 5 wrong guesses is functionally dead and should not block a
-    /// re-request.
+    /// re-request. The reaper picks them up too.
     pub async fn try_insert_magic_code_with_cooldown(
         &self,
         request_id: &str,
@@ -286,10 +307,12 @@ impl TursoRepo {
         cooldown_ms: i64,
     ) -> Result<InsertMagicCodeOutcome, AppError> {
         let conn = self.conn().await?;
-        conn.execute("BEGIN IMMEDIATE", ()).await?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .await?;
 
         // Most recent live + unlocked row, if any.
-        let mut rows = conn
+        let mut rows = tx
             .query(
                 "SELECT created_at FROM magic_codes
                   WHERE email = ?
@@ -317,54 +340,36 @@ impl TursoRepo {
         drop(rows);
 
         if let Some(remaining_ms) = cooldown_remaining_ms {
-            conn.execute("ROLLBACK", ()).await?;
+            tx.rollback().await?;
             return Ok(InsertMagicCodeOutcome::OnCooldown {
                 retry_after_ms: remaining_ms,
             });
         }
 
-        // Wrap the post-cooldown DML in a closure-style block so a
-        // failure on DELETE / INSERT doesn't leave the transaction
-        // dangling. libsql remote (Turso WebSocket) doesn't auto-rollback
-        // on connection drop the way local file libsql does, so a stuck
-        // transaction can hold a write lock indefinitely.
-        //
-        // Reaper predicate also picks up locked rows
-        // (`attempts >= MAX_CODE_ATTEMPTS`) — a code that's been brute-
-        // forced into lockout is functionally dead, no point keeping it
-        // around for the rest of its 15-minute TTL.
-        let dml: Result<(), AppError> = async {
-            conn.execute(
-                "DELETE FROM magic_codes
-                  WHERE email = ?
-                    AND (expires_at < ? OR consumed_at IS NOT NULL OR attempts >= ?)",
-                libsql::params![email, created_at_ms, MAX_CODE_ATTEMPTS],
-            )
-            .await?;
+        // Reap and insert. A `?`-propagated error here drops `tx`
+        // without committing, which auto-rolls-back via libsql's
+        // `Transaction` Drop impl. Reaper picks up locked rows
+        // (`attempts >= MAX_CODE_ATTEMPTS`) too — a code that's been
+        // brute-forced into lockout is functionally dead, so it
+        // shouldn't keep its row alive for the rest of its 15-minute
+        // TTL.
+        tx.execute(
+            "DELETE FROM magic_codes
+              WHERE email = ?
+                AND (expires_at < ? OR consumed_at IS NOT NULL OR attempts >= ?)",
+            libsql::params![email, created_at_ms, MAX_CODE_ATTEMPTS],
+        )
+        .await?;
 
-            conn.execute(
-                "INSERT INTO magic_codes (request_id, email, code_hash, created_at, expires_at, consumed_at, attempts)
-                 VALUES (?, ?, ?, ?, ?, NULL, 0)",
-                libsql::params![request_id, email, code_hash, created_at_ms, expires_at_ms],
-            )
-            .await?;
+        tx.execute(
+            "INSERT INTO magic_codes (request_id, email, code_hash, created_at, expires_at, consumed_at, attempts)
+             VALUES (?, ?, ?, ?, ?, NULL, 0)",
+            libsql::params![request_id, email, code_hash, created_at_ms, expires_at_ms],
+        )
+        .await?;
 
-            conn.execute("COMMIT", ()).await?;
-            Ok(())
-        }
-        .await;
-
-        match dml {
-            Ok(()) => Ok(InsertMagicCodeOutcome::Inserted),
-            Err(err) => {
-                // Best-effort rollback. If ROLLBACK itself fails we
-                // still surface the original error — the connection is
-                // about to drop anyway and SQLite will tear down the
-                // transaction.
-                let _ = conn.execute("ROLLBACK", ()).await;
-                Err(err)
-            }
-        }
+        tx.commit().await?;
+        Ok(InsertMagicCodeOutcome::Inserted)
     }
 
     /// Atomically check + consume a magic code. On success returns the
@@ -706,8 +711,10 @@ async fn bootstrap(conn: &Connection) -> Result<(), AppError> {
          )",
         "CREATE INDEX IF NOT EXISTS idx_auth_sessions_user
              ON auth_sessions(user_id, revoked_at, expires_at)",
-        "CREATE INDEX IF NOT EXISTS idx_auth_sessions_token
-             ON auth_sessions(token_hash)",
+        // No explicit index on `token_hash`: the `UNIQUE` constraint
+        // already creates an implicit B-tree on it, which is what
+        // `WHERE token_hash = ?` lookups use. A second index would just
+        // double the write cost on every session insert.
     ];
     for stmt in statements {
         conn.execute(stmt, ()).await?;

--- a/crates/dirt-api/src/turso.rs
+++ b/crates/dirt-api/src/turso.rs
@@ -219,6 +219,12 @@ impl TursoRepo {
     /// Insert a fresh magic-code row. `code_hash` is the sha256
     /// base64url (no padding) of `format!("{request_id}:{code}")` —
     /// never the raw code.
+    ///
+    /// Opportunistically reaps expired and consumed rows for the same
+    /// email before inserting, so the table can't grow without bound
+    /// per active address. Per-user reap uses the
+    /// `idx_magic_codes_email_active` index so the cleanup cost is
+    /// bounded by the (small) number of rows for one email.
     pub async fn insert_magic_code(
         &self,
         request_id: &str,
@@ -229,12 +235,47 @@ impl TursoRepo {
     ) -> Result<(), AppError> {
         let conn = self.conn().await?;
         conn.execute(
+            "DELETE FROM magic_codes
+              WHERE email = ?
+                AND (expires_at < ? OR consumed_at IS NOT NULL)",
+            libsql::params![email, created_at_ms],
+        )
+        .await?;
+        conn.execute(
             "INSERT INTO magic_codes (request_id, email, code_hash, created_at, expires_at, consumed_at, attempts)
              VALUES (?, ?, ?, ?, ?, NULL, 0)",
             libsql::params![request_id, email, code_hash, created_at_ms, expires_at_ms],
         )
         .await?;
         Ok(())
+    }
+
+    /// Returns the `created_at_ms` of the most recent live (unconsumed,
+    /// unexpired) magic-code row for `email`, if any. Used by
+    /// `/v1/auth/request` to enforce a per-email cooldown so an
+    /// attacker can't email-flood a victim's inbox once Resend lands
+    /// in P2.3.
+    pub async fn last_live_magic_code_created_at(
+        &self,
+        email: &str,
+        now_ms: i64,
+    ) -> Result<Option<i64>, AppError> {
+        let conn = self.conn().await?;
+        let mut rows = conn
+            .query(
+                "SELECT created_at FROM magic_codes
+                  WHERE email = ?
+                    AND consumed_at IS NULL
+                    AND expires_at > ?
+                  ORDER BY created_at DESC
+                  LIMIT 1",
+                libsql::params![email, now_ms],
+            )
+            .await?;
+        match rows.next().await? {
+            Some(row) => Ok(Some(row.get::<i64>(0)?)),
+            None => Ok(None),
+        }
     }
 
     /// Atomically check + consume a magic code. On success returns the
@@ -450,16 +491,21 @@ impl TursoRepo {
         }))
     }
 
-    /// Mark a session row revoked. Idempotent — re-revoking is fine.
-    pub async fn revoke_session(&self, session_id: &str, now_ms: i64) -> Result<(), AppError> {
+    /// Mark a session row revoked. Returns `true` if this call flipped
+    /// `revoked_at` from `NULL` to `now_ms`, `false` if the row was
+    /// already revoked (or doesn't exist). Refresh uses the bool to
+    /// detect concurrent refresh races: the caller that lost the race
+    /// must abort instead of forking a second live session.
+    pub async fn revoke_session(&self, session_id: &str, now_ms: i64) -> Result<bool, AppError> {
         let conn = self.conn().await?;
-        conn.execute(
-            "UPDATE auth_sessions SET revoked_at = ?
-              WHERE id = ? AND revoked_at IS NULL",
-            libsql::params![now_ms, session_id],
-        )
-        .await?;
-        Ok(())
+        let affected = conn
+            .execute(
+                "UPDATE auth_sessions SET revoked_at = ?
+                  WHERE id = ? AND revoked_at IS NULL",
+                libsql::params![now_ms, session_id],
+            )
+            .await?;
+        Ok(affected > 0)
     }
 }
 
@@ -531,12 +577,18 @@ async fn bootstrap(conn: &Connection) -> Result<(), AppError> {
          )",
         "CREATE INDEX IF NOT EXISTS idx_notes_user_sua ON notes(user_id, server_updated_at, id)",
         // Phase 2 magic-link auth: per-user identities replace the shared
-        // bearer token in Phase 1.
+        // bearer token in Phase 1. `is_deleted` follows the soft-delete
+        // convention CLAUDE.md mandates for sync compatibility — once
+        // account deletion is wired, offline clients holding `notes`
+        // referencing a deactivated user_id won't trip on a hard-DELETE
+        // boundary. Today no path flips it; the column is here so we
+        // don't have to migrate live data later.
         "CREATE TABLE IF NOT EXISTS users (
              id TEXT PRIMARY KEY,
              email TEXT NOT NULL UNIQUE,
              created_at INTEGER NOT NULL,
-             last_login_at INTEGER
+             last_login_at INTEGER,
+             is_deleted INTEGER NOT NULL DEFAULT 0
          )",
         // One row per outstanding magic-code request. `code_hash` is
         // sha256(request_id || ':' || code), encoded as base64url with

--- a/crates/dirt-api/src/turso.rs
+++ b/crates/dirt-api/src/turso.rs
@@ -215,16 +215,26 @@ pub enum ConsumeFailure {
 /// codes per success). Past this we stop accepting any code on the row.
 pub const MAX_CODE_ATTEMPTS: i64 = 5;
 
+/// Outcome of a `try_insert_magic_code_with_cooldown` call.
+#[derive(Debug, PartialEq, Eq)]
+pub enum InsertMagicCodeOutcome {
+    /// New row inserted (and any expired / consumed rows for the same
+    /// email opportunistically reaped).
+    Inserted,
+    /// A live, unlocked row for this email is younger than the
+    /// requested cooldown — caller must wait `retry_after_ms` before
+    /// requesting again.
+    OnCooldown { retry_after_ms: i64 },
+}
+
 impl TursoRepo {
-    /// Insert a fresh magic-code row. `code_hash` is the sha256
-    /// base64url (no padding) of `format!("{request_id}:{code}")` —
-    /// never the raw code.
-    ///
-    /// Opportunistically reaps expired and consumed rows for the same
-    /// email before inserting, so the table can't grow without bound
-    /// per active address. Per-user reap uses the
-    /// `idx_magic_codes_email_active` index so the cleanup cost is
-    /// bounded by the (small) number of rows for one email.
+    /// Test-only: insert a fresh magic-code row without any cooldown
+    /// check. Production goes through `try_insert_magic_code_with_cooldown`
+    /// which wraps the cooldown gate, the reaper, and the insert in a
+    /// single `BEGIN IMMEDIATE` / `COMMIT` transaction. Tests use this
+    /// primitive when they need to seed a row at a specific timestamp
+    /// (e.g. an already-expired row for the verify-expired test).
+    #[cfg(test)]
     pub async fn insert_magic_code(
         &self,
         request_id: &str,
@@ -250,32 +260,88 @@ impl TursoRepo {
         Ok(())
     }
 
-    /// Returns the `created_at_ms` of the most recent live (unconsumed,
-    /// unexpired) magic-code row for `email`, if any. Used by
-    /// `/v1/auth/request` to enforce a per-email cooldown so an
-    /// attacker can't email-flood a victim's inbox once Resend lands
-    /// in P2.3.
-    pub async fn last_live_magic_code_created_at(
+    /// Atomically: check the per-email cooldown, reap expired/consumed
+    /// rows for this email, and insert the new row — all on one
+    /// connection inside a `BEGIN IMMEDIATE` / `COMMIT` transaction.
+    ///
+    /// Why a transaction: without it, two concurrent `/v1/auth/request`
+    /// for the same email can both pass the cooldown SELECT, both reach
+    /// the INSERT, and both produce a fresh magic code (and, once
+    /// Resend ships in P2.3, two emails to the victim's inbox).
+    /// `BEGIN IMMEDIATE` takes a write lock at the start of the
+    /// transaction, so the second caller blocks behind the first and
+    /// then sees the freshly-inserted row when it runs its own SELECT.
+    ///
+    /// "Live" here means unconsumed AND unexpired AND **unlocked**
+    /// (`attempts < MAX_CODE_ATTEMPTS`). A code that's been locked by
+    /// 5 wrong guesses is functionally dead and should not block a
+    /// re-request.
+    pub async fn try_insert_magic_code_with_cooldown(
         &self,
+        request_id: &str,
         email: &str,
-        now_ms: i64,
-    ) -> Result<Option<i64>, AppError> {
+        code_hash: &str,
+        created_at_ms: i64,
+        expires_at_ms: i64,
+        cooldown_ms: i64,
+    ) -> Result<InsertMagicCodeOutcome, AppError> {
         let conn = self.conn().await?;
+        conn.execute("BEGIN IMMEDIATE", ()).await?;
+
+        // Most recent live + unlocked row, if any.
         let mut rows = conn
             .query(
                 "SELECT created_at FROM magic_codes
                   WHERE email = ?
                     AND consumed_at IS NULL
                     AND expires_at > ?
+                    AND attempts < ?
                   ORDER BY created_at DESC
                   LIMIT 1",
-                libsql::params![email, now_ms],
+                libsql::params![email, created_at_ms, MAX_CODE_ATTEMPTS],
             )
             .await?;
-        match rows.next().await? {
-            Some(row) => Ok(Some(row.get::<i64>(0)?)),
-            None => Ok(None),
+
+        let cooldown_remaining_ms = match rows.next().await? {
+            Some(row) => {
+                let last_created_at: i64 = row.get(0)?;
+                let elapsed = created_at_ms.saturating_sub(last_created_at);
+                if elapsed < cooldown_ms {
+                    Some(cooldown_ms - elapsed)
+                } else {
+                    None
+                }
+            }
+            None => None,
+        };
+        drop(rows);
+
+        if let Some(remaining_ms) = cooldown_remaining_ms {
+            conn.execute("ROLLBACK", ()).await?;
+            return Ok(InsertMagicCodeOutcome::OnCooldown {
+                retry_after_ms: remaining_ms,
+            });
         }
+
+        // Reap expired and consumed rows for this email so the table
+        // doesn't grow without bound for any active address.
+        conn.execute(
+            "DELETE FROM magic_codes
+              WHERE email = ?
+                AND (expires_at < ? OR consumed_at IS NOT NULL)",
+            libsql::params![email, created_at_ms],
+        )
+        .await?;
+
+        conn.execute(
+            "INSERT INTO magic_codes (request_id, email, code_hash, created_at, expires_at, consumed_at, attempts)
+             VALUES (?, ?, ?, ?, ?, NULL, 0)",
+            libsql::params![request_id, email, code_hash, created_at_ms, expires_at_ms],
+        )
+        .await?;
+
+        conn.execute("COMMIT", ()).await?;
+        Ok(InsertMagicCodeOutcome::Inserted)
     }
 
     /// Atomically check + consume a magic code. On success returns the


### PR DESCRIPTION
## Summary

Server-side scaffolding for the Phase 2 per-user, session-token auth that
replaces the Phase 1 shared bearer token. **This PR does not swap the
existing `/v1/notes/{push,pull}` auth path** — that's P2.2.

- `users / magic_codes / auth_sessions` tables added to `bootstrap()`
- `POST /v1/auth/{request,verify,refresh,logout}` routes
- `EmailSender` abstraction with `Log` mode only (writes the magic code
  to `tracing::info!`); Resend lands in P2.3 now that `catjam.dev` DNS
  is verified
- New error codes: `SESSION_EXPIRED` (401) plus
  `INVALID_EMAIL / INVALID_CODE / EXPIRED_CODE / TOO_MANY_ATTEMPTS` (400)

## Design choices

- **6-digit numeric codes**, OTP-style — no deeplinks or browser
  hand-off, same flow works on CLI / desktop / mobile.
- **`code_hash = sha256(request_id || ':' || code)`** so a code from one
  request can't be replayed against another `request_id`.
- **5 attempts per row** (`MAX_CODE_ATTEMPTS`); past that the row is
  locked and the user must request a new code. Bruteforcing 6 digits
  needs ~200 000 fresh requests per success.
- **15-minute code TTL, 30-day session TTL.** Sessions roll
  `last_used_at` forward on every authed request; `expires_at` only
  moves on explicit `/refresh`.
- **`InvalidCode` is the catch-all** for unknown `request_id`,
  consumed-already, and wrong-code: distinguishing them would let an
  attacker probe for live `request_id`s.
- **Session tokens are 32 random bytes** (43-char base64url), stored
  only as their sha256 hash. `lookup_session_by_token_hash` returns
  `None` for missing / revoked / expired so every "no good session"
  case maps to a single 401.

## Test plan

- [x] `cargo test -p dirt-api` (28 passed; 8 new integration tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Coverage: request → verify happy path, attempt-cap lockout,
      expired code, refresh rotation revokes old, logout idempotence,
      garbage email, malformed code, missing Authorization header
- [ ] Round-trip with a real client — gates on P2.4/P2.5 (CLI auth
      flow). Until then the routes are dev-mode only.

## Out of scope (followups)

- **P2.2** swaps `auth::require_bearer_token` on push/pull for
  `lookup_session_by_token_hash` and threads `user_id` through
  `routes::push_notes / pull_notes`. Existing `SOLO_USER_ID` notes will
  be backed up locally before that PR rewrites the path.
- **P2.3** wires Resend now that the domain is verified.
- **P2.4–P2.7** propagate session tokens into core / cli / desktop /
  mobile clients (with OS-keychain / Android KeyStore storage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)