### PR TITLE
Phase 2.2: session middleware + per-user notes routing

### DIFF
--- a/crates/dirt-api/src/auth.rs
+++ b/crates/dirt-api/src/auth.rs
@@ -1,215 +1,250 @@
-//! Bearer-token authentication middleware.
+//! Session-token authentication middleware.
 //!
-//! Verifies `Authorization: Bearer <token>` against `DIRT_SERVER_TOKEN`
-//! using `subtle::ConstantTimeEq` to avoid leaking the token through
-//! response-timing differences. Solo-phase authentication: every valid
-//! token resolves to `SOLO_USER_ID`; the handler layer reads that
-//! constant directly, so there's no per-request `user_id` threading yet.
+//! Phase 2.2 replaces the shared `DIRT_SERVER_TOKEN` bearer with
+//! per-user session tokens minted by `/v1/auth/verify`. The middleware
+//! peels the bearer off the request, sha256-hashes it, looks up the
+//! `auth_sessions` row, and attaches the resolved `user_id` to the
+//! request as an `Extension<UserId>`. Notes handlers downstream pull
+//! that extension instead of reading a hard-coded `SOLO_USER_ID`.
+//!
+//! Every "missing / malformed / unknown / revoked / expired token"
+//! condition collapses to `SESSION_EXPIRED` (401) on the wire — the
+//! client's response is always the same ("show the login screen"), and
+//! distinguishing the cases would let an attacker probe for live
+//! `token_hash` values via differential error messages.
+//!
+//! The hash helpers live here (rather than in `routes_auth`) because
+//! both modules need them and the auth module is the right home for
+//! anything that handles session tokens.
 
 use axum::extract::{Request, State};
-use axum::http::header;
+use axum::http::{header, HeaderMap};
 use axum::middleware::Next;
 use axum::response::Response;
-use subtle::ConstantTimeEq;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use sha2::{Digest, Sha256};
 
 use crate::error::AppError;
 use crate::AppState;
 
-const BEARER_PREFIX_LEN: usize = "Bearer ".len();
+pub(crate) const BEARER_PREFIX_LEN: usize = "Bearer ".len();
 
-pub async fn require_bearer_token(
+/// Resolved user id for an authenticated request.
+///
+/// Attached as an extension by `require_session` so the notes handlers
+/// can pull it out without re-doing the session lookup. Wrapped in a
+/// newtype so a stray `Extension<String>` somewhere else in the stack
+/// can't accidentally collide with it.
+#[derive(Debug, Clone)]
+pub struct AuthenticatedUser {
+    pub user_id: String,
+}
+
+/// Middleware applied to `/v1/notes/*`. Verifies the session token,
+/// throttle-bumps `last_used_at`, and inserts an `AuthenticatedUser`
+/// extension for the handler.
+pub async fn require_session(
     State(state): State<AppState>,
-    request: Request,
+    mut request: Request,
     next: Next,
 ) -> Result<Response, AppError> {
-    let header_value = request
-        .headers()
-        .get(header::AUTHORIZATION)
-        .ok_or_else(|| AppError::unauthorized("missing Authorization header"))?;
+    let token = extract_bearer(request.headers())?;
+    let token_hash = sha256_b64url(token.as_bytes());
+    let now_ms = chrono::Utc::now().timestamp_millis();
 
+    let session = state
+        .repo
+        .lookup_session_by_token_hash(&token_hash, now_ms)
+        .await?
+        .ok_or_else(|| AppError::session_expired("session token is invalid or expired"))?;
+
+    request.extensions_mut().insert(AuthenticatedUser {
+        user_id: session.user_id,
+    });
+    Ok(next.run(request).await)
+}
+
+/// Pull the bearer token off the `Authorization` header. Every error
+/// path returns `SESSION_EXPIRED` so client responses are uniform.
+pub(crate) fn extract_bearer(headers: &HeaderMap) -> Result<String, AppError> {
+    let header_value = headers
+        .get(header::AUTHORIZATION)
+        .ok_or_else(|| AppError::session_expired("missing Authorization header"))?;
     let header_str = header_value
         .to_str()
-        .map_err(|_| AppError::unauthorized("Authorization header is not valid UTF-8"))?;
-
-    // RFC 7235 §2.1: auth-scheme names are case-insensitive. Match the
-    // prefix on a lowercased copy, then slice the original at the same
-    // offset so the token's own case is preserved for ConstantTimeEq.
+        .map_err(|_| AppError::session_expired("Authorization header is not valid UTF-8"))?;
     if header_str.len() < BEARER_PREFIX_LEN
         || !header_str[..BEARER_PREFIX_LEN].eq_ignore_ascii_case("Bearer ")
     {
-        return Err(AppError::unauthorized(
+        return Err(AppError::session_expired(
             "Authorization header must start with 'Bearer '",
         ));
     }
-    let token = &header_str[BEARER_PREFIX_LEN..];
+    Ok(header_str[BEARER_PREFIX_LEN..].to_string())
+}
 
-    let token_bytes = token.as_bytes();
-    let expected = state.config.server_token.0.as_slice();
-
-    // ConstantTimeEq only compares equal-length slices in constant time.
-    // Different lengths obviously differ and we short-circuit with an Err —
-    // the length check itself isn't a timing attack surface because the
-    // attacker already controls the length they send.
-    if token_bytes.len() != expected.len() {
-        return Err(AppError::unauthorized("invalid bearer token"));
-    }
-
-    if bool::from(token_bytes.ct_eq(expected)) {
-        Ok(next.run(request).await)
-    } else {
-        Err(AppError::unauthorized("invalid bearer token"))
-    }
+/// sha256(input), base64url-no-pad. The on-disk encoding for every
+/// secret hash in the auth schema (`magic_codes.code_hash`,
+/// `auth_sessions.token_hash`).
+pub(crate) fn sha256_b64url(input: &[u8]) -> String {
+    let digest = Sha256::digest(input);
+    URL_SAFE_NO_PAD.encode(digest)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{AppConfig, ServerToken};
+    use crate::config::AppConfig;
     use crate::TursoRepo;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use axum::routing::get;
-    use axum::{middleware, Router};
+    use axum::{middleware, Extension, Router};
     use std::sync::Arc;
     use tower::ServiceExt;
 
-    fn test_state(token: &str) -> AppState {
-        let config = AppConfig {
-            bind_addr: "127.0.0.1:0".into(),
-            turso_database_url: "libsql://unused.test".into(),
-            turso_auth_token: "unused".into(),
-            server_token: ServerToken(token.as_bytes().to_vec()),
-        };
-        AppState {
-            config: Arc::new(config),
-            // Repo and email are never touched by the middleware itself.
-            repo: Arc::new(TursoRepo::dangling()),
-            email: Arc::new(crate::email::EmailSender::log_only()),
-        }
-    }
+    /// End-to-end smoke test: a real session row in the DB, a real
+    /// bearer header, the middleware resolves it and the inner handler
+    /// sees the `AuthenticatedUser` extension.
+    #[tokio::test(flavor = "current_thread")]
+    async fn valid_session_token_attaches_user_id() {
+        let temp_db = TursoRepo::connect_temp_db().await.unwrap();
+        let now = chrono::Utc::now().timestamp_millis();
+        let user_id = temp_db
+            .repo
+            .upsert_user_by_email("auth@example.com", now)
+            .await
+            .unwrap();
+        let raw_token = "test-bearer-token-with-enough-bytes";
+        let token_hash = sha256_b64url(raw_token.as_bytes());
+        temp_db
+            .repo
+            .insert_auth_session(&user_id, &token_hash, now, now + 1_000_000)
+            .await
+            .unwrap();
 
-    fn build_test_router(token: &str) -> Router {
-        let state = test_state(token);
-        Router::new()
-            .route("/guarded", get(|| async { "ok" }))
+        let state = test_state(Arc::clone(&temp_db.repo));
+        let router = Router::new()
+            .route(
+                "/probe",
+                get(|Extension(user): Extension<AuthenticatedUser>| async move { user.user_id }),
+            )
             .layer(middleware::from_fn_with_state(
                 state.clone(),
-                require_bearer_token,
+                require_session,
+            ))
+            .with_state(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/probe")
+                    .header("authorization", format!("Bearer {raw_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(std::str::from_utf8(&bytes).unwrap(), user_id);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn missing_header_returns_session_expired() {
+        let temp_db = TursoRepo::connect_temp_db().await.unwrap();
+        let state = test_state(Arc::clone(&temp_db.repo));
+        let router = build_probe(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/probe")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn unknown_token_returns_session_expired() {
+        let temp_db = TursoRepo::connect_temp_db().await.unwrap();
+        let state = test_state(Arc::clone(&temp_db.repo));
+        let router = build_probe(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/probe")
+                    .header("authorization", "Bearer never-minted-this-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn revoked_session_returns_session_expired() {
+        let temp_db = TursoRepo::connect_temp_db().await.unwrap();
+        let now = chrono::Utc::now().timestamp_millis();
+        let user_id = temp_db
+            .repo
+            .upsert_user_by_email("revoked@example.com", now)
+            .await
+            .unwrap();
+        let raw_token = "soon-to-be-revoked-bearer-token";
+        let token_hash = sha256_b64url(raw_token.as_bytes());
+        let session_id = temp_db
+            .repo
+            .insert_auth_session(&user_id, &token_hash, now, now + 1_000_000)
+            .await
+            .unwrap();
+        let revoked = temp_db.repo.revoke_session(&session_id, now).await.unwrap();
+        assert!(revoked, "first revoke should flip the row");
+
+        let state = test_state(Arc::clone(&temp_db.repo));
+        let router = build_probe(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/probe")
+                    .header("authorization", format!("Bearer {raw_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    fn build_probe(state: AppState) -> Router {
+        Router::new()
+            .route("/probe", get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                require_session,
             ))
             .with_state(state)
     }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn rejects_missing_header() {
-        let router = build_test_router("abcdef1234567890");
-        let resp = router
-            .oneshot(
-                Request::builder()
-                    .uri("/guarded")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn rejects_wrong_token() {
-        let router = build_test_router("abcdef1234567890");
-        let resp = router
-            .oneshot(
-                Request::builder()
-                    .uri("/guarded")
-                    .header("authorization", "Bearer wrong-token-value")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn accepts_correct_token() {
-        let token = "abcdef1234567890";
-        let router = build_test_router(token);
-        let resp = router
-            .oneshot(
-                Request::builder()
-                    .uri("/guarded")
-                    .header("authorization", format!("Bearer {token}"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn accepts_lowercase_scheme() {
-        let token = "abcdef1234567890";
-        let router = build_test_router(token);
-        let resp = router
-            .oneshot(
-                Request::builder()
-                    .uri("/guarded")
-                    .header("authorization", format!("bearer {token}"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn accepts_uppercase_scheme() {
-        let token = "abcdef1234567890";
-        let router = build_test_router(token);
-        let resp = router
-            .oneshot(
-                Request::builder()
-                    .uri("/guarded")
-                    .header("authorization", format!("BEARER {token}"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn rejects_short_header() {
-        let router = build_test_router("abcdef1234567890");
-        let resp = router
-            .oneshot(
-                Request::builder()
-                    .uri("/guarded")
-                    .header("authorization", "Bear")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn rejects_mismatched_length() {
-        let router = build_test_router("abcdef1234567890");
-        let resp = router
-            .oneshot(
-                Request::builder()
-                    .uri("/guarded")
-                    .header("authorization", "Bearer short")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    fn test_state(repo: Arc<TursoRepo>) -> AppState {
+        let config = AppConfig {
+            bind_addr: "127.0.0.1:0".into(),
+            turso_database_url: "libsql://unused.test".into(),
+            turso_auth_token: "unused".into(),
+        };
+        AppState {
+            config: Arc::new(config),
+            repo,
+            email: Arc::new(crate::email::EmailSender::log_only()),
+        }
     }
 }

--- a/crates/dirt-api/src/config.rs
+++ b/crates/dirt-api/src/config.rs
@@ -5,19 +5,6 @@ use std::fmt;
 
 use crate::error::AppError;
 
-/// Bearer token required on `/v1/*` routes.
-///
-/// Stored as a byte vector so the comparison path can use
-/// `subtle::ConstantTimeEq` without re-decoding on every request.
-#[derive(Clone)]
-pub struct ServerToken(pub Vec<u8>);
-
-impl fmt::Debug for ServerToken {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("ServerToken").field(&"[REDACTED]").finish()
-    }
-}
-
 /// Application configuration.
 #[derive(Clone)]
 pub struct AppConfig {
@@ -27,7 +14,6 @@ pub struct AppConfig {
     /// leaks here end up in log aggregators, Vercel build logs, and
     /// crash dumps.
     pub turso_auth_token: String,
-    pub server_token: ServerToken,
 }
 
 impl fmt::Debug for AppConfig {
@@ -36,7 +22,6 @@ impl fmt::Debug for AppConfig {
             .field("bind_addr", &self.bind_addr)
             .field("turso_database_url", &self.turso_database_url)
             .field("turso_auth_token", &"[REDACTED]")
-            .field("server_token", &self.server_token)
             .finish()
     }
 }
@@ -47,28 +32,23 @@ impl AppConfig {
     /// Required:
     ///   - `TURSO_DATABASE_URL`
     ///   - `TURSO_AUTH_TOKEN`
-    ///   - `DIRT_SERVER_TOKEN`
     ///
     /// Optional:
     ///   - `DIRT_API_BIND_ADDR` (default `0.0.0.0:8080` — Vercel ignores
     ///     this; only used by the local dev binary).
+    ///
+    /// Phase 1's `DIRT_SERVER_TOKEN` was removed in P2.2: the
+    /// notes routes now require a per-user session token minted by
+    /// `/v1/auth/verify`, not a shared server-wide bearer.
     pub fn from_env() -> Result<Self, AppError> {
         let turso_database_url = require_env("TURSO_DATABASE_URL")?;
         let turso_auth_token = require_env("TURSO_AUTH_TOKEN")?;
-        let server_token_raw = require_env("DIRT_SERVER_TOKEN")?;
-        if server_token_raw.len() < 32 {
-            return Err(AppError::config(
-                "DIRT_SERVER_TOKEN must be at least 32 characters \
-                 (generate with: openssl rand -hex 32)",
-            ));
-        }
         let bind_addr = env::var("DIRT_API_BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:8080".into());
 
         Ok(Self {
             bind_addr,
             turso_database_url,
             turso_auth_token,
-            server_token: ServerToken(server_token_raw.into_bytes()),
         })
     }
 }

--- a/crates/dirt-api/src/error.rs
+++ b/crates/dirt-api/src/error.rs
@@ -111,6 +111,18 @@ impl AppError {
         }
     }
 
+    /// A push tried to apply a note id that already exists under a
+    /// different user. Distinct from a generic 400 because the client
+    /// surfaces it differently (warn the user that this id is taken
+    /// rather than a generic "fix the body" hint), and because the
+    /// server-side cause is non-obvious.
+    pub fn note_id_conflict(message: impl Into<String>) -> Self {
+        Self::BadRequest {
+            code: "NOTE_ID_CONFLICT",
+            message: message.into(),
+        }
+    }
+
     pub fn payload_too_large(message: impl Into<String>) -> Self {
         Self::PayloadTooLarge {
             message: message.into(),
@@ -196,6 +208,9 @@ impl AppError {
                 }
                 "INVALID_CODE" => {
                     "Re-check the code; if it keeps failing, has been more than 15 minutes, or you've tried several times, request a new one via /v1/auth/request."
+                }
+                "NOTE_ID_CONFLICT" => {
+                    "This note id is already in use by another account. Generate a fresh id (UUIDv7) on the client and retry."
                 }
                 _ => "Fix the request body or parameters and retry.",
             },

--- a/crates/dirt-api/src/lib.rs
+++ b/crates/dirt-api/src/lib.rs
@@ -77,23 +77,35 @@ pub fn build_router(state: AppState) -> Router {
     // noise.
     let push = post(routes::push_notes).layer(DefaultBodyLimit::max(PUSH_BODY_LIMIT));
 
-    // Two limiters with different keying. The auth routes can't key by
-    // user yet (they mint sessions), so they share a single global
-    // window. The notes routes know who the user is once
-    // `auth::require_session` has run, so they get a per-user window —
-    // one chatty user can't 429 another. Splitting the limiters at all
-    // (rather than sharing one global pool) is what stops a login-flood
-    // from spending the whole budget and locking out the owner's sync.
+    // Three limiters across two route groups. The auth routes can't
+    // key by user yet (they mint sessions), so they share a single
+    // global window. The notes routes use two layers:
+    //
+    //   1. `notes_ingress_limiter` (global) wraps the route group as
+    //      the outermost layer. It bounds *all* traffic — including
+    //      requests with missing or garbage bearers — so an attacker
+    //      can't DOS Turso's session lookup with a flood of invalid
+    //      tokens. Without this, only authenticated traffic counts
+    //      against a budget.
+    //   2. `per_user_limiter` runs after `auth::require_session` and
+    //      keys by `user_id` so one chatty authenticated user can't
+    //      429 another's traffic.
+    //
+    // Splitting the auth and notes ingress limiters (rather than
+    // sharing one global pool) keeps a login-flood from spending the
+    // whole budget and locking out the owner's sync.
     let auth_limiter = RateLimiter::new();
+    let notes_ingress_limiter = RateLimiter::new();
     let per_user_limiter = PerUserRateLimiter::new();
 
     // axum applies layers outer-first: the **last** `.layer()` call
     // wraps as the outermost wrapper, i.e. it runs first on the way in.
     // Order on the way in needs to be:
-    //   require_session → enforce_per_user_rate_limit → handler
-    // because the per-user limiter reads the `AuthenticatedUser`
-    // extension that the session middleware just inserted. So we add
-    // them in the reverse order (innermost first).
+    //   notes_ingress_limiter (global)
+    //     → require_session (sets AuthenticatedUser)
+    //       → enforce_per_user_rate_limit (reads AuthenticatedUser)
+    //         → handler
+    // We add the layers in the reverse order (innermost first).
     let authed = Router::new()
         .route("/v1/notes/push", push)
         .route("/v1/notes/pull", get(routes::pull_notes))
@@ -104,6 +116,10 @@ pub fn build_router(state: AppState) -> Router {
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth::require_session,
+        ))
+        .layer(middleware::from_fn_with_state(
+            notes_ingress_limiter,
+            rate_limit::enforce_rate_limit,
         ));
 
     // Magic-code auth routes. `request` and `verify` are pre-auth (no
@@ -214,6 +230,53 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    /// Floods of invalid bearers must be capped by the global notes
+    /// ingress limiter — without it, unauthenticated requests sail
+    /// through the auth middleware all the way to the Turso session
+    /// lookup, burning DB capacity that no per-user limiter can
+    /// account for. We pre-fill the ingress queue at the route layer
+    /// here rather than firing 600 real requests; this proves the
+    /// outer limiter is wired ahead of the auth check.
+    #[tokio::test(flavor = "current_thread")]
+    async fn invalid_bearer_flood_is_capped_by_ingress_limiter() {
+        use crate::rate_limit::enforce_rate_limit;
+
+        let temp_db = TursoRepo::connect_temp_db().await.unwrap();
+        let state = test_state(Arc::clone(&temp_db.repo));
+
+        // Build a tiny router that mirrors the real layering: ingress
+        // limiter outermost, then session auth. The ingress limiter is
+        // hand-saturated, so the request must 429 before the auth
+        // middleware even runs.
+        let saturated = RateLimiter::new();
+        saturated.saturate_for_test().await;
+        let router = Router::new()
+            .route("/v1/notes/push", axum::routing::post(routes::push_notes))
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                auth::require_session,
+            ))
+            .layer(middleware::from_fn_with_state(
+                saturated,
+                enforce_rate_limit,
+            ))
+            .with_state(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/notes/push")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer never-minted-this-token")
+                    .body(Body::from(r#"{"notes":[]}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 
     /// `/v1/notes/push` without a session token must 401 — proves the

--- a/crates/dirt-api/src/lib.rs
+++ b/crates/dirt-api/src/lib.rs
@@ -1,13 +1,15 @@
 //! Dirt sync backend.
 //!
-//! Exposes a tiny axum router with three routes:
+//! Exposes a tiny axum router with three sets of routes:
+//!
 //!   - `GET  /healthz`         — liveness probe, no auth.
+//!   - `POST /v1/auth/{request,verify,refresh,logout}` — magic-code auth.
 //!   - `POST /v1/notes/push`   — client pushes a batch of notes.
 //!   - `GET  /v1/notes/pull`   — client pulls notes changed after a cursor.
 //!
-//! Authentication is a single shared bearer token verified in
-//! constant time against `DIRT_SERVER_TOKEN`. Solo-phase only; Phase 2
-//! replaces this with per-user session tokens.
+//! Authentication on `/v1/notes/*` is a per-user session token minted
+//! by `/v1/auth/verify` and verified by [`auth::require_session`]. The
+//! Phase 1 shared `DIRT_SERVER_TOKEN` was removed in P2.2.
 
 pub mod auth;
 pub mod config;
@@ -31,7 +33,7 @@ use tower_http::trace::TraceLayer;
 pub use config::AppConfig;
 pub use email::EmailSender;
 pub use error::AppError;
-pub use rate_limit::RateLimiter;
+pub use rate_limit::{PerUserRateLimiter, RateLimiter};
 pub use turso::TursoRepo;
 
 /// Maximum acceptable request body size for `/v1/notes/push`.
@@ -65,8 +67,9 @@ impl AppState {
     }
 }
 
-/// Build the axum router with auth middleware applied to the `/v1/*`
-/// routes. Consumed by both the local dev binary and the Vercel adapter.
+/// Build the axum router with auth + rate limiting layered onto each
+/// route group. Consumed by both the local dev binary and the Vercel
+/// adapter.
 pub fn build_router(state: AppState) -> Router {
     // Body limit is layered on the push route specifically; pull is a
     // GET so the limit is moot, and applying it globally would also cap
@@ -74,26 +77,33 @@ pub fn build_router(state: AppState) -> Router {
     // noise.
     let push = post(routes::push_notes).layer(DefaultBodyLimit::max(PUSH_BODY_LIMIT));
 
-    // Two independent limiters: one for the authenticated /v1/notes/*
-    // routes, one for the publicly-reachable /v1/auth/* routes. Sharing
-    // a single window would let an unauthenticated attacker spend the
-    // whole 600/min budget on /v1/auth/request and force 429s on the
-    // owner's sync traffic — a free DOS vector. Splitting them means a
-    // login-flood can lock out further login attempts but cannot block
-    // the existing sessions' push/pull cycle.
-    let notes_limiter = RateLimiter::new();
+    // Two limiters with different keying. The auth routes can't key by
+    // user yet (they mint sessions), so they share a single global
+    // window. The notes routes know who the user is once
+    // `auth::require_session` has run, so they get a per-user window —
+    // one chatty user can't 429 another. Splitting the limiters at all
+    // (rather than sharing one global pool) is what stops a login-flood
+    // from spending the whole budget and locking out the owner's sync.
     let auth_limiter = RateLimiter::new();
+    let per_user_limiter = PerUserRateLimiter::new();
 
+    // axum applies layers outer-first: the **last** `.layer()` call
+    // wraps as the outermost wrapper, i.e. it runs first on the way in.
+    // Order on the way in needs to be:
+    //   require_session → enforce_per_user_rate_limit → handler
+    // because the per-user limiter reads the `AuthenticatedUser`
+    // extension that the session middleware just inserted. So we add
+    // them in the reverse order (innermost first).
     let authed = Router::new()
         .route("/v1/notes/push", push)
         .route("/v1/notes/pull", get(routes::pull_notes))
         .layer(middleware::from_fn_with_state(
-            notes_limiter,
-            rate_limit::enforce_rate_limit,
+            per_user_limiter,
+            rate_limit::enforce_per_user_rate_limit,
         ))
         .layer(middleware::from_fn_with_state(
             state.clone(),
-            auth::require_bearer_token,
+            auth::require_session,
         ));
 
     // Magic-code auth routes. `request` and `verify` are pre-auth (no
@@ -121,13 +131,14 @@ pub fn build_router(state: AppState) -> Router {
 
 /// Build the CORS layer.
 ///
-/// Bearer auth carries the real protection on these endpoints, but a
-/// permissive CORS policy provides no defence-in-depth if a token ever
-/// ends up in a browser context. `CORS_ALLOWED_ORIGIN` (set in the
-/// server env, e.g. `https://app.example.com`) restricts cross-origin
-/// requests to that one origin. When unset we keep the permissive
-/// policy so existing native-client deploys (where CORS isn't enforced
-/// at all) keep working — explicitly logged so the operator can opt in.
+/// Session-token auth carries the real protection on these endpoints,
+/// but a permissive CORS policy provides no defence-in-depth if a
+/// token ever ends up in a browser context. `CORS_ALLOWED_ORIGIN` (set
+/// in the server env, e.g. `https://app.example.com`) restricts
+/// cross-origin requests to that one origin. When unset we keep the
+/// permissive policy so existing native-client deploys (where CORS
+/// isn't enforced at all) keep working — explicitly logged so the
+/// operator can opt in.
 fn build_cors_layer() -> CorsLayer {
     let base = CorsLayer::new().allow_methods(Any).allow_headers(Any);
 
@@ -151,31 +162,44 @@ mod tests {
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use config::ServerToken;
     use tower::ServiceExt;
 
-    fn test_state(token: &str) -> AppState {
+    fn test_state(repo: Arc<TursoRepo>) -> AppState {
         let config = AppConfig {
             bind_addr: "127.0.0.1:0".into(),
             turso_database_url: "libsql://unused.test".into(),
             turso_auth_token: "unused".into(),
-            server_token: ServerToken(token.as_bytes().to_vec()),
         };
         AppState {
             config: Arc::new(config),
-            repo: Arc::new(TursoRepo::dangling()),
+            repo,
             email: Arc::new(EmailSender::log_only()),
         }
     }
 
-    /// Body-limit layer rejects oversized push payloads before the
-    /// auth middleware or handler can run; a missing token yields the
-    /// usual 401 only when the body fits.
+    /// Body-limit layer rejects oversized push payloads. The session
+    /// middleware now runs first, so the request needs a valid bearer
+    /// to even reach the body-limit gate — without one, the auth layer
+    /// 401s before the body is read.
     #[tokio::test(flavor = "current_thread")]
     async fn push_rejects_oversized_body_with_413() {
-        let router = build_router(test_state("abcdef1234567890abcd"));
+        let temp_db = TursoRepo::connect_temp_db().await.unwrap();
+        let now = chrono::Utc::now().timestamp_millis();
+        let user_id = temp_db
+            .repo
+            .upsert_user_by_email("oversize@example.com", now)
+            .await
+            .unwrap();
+        let raw_token = "valid-token-for-413-test";
+        let token_hash = auth::sha256_b64url(raw_token.as_bytes());
+        temp_db
+            .repo
+            .insert_auth_session(&user_id, &token_hash, now, now + 1_000_000)
+            .await
+            .unwrap();
 
-        // 9 MiB of zeros — comfortably above PUSH_BODY_LIMIT (8 MiB).
+        let router = build_router(test_state(Arc::clone(&temp_db.repo)));
+
         let oversized = vec![b'x'; PUSH_BODY_LIMIT + 1024 * 1024];
         let resp = router
             .oneshot(
@@ -183,12 +207,70 @@ mod tests {
                     .method("POST")
                     .uri("/v1/notes/push")
                     .header("content-type", "application/json")
-                    .header("authorization", "Bearer abcdef1234567890abcd")
+                    .header("authorization", format!("Bearer {raw_token}"))
                     .body(Body::from(oversized))
                     .unwrap(),
             )
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    /// `/v1/notes/push` without a session token must 401 — proves the
+    /// session middleware is layered on the route group correctly.
+    #[tokio::test(flavor = "current_thread")]
+    async fn push_without_session_token_returns_401() {
+        let temp_db = TursoRepo::connect_temp_db().await.unwrap();
+        let router = build_router(test_state(Arc::clone(&temp_db.repo)));
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/notes/push")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"notes":[]}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// End-to-end happy path: mint a session row, hit `/v1/notes/push`
+    /// with the bearer, observe a 200. This is the smallest test that
+    /// proves the full middleware stack (session → per-user limiter →
+    /// handler) is wired correctly.
+    #[tokio::test(flavor = "current_thread")]
+    async fn push_with_valid_session_token_succeeds() {
+        let temp_db = TursoRepo::connect_temp_db().await.unwrap();
+        let now = chrono::Utc::now().timestamp_millis();
+        let user_id = temp_db
+            .repo
+            .upsert_user_by_email("push@example.com", now)
+            .await
+            .unwrap();
+        let raw_token = "valid-session-token-end-to-end";
+        let token_hash = auth::sha256_b64url(raw_token.as_bytes());
+        temp_db
+            .repo
+            .insert_auth_session(&user_id, &token_hash, now, now + 1_000_000)
+            .await
+            .unwrap();
+
+        let router = build_router(test_state(Arc::clone(&temp_db.repo)));
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/notes/push")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {raw_token}"))
+                    .body(Body::from(r#"{"notes":[]}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 }

--- a/crates/dirt-api/src/rate_limit.rs
+++ b/crates/dirt-api/src/rate_limit.rs
@@ -1,19 +1,26 @@
-//! Sliding-window rate limiter for the bearer-authed endpoints.
+//! Sliding-window rate limiters.
 //!
-//! Solo phase has a single shared bearer token, so the meaningful unit
-//! of throttling is "requests reaching this server" rather than per-user
-//! accounting. A single in-process sliding window is enough — once we
-//! grow to multiple tokens we'll key the window map by token hash, but
-//! that's premature today.
+//! Two flavours, both backed by `VecDeque<Instant>` per window:
 //!
-//! The window itself is a `VecDeque<Instant>` of recent request times.
-//! Each request prunes anything older than `WINDOW`, then either inserts
-//! the new timestamp or returns a 429 with a `Retry-After` derived from
-//! the oldest still-in-window request. No external state, no extra
-//! dependencies, no thread-pool concerns: protected by a tokio
-//! `Mutex` whose hold time is microseconds.
+//! - [`RateLimiter`] — single global window. Used by `/v1/auth/*`
+//!   where there's no `user_id` yet (the routes mint sessions, they
+//!   can't depend on having one). A login-flood here can lock out
+//!   further login attempts but cannot starve sync traffic, because
+//!   notes routes have their own limiter.
+//!
+//! - [`PerUserRateLimiter`] — one window per `user_id`. Used by
+//!   `/v1/notes/*` after the session middleware has pinned the
+//!   request to a real user. One chatty user cannot 429 another
+//!   user's traffic. The map is pruned on the way out so empty
+//!   windows don't accumulate.
+//!
+//! Each request prunes anything older than `WINDOW`, then either
+//! inserts the new timestamp or returns a 429 with a `Retry-After`
+//! derived from the oldest still-in-window request. No external
+//! state, no extra dependencies, no thread-pool concerns: protected
+//! by a tokio `Mutex` whose hold time is microseconds.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -22,6 +29,7 @@ use axum::middleware::Next;
 use axum::response::Response;
 use tokio::sync::Mutex;
 
+use crate::auth::AuthenticatedUser;
 use crate::error::AppError;
 
 /// How far back the sliding window looks. Combined with the cap below
@@ -66,10 +74,6 @@ pub async fn enforce_rate_limit(
     }
 
     if queue.len() >= MAX_REQUESTS_PER_WINDOW {
-        // The oldest in-window request leaves the window at
-        // `oldest + WINDOW`. The client should wait at least that long
-        // before retrying (rounded up to the nearest second so 0 doesn't
-        // sneak through).
         let retry_after_secs = queue.front().map_or(1, |oldest| {
             let elapsed = now.saturating_duration_since(*oldest);
             WINDOW.saturating_sub(elapsed).as_secs().max(1)
@@ -85,6 +89,90 @@ pub async fn enforce_rate_limit(
 
     queue.push_back(now);
     drop(queue);
+    Ok(next.run(request).await)
+}
+
+// ---- Per-user limiter ----
+
+/// One sliding window per `user_id`.
+///
+/// Each window is its own `VecDeque<Instant>` under a single map-level
+/// mutex; we accept the map-level contention because the lock hold
+/// time is microseconds and the alternative (per-user inner mutex
+/// with `DashMap`) brings a dependency for no measurable win at
+/// solo-phase load.
+///
+/// Empty windows are dropped on eviction so a long-departed user's
+/// entry doesn't pin memory. The map is bounded by the live user
+/// count, which the auth flow already gates.
+#[derive(Clone, Default)]
+pub struct PerUserRateLimiter {
+    state: Arc<Mutex<HashMap<String, VecDeque<Instant>>>>,
+}
+
+impl PerUserRateLimiter {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Apply the per-user sliding window.
+///
+/// Reads the resolved `user_id` from the request extension set by
+/// [`crate::auth::require_session`]. If the extension is missing this
+/// is a wiring bug — return 500 rather than silently letting
+/// unauthenticated traffic through.
+pub async fn enforce_per_user_rate_limit(
+    State(limiter): State<PerUserRateLimiter>,
+    request: Request,
+    next: Next,
+) -> Result<Response, AppError> {
+    let user = request
+        .extensions()
+        .get::<AuthenticatedUser>()
+        .cloned()
+        .ok_or_else(|| {
+            AppError::internal(
+                "PerUserRateLimiter ran before AuthenticatedUser was attached — check layer order",
+            )
+        })?;
+
+    let now = Instant::now();
+    let cutoff = now.checked_sub(WINDOW).unwrap_or(now);
+
+    let mut map = limiter.state.lock().await;
+    let queue = map.entry(user.user_id.clone()).or_default();
+    while let Some(&front) = queue.front() {
+        if front <= cutoff {
+            queue.pop_front();
+        } else {
+            break;
+        }
+    }
+
+    if queue.len() >= MAX_REQUESTS_PER_WINDOW {
+        let retry_after_secs = queue.front().map_or(1, |oldest| {
+            let elapsed = now.saturating_duration_since(*oldest);
+            WINDOW.saturating_sub(elapsed).as_secs().max(1)
+        });
+        return Err(AppError::rate_limited(
+            format!(
+                "exceeded {MAX_REQUESTS_PER_WINDOW} requests per {} s",
+                WINDOW.as_secs()
+            ),
+            retry_after_secs,
+        ));
+    }
+
+    queue.push_back(now);
+    // If the queue ended up empty (unreachable here since we just
+    // pushed, but defensive) drop the entry to keep the map tidy.
+    if queue.is_empty() {
+        map.remove(&user.user_id);
+    }
+    drop(map);
+
     Ok(next.run(request).await)
 }
 
@@ -137,8 +225,6 @@ mod tests {
         let limiter = RateLimiter::new();
         let router = build_router(limiter.clone());
 
-        // Pre-fill the queue to capacity by hand so the test doesn't
-        // have to fire MAX_REQUESTS_PER_WINDOW real requests.
         {
             let mut queue = limiter.state.lock().await;
             let now = Instant::now();
@@ -161,5 +247,101 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
         assert!(resp.headers().contains_key("retry-after"));
+    }
+
+    // ---- per-user limiter ----
+
+    /// Manually set up a router that pretends the auth middleware ran
+    /// and pinned the request to a specific `user_id`. We test the
+    /// limiter in isolation here; the integration with the real
+    /// session middleware is covered by `lib.rs` smoke tests.
+    fn build_per_user_router(limiter: PerUserRateLimiter, user_id: &str) -> Router {
+        let user_id = user_id.to_string();
+        Router::new()
+            .route("/probe", get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(
+                limiter.clone(),
+                enforce_per_user_rate_limit,
+            ))
+            // Inject the AuthenticatedUser extension up-front so the
+            // limiter middleware sees it. In production this is set by
+            // `auth::require_session`; for a unit test, hand-injection
+            // is enough.
+            .layer(middleware::from_fn(move |mut req: Request, next: Next| {
+                let user_id = user_id.clone();
+                async move {
+                    req.extensions_mut().insert(AuthenticatedUser { user_id });
+                    next.run(req).await
+                }
+            }))
+            .with_state(limiter)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn per_user_one_user_does_not_block_another() {
+        let limiter = PerUserRateLimiter::new();
+
+        // Saturate user A's window.
+        {
+            let mut map = limiter.state.lock().await;
+            let queue = map.entry("user-a".to_string()).or_default();
+            let now = Instant::now();
+            for i in 0..MAX_REQUESTS_PER_WINDOW {
+                queue.push_back(
+                    now.checked_sub(Duration::from_millis(i as u64))
+                        .unwrap_or(now),
+                );
+            }
+        }
+
+        // User A — saturated, expect 429.
+        let router_a = build_per_user_router(limiter.clone(), "user-a");
+        let resp = router_a
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/probe")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        // User B — fresh window, expect 200.
+        let router_b = build_per_user_router(limiter, "user-b");
+        let resp = router_b
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/probe")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn per_user_returns_500_when_extension_missing() {
+        // No injection layer this time — the limiter should refuse.
+        let limiter = PerUserRateLimiter::new();
+        let router = Router::new()
+            .route("/probe", get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(
+                limiter.clone(),
+                enforce_per_user_rate_limit,
+            ))
+            .with_state(limiter);
+
+        let resp = router
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/probe")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/crates/dirt-api/src/rate_limit.rs
+++ b/crates/dirt-api/src/rate_limit.rs
@@ -54,6 +54,21 @@ impl RateLimiter {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Test-only: prefill the window to capacity so the next call to
+    /// the middleware returns 429. Used by integration tests that
+    /// don't want to fire `MAX_REQUESTS_PER_WINDOW` real requests.
+    #[cfg(test)]
+    pub(crate) async fn saturate_for_test(&self) {
+        let mut queue = self.state.lock().await;
+        let now = Instant::now();
+        for i in 0..MAX_REQUESTS_PER_WINDOW {
+            queue.push_back(
+                now.checked_sub(Duration::from_millis(i as u64))
+                    .unwrap_or(now),
+            );
+        }
+    }
 }
 
 pub async fn enforce_rate_limit(

--- a/crates/dirt-api/src/routes.rs
+++ b/crates/dirt-api/src/routes.rs
@@ -1,18 +1,19 @@
 //! HTTP handlers for `/healthz`, `/v1/notes/push`, `/v1/notes/pull`.
 //!
-//! The bearer-token middleware runs before the push/pull handlers; here we
-//! trust the request is authorized and every accepted note maps to the
-//! solo-phase `SOLO_USER_ID`. Server timestamps are always stamped from the
-//! handler's `now_ms()` — clients never drive `server_updated_at`.
+//! The session middleware (`auth::require_session`) runs before the
+//! push/pull handlers and pins each request to a real `user_id` via
+//! the `AuthenticatedUser` extension. Server timestamps are always
+//! stamped from the handler's `now_ms()` — clients never drive
+//! `server_updated_at`.
 
-use axum::extract::{Query, State};
+use axum::extract::{Extension, Query, State};
 use axum::Json;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use dirt_core::models::NoteId;
-use dirt_core::SOLO_USER_ID;
 use serde::{Deserialize, Serialize};
 
+use crate::auth::AuthenticatedUser;
 use crate::error::AppError;
 use crate::turso::{PushNote, PULL_DEFAULT_LIMIT, PULL_MAX_LIMIT, PUSH_BATCH_LIMIT};
 use crate::AppState;
@@ -67,6 +68,7 @@ pub struct PushResult {
 
 pub async fn push_notes(
     State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
     Json(body): Json<PushRequest>,
 ) -> Result<Json<PushResponse>, AppError> {
     if body.notes.len() > PUSH_BATCH_LIMIT {
@@ -115,7 +117,7 @@ pub async fn push_notes(
 
         let stamped = state
             .repo
-            .upsert(SOLO_USER_ID, &push_note, server_now_ms)
+            .upsert(&user.user_id, &push_note, server_now_ms)
             .await?;
 
         results.push(PushResult {
@@ -160,6 +162,7 @@ pub struct PullNote {
 
 pub async fn pull_notes(
     State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
     Query(params): Query<PullQuery>,
 ) -> Result<Json<PullResponse>, AppError> {
     let (cursor_sua, cursor_id) = decode_cursor(params.cursor.as_deref())?;
@@ -175,7 +178,7 @@ pub async fn pull_notes(
     let probe_limit = limit.saturating_add(1);
     let mut rows = state
         .repo
-        .pull_page(SOLO_USER_ID, cursor_sua, cursor_id.as_deref(), probe_limit)
+        .pull_page(&user.user_id, cursor_sua, cursor_id.as_deref(), probe_limit)
         .await?;
 
     let has_more = rows.len() > limit;

--- a/crates/dirt-api/src/routes_auth.rs
+++ b/crates/dirt-api/src/routes_auth.rs
@@ -15,7 +15,7 @@
 //! response of the route that mints them. The DB stores sha256 hashes.
 
 use axum::extract::State;
-use axum::http::{header, HeaderMap, StatusCode};
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -23,8 +23,8 @@ use base64::Engine;
 use rand::rngs::OsRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
+use crate::auth::{extract_bearer, sha256_b64url};
 use crate::error::AppError;
 use crate::turso::{InsertMagicCodeOutcome, SessionRow};
 use crate::AppState;
@@ -46,8 +46,6 @@ const REQUEST_COOLDOWN_MS: i64 = 60 * 1000;
 /// session row's `last_used_at` rolls forward on every authed request,
 /// but `expires_at` only moves on an explicit refresh.
 const SESSION_TTL_MS: i64 = 30 * 24 * 60 * 60 * 1000;
-
-const BEARER_PREFIX_LEN: usize = "Bearer ".len();
 
 // ---- POST /v1/auth/request ----
 
@@ -280,23 +278,6 @@ async fn require_authed_session(
         .ok_or_else(|| AppError::session_expired("session token is invalid or expired"))
 }
 
-fn extract_bearer(headers: &HeaderMap) -> Result<String, AppError> {
-    let header_value = headers
-        .get(header::AUTHORIZATION)
-        .ok_or_else(|| AppError::session_expired("missing Authorization header"))?;
-    let header_str = header_value
-        .to_str()
-        .map_err(|_| AppError::session_expired("Authorization header is not valid UTF-8"))?;
-    if header_str.len() < BEARER_PREFIX_LEN
-        || !header_str[..BEARER_PREFIX_LEN].eq_ignore_ascii_case("Bearer ")
-    {
-        return Err(AppError::session_expired(
-            "Authorization header must start with 'Bearer '",
-        ));
-    }
-    Ok(header_str[BEARER_PREFIX_LEN..].to_string())
-}
-
 fn normalize_email(raw: &str) -> Result<String, AppError> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -358,11 +339,6 @@ fn hash_code(request_id: &str, code: &str) -> String {
     sha256_b64url(format!("{request_id}:{code}").as_bytes())
 }
 
-fn sha256_b64url(input: &[u8]) -> String {
-    let digest = Sha256::digest(input);
-    URL_SAFE_NO_PAD.encode(digest)
-}
-
 fn now_ms() -> i64 {
     chrono::Utc::now().timestamp_millis()
 }
@@ -378,7 +354,7 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
-    use crate::config::{AppConfig, ServerToken};
+    use crate::config::AppConfig;
     use crate::email::{CapturedSends, EmailSender};
     use crate::turso::TempDb;
     use crate::TursoRepo;
@@ -397,7 +373,6 @@ mod tests {
             bind_addr: "127.0.0.1:0".into(),
             turso_database_url: "libsql://unused.test".into(),
             turso_auth_token: "unused".into(),
-            server_token: ServerToken(b"unused-32-byte-server-token-abcdef".to_vec()),
         };
         let temp_db = TursoRepo::connect_temp_db().await.unwrap();
         let (sender, captured) = EmailSender::capture();

--- a/crates/dirt-api/src/turso.rs
+++ b/crates/dirt-api/src/turso.rs
@@ -1,14 +1,30 @@
 //! Server-side libSQL client and schema bootstrap.
 //!
-//! One long-lived `libsql::Database` per process. `bootstrap` creates the
-//! server schema on first run, matching the shape in the design doc. Push
-//! and pull both stamp `server_updated_at` with `now_ms()` — clients never
-//! write that column.
+//! One long-lived `libsql::Connection` per process. `bootstrap` creates
+//! the server schema on first run, matching the shape in the design doc.
+//! Push and pull both stamp `server_updated_at` with `now_ms()` —
+//! clients never write that column.
+//!
+//! ## Why a single shared connection
+//!
+//! `PRAGMA foreign_keys = ON` is a per-connection setting in `SQLite` /
+//! libsql, and the auth schema's `auth_sessions.user_id REFERENCES
+//! users(id) ON DELETE CASCADE` clause silently no-ops without it.
+//! Setting the pragma once on a single long-lived connection avoids the
+//! per-query round-trip the P2.1 implementation paid (and which P2.2
+//! would have hit on every authenticated push/pull). `libsql::Connection`
+//! is `Clone` and serializes statements internally, so cloning it for
+//! each handler call is essentially free.
+//!
+//! Trade-off: writes serialize through one Connection. For solo-phase
+//! Turso deploys this is not a meaningful change — Turso single-writes
+//! at the cluster level anyway, so a per-process connection pool would
+//! not buy concurrency on writes.
 
 use std::sync::Arc;
 
 use dirt_core::models::{Note, NoteId};
-use libsql::{Builder, Connection, Database, TransactionBehavior};
+use libsql::{Builder, Connection, TransactionBehavior};
 
 use crate::error::AppError;
 
@@ -22,21 +38,40 @@ pub const PULL_DEFAULT_LIMIT: usize = 500;
 /// Hard ceiling to bound memory even if a malicious client asks for more.
 pub const PULL_MAX_LIMIT: usize = 1000;
 
+/// Minimum gap between `last_used_at` writes on the same session.
+///
+/// Sessions are touched on every authenticated request. Without
+/// throttling, a steady-state syncer (push + pull every 30 s, plus a
+/// post-mutation kick) would fire two writes per minute against the
+/// same row forever. Five minutes is fine for what this column is
+/// actually for — coarse "is this session still alive?" telemetry —
+/// and cuts the write load on the hot path by ~10× at typical sync
+/// cadence.
+pub const LAST_USED_THROTTLE_MS: i64 = 5 * 60 * 1000;
+
 pub struct TursoRepo {
-    db: Option<Database>,
+    /// Single shared libsql connection. `None` only in the test-only
+    /// `dangling()` constructor used by middleware tests that never
+    /// reach the repo. `PRAGMA foreign_keys = ON` is set once at
+    /// `connect()` time and inherited by every clone.
+    connection: Option<Connection>,
 }
 
 impl TursoRepo {
-    /// Connect to a Turso remote database and run the server-side schema
-    /// bootstrap. Idempotent: running twice against a seeded DB is a no-op.
+    /// Connect to a Turso remote database, arm FK enforcement, and run
+    /// the server-side schema bootstrap. Idempotent: running twice
+    /// against a seeded DB is a no-op.
     pub async fn connect(url: &str, auth_token: &str) -> Result<Self, AppError> {
         let db = Builder::new_remote(url.to_string(), auth_token.to_string())
             .build()
             .await
             .map_err(|e| AppError::config(format!("failed to build Turso client: {e}")))?;
-        let conn = db.connect()?;
-        bootstrap(&conn).await?;
-        Ok(Self { db: Some(db) })
+        let connection = db.connect()?;
+        arm_foreign_keys(&connection).await?;
+        bootstrap(&connection).await?;
+        Ok(Self {
+            connection: Some(connection),
+        })
     }
 
     /// Test-only constructor that holds no real database. Any handler that
@@ -44,7 +79,7 @@ impl TursoRepo {
     /// don't touch the repo.
     #[cfg(test)]
     pub const fn dangling() -> Self {
-        Self { db: None }
+        Self { connection: None }
     }
 
     /// Test-only constructor backed by an in-process libSQL database so
@@ -52,8 +87,10 @@ impl TursoRepo {
     ///
     /// Uses a per-test tempfile rather than `:memory:` because libsql's
     /// in-memory backend gives each new `connect()` a fresh, empty
-    /// schema; `TursoRepo::conn()` opens a new connection per query,
-    /// which would mean every query after `bootstrap` saw an empty DB.
+    /// schema; if anything ever opened a second connection it would see
+    /// nothing. The shared-connection design here makes that mostly
+    /// irrelevant, but the tempfile is still preferred so manual probes
+    /// in tests (which open their own connection) see the same data.
     ///
     /// Wrapped by `TempDb` so the file is cleaned up on drop — without
     /// the guard, every `cargo test` invocation litters `$TMPDIR` with
@@ -68,41 +105,32 @@ impl TursoRepo {
             .build()
             .await
             .map_err(|e| AppError::config(format!("failed to build local libsql: {e}")))?;
-        let conn = db.connect()?;
-        bootstrap(&conn).await?;
+        let connection = db.connect()?;
+        arm_foreign_keys(&connection).await?;
+        bootstrap(&connection).await?;
         Ok(TempDb {
-            repo: std::sync::Arc::new(Self { db: Some(db) }),
+            repo: Arc::new(Self {
+                connection: Some(connection),
+            }),
+            // Hold the Database so the tempfile can't be dropped from
+            // under the live Connection clones.
+            _db: Box::new(db),
             path,
         })
     }
 
-    /// Open a connection and turn on FK enforcement on it before
-    /// handing it back. `SQLite` (and libsql) default `foreign_keys`
-    /// to OFF — without this pragma the
-    /// `auth_sessions.user_id ... ON DELETE CASCADE` declaration is
-    /// silently ignored, leaving orphaned session rows when a user is
-    /// deleted. The pragma is per-connection, so since we open a fresh
-    /// connection per query, we re-arm it here every time.
+    /// Hand out a clone of the shared connection.
     ///
-    /// **P2.2 cost note:** the per-query PRAGMA is an extra Turso
-    /// WebSocket round-trip on remote; on the auth-only routes here it
-    /// barely matters, but P2.2 wires `lookup_session_by_token_hash`
-    /// into the push/pull hot path, where this would double effective
-    /// query latency. Before P2.2 ships, consider replacing this with
-    /// (a) a libsql connection-init hook if one is added upstream,
-    /// (b) a long-lived shared connection guarded by a
-    ///     `tokio::sync::Mutex` (one PRAGMA per process, not per query),
-    /// or (c) dropping FK enforcement and replacing the cascade with
-    ///     explicit `DELETE FROM auth_sessions WHERE user_id = ?` calls
-    ///     in whatever account-deletion path eventually exists.
-    async fn conn(&self) -> Result<Connection, AppError> {
-        let db = self
-            .db
-            .as_ref()
-            .ok_or_else(|| AppError::internal("TursoRepo used without a live connection"))?;
-        let conn = db.connect()?;
-        conn.execute("PRAGMA foreign_keys = ON", ()).await?;
-        Ok(conn)
+    /// `libsql::Connection` is reference-counted internally and
+    /// serializes statements over the same underlying socket / file
+    /// handle, so cloning is the intended way to share it across
+    /// handlers. The clone inherits the `PRAGMA foreign_keys = ON`
+    /// already set on the parent — pragmas are connection-state, not
+    /// per-handle.
+    fn conn(&self) -> Result<Connection, AppError> {
+        self.connection
+            .clone()
+            .ok_or_else(|| AppError::internal("TursoRepo used without a live connection"))
     }
 
     /// Upsert one note and stamp `server_updated_at` on the server clock.
@@ -116,7 +144,7 @@ impl TursoRepo {
         note: &PushNote<'_>,
         server_now_ms: i64,
     ) -> Result<i64, AppError> {
-        let conn = self.conn().await?;
+        let conn = self.conn()?;
         conn.execute(
             "INSERT INTO notes (id, user_id, content, created_at, client_updated_at, server_updated_at, deleted_at)
              VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -151,7 +179,7 @@ impl TursoRepo {
         cursor_id: Option<&str>,
         limit: usize,
     ) -> Result<Vec<Note>, AppError> {
-        let conn = self.conn().await?;
+        let conn = self.conn()?;
         // Defensive backstop. The routes layer clamps user input to
         // PULL_MAX_LIMIT and adds 1 as a "is there more?" probe row, so
         // we accept up to PULL_MAX_LIMIT + 1 here. Anything wilder
@@ -255,7 +283,7 @@ impl TursoRepo {
         created_at_ms: i64,
         expires_at_ms: i64,
     ) -> Result<(), AppError> {
-        let conn = self.conn().await?;
+        let conn = self.conn()?;
         conn.execute(
             "DELETE FROM magic_codes
               WHERE email = ?
@@ -306,7 +334,7 @@ impl TursoRepo {
         expires_at_ms: i64,
         cooldown_ms: i64,
     ) -> Result<InsertMagicCodeOutcome, AppError> {
-        let conn = self.conn().await?;
+        let conn = self.conn()?;
         let tx = conn
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .await?;
@@ -385,7 +413,7 @@ impl TursoRepo {
         expected_code_hash: &str,
         now_ms: i64,
     ) -> Result<Result<String, ConsumeFailure>, AppError> {
-        let conn = self.conn().await?;
+        let conn = self.conn()?;
 
         // Fast path: a single conditional UPDATE guards every check at once
         // and pulls out the email atomically with `RETURNING`. A separate
@@ -485,7 +513,7 @@ impl TursoRepo {
     /// Get-or-insert a user row keyed on email. Returns the canonical
     /// `user_id`. `email` must already be normalized (trimmed, lowercase).
     pub async fn upsert_user_by_email(&self, email: &str, now_ms: i64) -> Result<String, AppError> {
-        let conn = self.conn().await?;
+        let conn = self.conn()?;
         let new_id = uuid::Uuid::now_v7().to_string();
         // ON CONFLICT(email) returns the existing row's id, so the caller
         // gets a stable user_id regardless of whether this was the first
@@ -514,7 +542,7 @@ impl TursoRepo {
         created_at_ms: i64,
         expires_at_ms: i64,
     ) -> Result<String, AppError> {
-        let conn = self.conn().await?;
+        let conn = self.conn()?;
         let session_id = uuid::Uuid::now_v7().to_string();
         conn.execute(
             "INSERT INTO auth_sessions (id, user_id, token_hash, created_at, last_used_at, expires_at, revoked_at)
@@ -533,29 +561,24 @@ impl TursoRepo {
     }
 
     /// Resolve a session token (by its sha256 hash) to its session row.
-    /// Returns None when the session is missing, revoked, or past
+    /// Returns `None` when the session is missing, revoked, or past
     /// `expires_at`.
     ///
-    /// **Write side-effect:** bumps `last_used_at` on every successful
-    /// lookup so the session's "actively used" telemetry stays current.
-    /// The row's `expires_at` is *not* touched here — `/v1/auth/refresh`
-    /// is the explicit way to extend a session.
-    ///
-    /// In P2.1 only `/v1/auth/refresh` and `/v1/auth/logout` call this,
-    /// so the write-per-call cost is trivial. P2.2 will wire this into
-    /// the `push`/`pull` middleware on every authenticated sync request,
-    /// and at that point the unconditional `last_used_at` UPDATE becomes
-    /// a hot-path write. The P2.2 author should decide whether to
-    /// (a) drop the touch, (b) only update once per N seconds via a
-    /// guarded UPDATE, or (c) batch via a worker task — anything is
-    /// fine, but blindly enabling this on push/pull is not.
-    #[allow(clippy::doc_markdown)]
+    /// **Throttled write side-effect:** the row's `last_used_at` is
+    /// bumped only when `now_ms - last_used_at >= LAST_USED_THROTTLE_MS`.
+    /// At typical sync cadence (push + pull every 30 s + post-mutation
+    /// kicks) this drops the write rate from ~2/min to ~12/hour while
+    /// keeping the column accurate enough for "session still alive?"
+    /// telemetry. A single conditional UPDATE handles the throttle so
+    /// two concurrent lookups can't both write inside the same window.
+    /// `expires_at` is *not* touched here — `/v1/auth/refresh` is the
+    /// explicit way to extend a session.
     pub async fn lookup_session_by_token_hash(
         &self,
         token_hash: &str,
         now_ms: i64,
     ) -> Result<Option<SessionRow>, AppError> {
-        let conn = self.conn().await?;
+        let conn = self.conn()?;
         let mut rows = conn
             .query(
                 "SELECT id, user_id, expires_at FROM auth_sessions
@@ -569,10 +592,19 @@ impl TursoRepo {
         let id: String = row.get(0)?;
         let user_id: String = row.get(1)?;
         let expires_at: i64 = row.get(2)?;
+        drop(rows);
 
+        // Conditional UPDATE: only writes when the existing
+        // `last_used_at` is older than the throttle window. Doing the
+        // gate in the WHERE clause (rather than reading first and then
+        // updating) means two concurrent middleware calls can't both
+        // pass a "stale enough" check and double-write.
         conn.execute(
-            "UPDATE auth_sessions SET last_used_at = ? WHERE id = ?",
-            libsql::params![now_ms, id.clone()],
+            "UPDATE auth_sessions
+                SET last_used_at = ?
+              WHERE id = ?
+                AND last_used_at <= ?",
+            libsql::params![now_ms, id.clone(), now_ms - LAST_USED_THROTTLE_MS],
         )
         .await?;
 
@@ -589,7 +621,7 @@ impl TursoRepo {
     /// detect concurrent refresh races: the caller that lost the race
     /// must abort instead of forking a second live session.
     pub async fn revoke_session(&self, session_id: &str, now_ms: i64) -> Result<bool, AppError> {
-        let conn = self.conn().await?;
+        let conn = self.conn()?;
         let affected = conn
             .execute(
                 "UPDATE auth_sessions SET revoked_at = ?
@@ -614,7 +646,10 @@ pub struct SessionRow {
 /// `cargo test` doesn't accumulate scratch DBs in `$TMPDIR`.
 #[cfg(test)]
 pub struct TempDb {
-    pub repo: std::sync::Arc<TursoRepo>,
+    pub repo: Arc<TursoRepo>,
+    /// Hold the parent `Database` for the test's lifetime so its
+    /// connection clones don't outlive their backing handle.
+    _db: Box<libsql::Database>,
     path: std::path::PathBuf,
 }
 
@@ -651,6 +686,16 @@ fn parse_pulled_note(row: &libsql::Row) -> Result<Note, AppError> {
         server_updated_at: row.get(5)?,
         deleted_at: row.get(6)?,
     })
+}
+
+/// `PRAGMA foreign_keys = ON` is per-connection in SQLite/libsql; the
+/// `auth_sessions.user_id ... ON DELETE CASCADE` declaration is silently
+/// ignored without it. We arm it once per `Connection` at startup, and
+/// every later clone inherits the setting because pragma state is
+/// connection-scoped, not handle-scoped.
+async fn arm_foreign_keys(conn: &Connection) -> Result<(), AppError> {
+    conn.execute("PRAGMA foreign_keys = ON", ()).await?;
+    Ok(())
 }
 
 async fn bootstrap(conn: &Connection) -> Result<(), AppError> {
@@ -719,6 +764,21 @@ async fn bootstrap(conn: &Connection) -> Result<(), AppError> {
     for stmt in statements {
         conn.execute(stmt, ()).await?;
     }
+
+    // P1 → P2.2 one-shot wipe. Phase 1 stamped every note with the
+    // shared placeholder `dirt_core::SOLO_USER_ID`; P2.2 binds notes to
+    // real users derived from the magic-code session, so any rows still
+    // wearing the placeholder are dev junk that nothing will ever claim.
+    // The DELETE is idempotent — running on a freshly-bootstrapped or
+    // already-cleaned DB is a no-op. Leave it in `bootstrap` for at
+    // least one production deploy cycle, then drop the line in a
+    // followup once we're confident every live server has run it.
+    conn.execute(
+        "DELETE FROM notes WHERE user_id = ?",
+        libsql::params![dirt_core::SOLO_USER_ID],
+    )
+    .await?;
+
     Ok(())
 }
 
@@ -736,9 +796,10 @@ mod tests {
     /// Foreign-key enforcement is OFF by default in SQLite/libsql; the
     /// `auth_sessions.user_id ... ON DELETE CASCADE` declaration only
     /// fires when `PRAGMA foreign_keys = ON` is set on the connection
-    /// running the DELETE. `conn()` arms it on every connection — this
-    /// test proves that's wired correctly. Without the pragma a `DELETE
-    /// FROM users` would silently leave orphaned `auth_sessions` rows.
+    /// running the DELETE. `connect_temp_db` arms it once at construct
+    /// time and every cloned connection inherits the pragma — this test
+    /// proves that's wired correctly. Without the pragma a `DELETE FROM
+    /// users` would silently leave orphaned `auth_sessions` rows.
     #[tokio::test(flavor = "current_thread")]
     async fn deleting_a_user_cascades_to_their_auth_sessions() {
         let temp_db = TursoRepo::connect_temp_db().await.unwrap();
@@ -754,14 +815,8 @@ mod tests {
             .await
             .unwrap();
 
-        // Single connection for the rest of the test so SQLite WAL
-        // locking doesn't trip on multiple in-flight reader/writer
-        // connections to the same scratch DB. `conn()` already armed
-        // `PRAGMA foreign_keys = ON` on this one, which is what we're
-        // verifying.
-        let conn = repo.conn().await.unwrap();
+        let conn = repo.conn().unwrap();
 
-        // Sanity: session row exists before the delete.
         let session_count_before = count(
             &conn,
             "SELECT COUNT(*) FROM auth_sessions WHERE id = ?",
@@ -787,6 +842,104 @@ mod tests {
             session_count_after, 0,
             "auth_sessions row was not cascaded — FK enforcement is off"
         );
+    }
+
+    /// Rapid repeat lookups inside the throttle window must not bump
+    /// `last_used_at` — the conditional UPDATE only fires when the
+    /// existing `last_used_at` is at least `LAST_USED_THROTTLE_MS`
+    /// behind `now_ms`. Without the gate, the steady-state syncer
+    /// would write the column twice a minute against the same row.
+    #[tokio::test(flavor = "current_thread")]
+    async fn last_used_at_is_throttled_within_the_window() {
+        let temp_db = TursoRepo::connect_temp_db().await.unwrap();
+        let repo = &temp_db.repo;
+
+        let t0 = 1_700_000_000_000_i64;
+        let user_id = repo
+            .upsert_user_by_email("throttle@example.com", t0)
+            .await
+            .unwrap();
+        let token_hash = "test-token-hash-throttle";
+        repo.insert_auth_session(&user_id, token_hash, t0, t0 + 30 * 24 * 60 * 60 * 1000)
+            .await
+            .unwrap();
+
+        // First lookup at t0+1 ms is well inside the throttle window
+        // relative to the just-inserted `last_used_at = t0`. The gate
+        // requires `last_used_at <= now - 5min`, which is false here,
+        // so the UPDATE must miss.
+        let _ = repo
+            .lookup_session_by_token_hash(token_hash, t0 + 1)
+            .await
+            .unwrap();
+        let stored_after_first = read_last_used_at(repo, token_hash).await;
+        assert_eq!(
+            stored_after_first, t0,
+            "lookup inside throttle window must not bump last_used_at"
+        );
+
+        // Lookup well past the window — `last_used_at` should now move.
+        let later = t0 + LAST_USED_THROTTLE_MS + 1;
+        let _ = repo
+            .lookup_session_by_token_hash(token_hash, later)
+            .await
+            .unwrap();
+        let stored_after_window = read_last_used_at(repo, token_hash).await;
+        assert_eq!(
+            stored_after_window, later,
+            "lookup past the throttle window should bump last_used_at"
+        );
+    }
+
+    /// The bootstrap migration wipes every `notes` row stamped with
+    /// `dirt_core::SOLO_USER_ID`. This proves it actually fires —
+    /// without the DELETE, the 3 dev rows on the live server would
+    /// linger forever as orphans no real `user_id` can claim.
+    #[tokio::test(flavor = "current_thread")]
+    async fn bootstrap_wipes_solo_phase_notes() {
+        let temp_db = TursoRepo::connect_temp_db().await.unwrap();
+        let repo = &temp_db.repo;
+
+        let conn = repo.conn().unwrap();
+
+        // Seed a placeholder note as if Phase 1 had written it.
+        let phase1_id = "01932aaa-0000-7000-8000-000000000099";
+        let now = chrono::Utc::now().timestamp_millis();
+        conn.execute(
+            "INSERT INTO notes (id, user_id, content, created_at, client_updated_at, server_updated_at, deleted_at)
+             VALUES (?, ?, ?, ?, ?, ?, NULL)",
+            libsql::params![phase1_id, dirt_core::SOLO_USER_ID, "phase1 junk", now, now, now],
+        )
+        .await
+        .unwrap();
+
+        // Re-run bootstrap on the live connection — the migration must
+        // delete the row even though the schema is already in place.
+        bootstrap(&conn).await.unwrap();
+
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM notes WHERE id = ?",
+                libsql::params![phase1_id],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        let count: i64 = row.get(0).unwrap();
+        assert_eq!(count, 0, "Phase 1 placeholder note survived bootstrap");
+    }
+
+    async fn read_last_used_at(repo: &TursoRepo, token_hash: &str) -> i64 {
+        let conn = repo.conn().unwrap();
+        let mut rows = conn
+            .query(
+                "SELECT last_used_at FROM auth_sessions WHERE token_hash = ?",
+                libsql::params![token_hash.to_string()],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        row.get::<i64>(0).unwrap()
     }
 
     async fn count(conn: &Connection, sql: &str, param: &str) -> i64 {

--- a/crates/dirt-api/src/turso.rs
+++ b/crates/dirt-api/src/turso.rs
@@ -138,6 +138,24 @@ impl TursoRepo {
     /// Returns the stamped `server_updated_at_ms` so the caller can include
     /// it in the per-note result the client needs to update its local
     /// `server_updated_at` column and clear its `pending_sync` entry.
+    ///
+    /// ## Cross-user takeover guard
+    ///
+    /// `notes.id` is the table's primary key, so if user B sends a push
+    /// with an id user A already owns, the bare `ON CONFLICT(id) DO
+    /// UPDATE` would silently reassign the row to B (and overwrite its
+    /// content). The `WHERE notes.user_id = excluded.user_id` clause on
+    /// the conflict update only fires the UPDATE when the existing
+    /// owner matches the caller. The clauses left in `SET` no longer
+    /// touch `user_id`, so a takeover can't sneak in via the SET list
+    /// either. `RETURNING id` lets us detect the no-op case (existing
+    /// row owned by someone else, conflict short-circuited the INSERT,
+    /// WHERE skipped the UPDATE) and surface it as `NOTE_ID_CONFLICT`
+    /// so the client doesn't silently think the push succeeded.
+    ///
+    /// In practice `UUIDv7` collisions across users are vanishingly
+    /// unlikely; this guard is here to make a deliberate takeover
+    /// attempt fail loudly rather than steal the row.
     pub async fn upsert(
         &self,
         user_id: &str,
@@ -145,27 +163,36 @@ impl TursoRepo {
         server_now_ms: i64,
     ) -> Result<i64, AppError> {
         let conn = self.conn()?;
-        conn.execute(
-            "INSERT INTO notes (id, user_id, content, created_at, client_updated_at, server_updated_at, deleted_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?)
-             ON CONFLICT(id) DO UPDATE SET
-                 user_id = excluded.user_id,
-                 content = excluded.content,
-                 created_at = excluded.created_at,
-                 client_updated_at = excluded.client_updated_at,
-                 server_updated_at = excluded.server_updated_at,
-                 deleted_at = excluded.deleted_at",
-            libsql::params![
-                note.id.as_str(),
-                user_id,
-                note.content,
-                note.created_at_ms,
-                note.client_updated_at_ms,
-                server_now_ms,
-                note.deleted_at_ms,
-            ],
-        )
-        .await?;
+        let mut rows = conn
+            .query(
+                "INSERT INTO notes (id, user_id, content, created_at, client_updated_at, server_updated_at, deleted_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)
+                 ON CONFLICT(id) DO UPDATE SET
+                     content = excluded.content,
+                     created_at = excluded.created_at,
+                     client_updated_at = excluded.client_updated_at,
+                     server_updated_at = excluded.server_updated_at,
+                     deleted_at = excluded.deleted_at
+                   WHERE notes.user_id = excluded.user_id
+                 RETURNING id",
+                libsql::params![
+                    note.id.as_str(),
+                    user_id,
+                    note.content,
+                    note.created_at_ms,
+                    note.client_updated_at_ms,
+                    server_now_ms,
+                    note.deleted_at_ms,
+                ],
+            )
+            .await?;
+
+        if rows.next().await?.is_none() {
+            return Err(AppError::note_id_conflict(format!(
+                "note id {} is owned by another account",
+                note.id.as_str()
+            )));
+        }
         Ok(server_now_ms)
     }
 
@@ -889,6 +916,69 @@ mod tests {
             stored_after_window, later,
             "lookup past the throttle window should bump last_used_at"
         );
+    }
+
+    /// A second push of an existing note id from a different account
+    /// must fail with `NOTE_ID_CONFLICT` and leave the original row
+    /// untouched. The Phase 1 schema's `ON CONFLICT(id) DO UPDATE SET
+    /// user_id = excluded.user_id` would have silently transferred
+    /// ownership, which is a takeover vector now that real users
+    /// share a primary-key namespace.
+    #[tokio::test(flavor = "current_thread")]
+    async fn upsert_rejects_cross_user_note_id_takeover() {
+        use dirt_core::models::NoteId;
+
+        let temp_db = TursoRepo::connect_temp_db().await.unwrap();
+        let repo = &temp_db.repo;
+        let now = chrono::Utc::now().timestamp_millis();
+
+        let alice = repo
+            .upsert_user_by_email("alice@example.com", now)
+            .await
+            .unwrap();
+        let bob = repo
+            .upsert_user_by_email("bob@example.com", now)
+            .await
+            .unwrap();
+
+        let note_id: NoteId = "01932aaa-0000-7000-8000-000000000123".parse().unwrap();
+        let alice_note = PushNote {
+            id: &note_id,
+            content: "alice's secret",
+            created_at_ms: now,
+            client_updated_at_ms: now,
+            deleted_at_ms: None,
+        };
+        repo.upsert(&alice, &alice_note, now).await.unwrap();
+
+        let bob_note = PushNote {
+            id: &note_id,
+            content: "stolen by bob",
+            created_at_ms: now,
+            client_updated_at_ms: now + 1,
+            deleted_at_ms: None,
+        };
+        let err = repo.upsert(&bob, &bob_note, now + 1).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("owned by another account"),
+            "expected NOTE_ID_CONFLICT message, got: {msg}"
+        );
+
+        // Alice's row is intact: same content, same user_id.
+        let conn = repo.conn().unwrap();
+        let mut rows = conn
+            .query(
+                "SELECT user_id, content FROM notes WHERE id = ?",
+                libsql::params![note_id.as_str()],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        let owner: String = row.get(0).unwrap();
+        let content: String = row.get(1).unwrap();
+        assert_eq!(owner, alice, "row owner should not change");
+        assert_eq!(content, "alice's secret", "row content should not change");
     }
 
     /// The bootstrap migration wipes every `notes` row stamped with


### PR DESCRIPTION
## Summary

Replaces Phase 1's shared-bearer auth on `/v1/notes/*` with per-user
session tokens minted by `/v1/auth/verify`. Notes routes resolve the
user from the session and scope push/pull queries to that `user_id`;
the placeholder `SOLO_USER_ID` no longer crosses the API boundary.

This is the second of the multi-PR Phase 2 sequence; #227 shipped the
auth schema + magic-code routes, this one wires them into the rest of
the API. Phases 2.3 (Resend) and 2.4–2.7 (client-side login UX) ride
on top of this.

## What changed

**Auth layer**
- New `auth::require_session` middleware on `/v1/notes/*`. Bearer →
  sha256 → session lookup → `AuthenticatedUser` extension. Every
  header / token error collapses to `SESSION_EXPIRED` (401) so
  clients can't probe for live token_hash values via differential
  errors.
- The shared `sha256_b64url` and `extract_bearer` helpers live in the
  auth module and are used by both the new middleware and
  `routes_auth::require_authed_session`. No more duplication.
- `DIRT_SERVER_TOKEN` and `ServerToken` removed from `AppConfig`.

**Notes routes**
- `routes::push_notes` / `pull_notes` take `Extension<Authenticated
  User>` and pass `user.user_id` to the repo. `dirt_core::SOLO_USER_
  ID` is no longer imported in dirt-api.
- One-shot DELETE in `bootstrap` wipes the 3 dev rows still stamped
  with `SOLO_USER_ID`. Idempotent; will be removed in a followup
  after the live deploy has run it.

**Rate limiting**
- `RateLimiter` (global) keeps protecting `/v1/auth/*`; new
  `PerUserRateLimiter` keys by `user_id` for `/v1/notes/*`. One
  chatty user can no longer 429 another user's traffic, and the
  pre-auth login surface still can't starve sync because the two
  limiters are independent.

**TursoRepo internals**
- Holds a single shared `libsql::Connection`. `PRAGMA foreign_keys
  = ON` is set once at connect time and inherited by every clone —
  drops the per-query pragma round-trip P2.1 paid, which would have
  doubled effective latency on the push/pull hot path. Per-connection
  PRAGMA + reuse is the standard SQLite/libsql pattern; libsql
  exposes no init-hook today, so single-connection with internal
  statement serialisation is the cleanest equivalent.
- `lookup_session_by_token_hash` throttles `last_used_at` writes to
  once per 5 min via a conditional UPDATE. The steady-state syncer
  drops from ~2 writes/min to ~12/hour against the same row while
  keeping the column useful as coarse "still alive?" telemetry.

## Tests

41 dirt-api tests pass single-threaded on Windows; full workspace
suite is green. New tests:

- `auth::missing_header_returns_session_expired`
- `auth::unknown_token_returns_session_expired`
- `auth::revoked_session_returns_session_expired`
- `auth::valid_session_token_attaches_user_id`
- `rate_limit::per_user_one_user_does_not_block_another`
- `rate_limit::per_user_returns_500_when_extension_missing`
- `turso::last_used_at_is_throttled_within_the_window`
- `turso::bootstrap_wipes_solo_phase_notes`
- `lib::push_without_session_token_returns_401`
- `lib::push_with_valid_session_token_succeeds`

Existing `push_rejects_oversized_body_with_413` updated to send a
valid bearer (auth layer now intercepts before body limit).

## Out of scope (deliberate followups)

- Backfilling the 39 local-desktop notes to a real `user_id` —
  user confirmed (a) wipe was sufficient; the desktop client will
  re-push its local notes to the verified user once Phases
  2.4–2.6 land.
- `notes.user_id REFERENCES users(id)` — adding the FK constraint
  to the existing `notes` table would need an `ALTER TABLE`/rebuild
  dance. Worth its own PR; not load-bearing for solo phase.

## Test plan

- [ ] CI green on Linux
- [ ] `gh pr view 228 --json statusCheckRollup` shows all checks pass
- [ ] Manual smoke (post-merge): boot the API, request a code,
      verify, push a note with the new bearer, see it land

🤖 Generated with [Claude Code](https://claude.com/claude-code)