### PR TITLE
Phase 2.3: Resend email integration

### DIFF
--- a/.env.server.example
+++ b/.env.server.example
@@ -31,7 +31,9 @@ TURSO_AUTH_TOKEN=
 # two is a hard config error — silently falling back to Log would put live
 # magic codes into log aggregators instead of users' inboxes.
 RESEND_API_KEY=
-RESEND_FROM_ADDRESS=Dirt <noreply@catjam.dev>
+# Quoted because dotenvy 0.15 won't accept `<` in an unquoted value —
+# the line above silently parses to empty without the surrounding "".
+RESEND_FROM_ADDRESS="Dirt <noreply@catjam.dev>"
 
 # --- CORS (optional) ---
 # Restricts cross-origin requests to one origin (e.g. `https://app.example.com`).

--- a/.env.server.example
+++ b/.env.server.example
@@ -5,8 +5,8 @@
 #   cp .env.server.example .env.server
 #
 # In production, use platform-native env injection instead:
-#   vercel env add DIRT_SERVER_TOKEN production
-#   docker run -e DIRT_SERVER_TOKEN=...
+#   vercel env add RESEND_API_KEY production
+#   docker run -e RESEND_API_KEY=...
 
 # --- Server binding ---
 # Use 0.0.0.0 for Android emulator access via http://10.0.2.2:8080.
@@ -20,11 +20,18 @@ DIRT_API_BIND_ADDR=0.0.0.0:8080
 TURSO_DATABASE_URL=
 TURSO_AUTH_TOKEN=
 
-# --- Bearer token for the new sync API ---
-# Shared secret all clients must present in `Authorization: Bearer <token>`.
-# Must be at least 32 characters (generate with: `openssl rand -hex 32`).
-# Mirror to DIRT_CLIENT_TOKEN on every client.
-DIRT_SERVER_TOKEN=
+# --- Magic-code email delivery (P2.3) ---
+# Both must be set together. Get the API key from https://resend.com/api-keys
+# (a domain-restricted send-only key is enough — the server never reads).
+# RESEND_FROM_ADDRESS must be a verified sender on a Resend-DKIM'd domain;
+# Resend rejects unverified senders with 403.
+#
+# Leave both unset to keep the dev `Log` mode (the magic code drops into
+# tracing::debug! and never leaves the process). Setting only one of the
+# two is a hard config error — silently falling back to Log would put live
+# magic codes into log aggregators instead of users' inboxes.
+RESEND_API_KEY=
+RESEND_FROM_ADDRESS=Dirt <noreply@catjam.dev>
 
 # --- CORS (optional) ---
 # Restricts cross-origin requests to one origin (e.g. `https://app.example.com`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,6 +1791,7 @@ dependencies = [
  "dotenvy",
  "libsql",
  "rand 0.8.5",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -1802,6 +1803,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/api/axum.rs
+++ b/api/axum.rs
@@ -28,7 +28,10 @@ async fn main() -> Result<(), Error> {
             .await
             .map_err(|e| Error::from(format!("failed to connect to Turso: {e}")))?,
     );
-    let email = Arc::new(EmailSender::from_env());
+    let email = Arc::new(
+        EmailSender::from_env()
+            .map_err(|e| Error::from(format!("failed to load email config: {e}")))?,
+    );
     let state = AppState::new(config, repo, email);
     let router = build_router(state);
 

--- a/crates/dirt-api/Cargo.toml
+++ b/crates/dirt-api/Cargo.toml
@@ -44,10 +44,23 @@ rand = "0.8"
 sha2 = "0.10"
 uuid.workspace = true
 
+# Outbound HTTP for the Resend email backend (P2.3). `default-features =
+# false` drops the implicit `default-tls = native-tls` pull-in, which on
+# Vercel's Rust runtime drags OpenSSL into the build closure for no
+# benefit; `rustls-tls` is statically linked and CA-rooted via webpki so
+# it works the same in the local dev binary, on Vercel, and on the CI
+# Linux runners. `json` is the Serialize-payload helper used by
+# `EmailSender::send_via_resend`.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+
 [dev-dependencies]
 # `ServiceExt::oneshot` lets the auth-middleware tests drive the axum
 # Router in-process without spinning up a TCP listener.
 tower = { version = "0.5", features = ["util"] }
+# Mock HTTP server for the Resend email tests — the alternative is a
+# real Resend account in CI, which leaks an API key into the test
+# pipeline and exposes the test inbox to abuse.
+wiremock = "0.6"
 
 [lints]
 workspace = true

--- a/crates/dirt-api/src/email.rs
+++ b/crates/dirt-api/src/email.rs
@@ -62,6 +62,13 @@ enum Mode {
     /// parallel one and pretending.
     #[cfg(test)]
     Capture(CapturedSends),
+    /// Test-only: every send returns `AppError::Internal`. Used by the
+    /// route-level test that proves `request_magic_code` rolls back the
+    /// just-inserted DB row when the downstream send fails. The real
+    /// production failure path is the Resend HTTPS branch; that's
+    /// covered by the wiremock 4xx/5xx tests.
+    #[cfg(test)]
+    Failing,
 }
 
 struct ResendConfig {
@@ -147,6 +154,17 @@ impl EmailSender {
         )
     }
 
+    /// Test-only: a sender whose every `send_magic_code` call resolves
+    /// to `AppError::Internal`. Lets the route-level test cover the
+    /// rollback branch in `request_magic_code` without standing up a
+    /// wiremock server in the same test.
+    #[cfg(test)]
+    pub(crate) const fn always_failing() -> Self {
+        Self {
+            mode: Mode::Failing,
+        }
+    }
+
     /// Pick a mode from the process environment.
     ///
     /// Selection rules:
@@ -206,6 +224,10 @@ impl EmailSender {
                     .push((email.to_string(), code.to_string()));
                 Ok(())
             }
+            #[cfg(test)]
+            Mode::Failing => Err(AppError::internal(
+                "test-only forced send failure for rollback coverage",
+            )),
         }
     }
 }
@@ -361,6 +383,30 @@ mod tests {
             .send_magic_code("user@example.com", "123456", 15)
             .await
             .unwrap();
+    }
+
+    /// Snapshot the rendered body so a typo or format-string change is
+    /// caught here, not silently in the wiremock test (which feeds the
+    /// same `render_magic_code_body` output into both the mock matcher
+    /// and the production payload — circular by construction).
+    #[test]
+    fn render_magic_code_body_snapshot() {
+        let body = render_magic_code_body("123456", 15);
+        assert_eq!(
+            body,
+            "Your Dirt sign-in code is: 123456\n\n\
+             It expires in 15 minutes. \
+             If you didn't request this code, you can ignore this email.\n"
+        );
+    }
+
+    /// `expires_in_minutes` actually reaches the rendered body — the
+    /// reason we plumbed the parameter through in the first place
+    /// (see `render_magic_code_body` doc comment about TTL drift).
+    #[test]
+    fn render_magic_code_body_uses_ttl_argument() {
+        assert!(render_magic_code_body("000000", 7).contains("expires in 7 minutes"));
+        assert!(render_magic_code_body("000000", 30).contains("expires in 30 minutes"));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/dirt-api/src/email.rs
+++ b/crates/dirt-api/src/email.rs
@@ -175,7 +175,17 @@ impl EmailSender {
     /// `AppError::Internal` so the request handler maps them onto a 500
     /// — the user can't fix a Resend outage themselves, retrying the
     /// `/v1/auth/request` is the right user-facing prompt.
-    pub async fn send_magic_code(&self, email: &str, code: &str) -> Result<(), AppError> {
+    ///
+    /// `expires_in_minutes` is forwarded to the rendered body so the
+    /// "expires in N minutes" copy can't drift from the actual code TTL.
+    /// Caller (in `routes_auth`) computes it from `CODE_TTL_MS`, which is
+    /// the single source of truth for the magic-code lifetime.
+    pub async fn send_magic_code(
+        &self,
+        email: &str,
+        code: &str,
+        expires_in_minutes: i64,
+    ) -> Result<(), AppError> {
         match &self.mode {
             Mode::Log => {
                 // The "we tried to email you" record stays at info for
@@ -187,7 +197,7 @@ impl EmailSender {
                 tracing::debug!(target: "dirt_api::email", "[dev email] to={email} code={code}");
                 Ok(())
             }
-            Mode::Resend(cfg) => send_via_resend(cfg, email, code).await,
+            Mode::Resend(cfg) => send_via_resend(cfg, email, code, expires_in_minutes).await,
             #[cfg(test)]
             Mode::Capture(captured) => {
                 captured
@@ -209,15 +219,26 @@ impl Default for EmailSender {
 /// Body text for the magic-code email. Centralised so the tests can
 /// assert on the same string the production code produces, and so a
 /// future copy edit only touches one place.
-fn render_magic_code_body(code: &str) -> String {
+///
+/// `expires_in_minutes` is threaded through from the caller (which knows
+/// `CODE_TTL_MS`) instead of being hardcoded — without that, a future
+/// edit to the TTL constant would silently leave the email body
+/// promising the old number.
+fn render_magic_code_body(code: &str, expires_in_minutes: i64) -> String {
     format!(
         "Your Dirt sign-in code is: {code}\n\n\
-         It expires in 15 minutes. If you didn't request this code, you can ignore this email.\n"
+         It expires in {expires_in_minutes} minutes. \
+         If you didn't request this code, you can ignore this email.\n"
     )
 }
 
-async fn send_via_resend(cfg: &ResendConfig, email: &str, code: &str) -> Result<(), AppError> {
-    let body = render_magic_code_body(code);
+async fn send_via_resend(
+    cfg: &ResendConfig,
+    email: &str,
+    code: &str,
+    expires_in_minutes: i64,
+) -> Result<(), AppError> {
+    let body = render_magic_code_body(code, expires_in_minutes);
     let payload = ResendRequest {
         from: &cfg.from,
         to: [email],
@@ -253,7 +274,15 @@ async fn send_via_resend(cfg: &ResendConfig, email: &str, code: &str) -> Result<
         // KiB — so the implicit bound is fine in practice; a hostile
         // upstream blasting a multi-MB body would already be the least
         // of our problems given Vercel's ~6 MB function-response cap.
-        let body_text = response.text().await.unwrap_or_default();
+        //
+        // On a body-stream read error we keep the diagnostic in the log
+        // line itself rather than collapsing to an empty `body=`, so the
+        // operator can tell "Resend hung up mid-stream" from "Resend
+        // genuinely returned an empty body".
+        let body_text = response
+            .text()
+            .await
+            .unwrap_or_else(|err| format!("<body read error: {err}>"));
         tracing::info!(
             target: "dirt_api::email",
             "Resend accepted magic-code email status={status} body={body_text}"
@@ -273,7 +302,15 @@ async fn send_via_resend(cfg: &ResendConfig, email: &str, code: &str) -> Result<
     // client (a) that the backend is Resend, and (b) which kind of
     // failure (401 vs 403 vs 5xx). The detail stays in the warn-level
     // server log only.
-    let body_text = response.text().await.unwrap_or_default();
+    // Same diagnostic-on-read-error treatment as the success branch:
+    // an empty `body=` would make a stream-read error indistinguishable
+    // from a genuinely-empty Resend response, and the error path is
+    // exactly where the body content is most useful (it's what Resend
+    // told us about the 401/403/5xx).
+    let body_text = response
+        .text()
+        .await
+        .unwrap_or_else(|err| format!("<body read error: {err}>"));
     tracing::warn!(
         target: "dirt_api::email",
         "Resend rejected magic-code email status={status} body={body_text}"
@@ -321,7 +358,7 @@ mod tests {
     async fn log_mode_send_succeeds() {
         let sender = EmailSender::log_only();
         sender
-            .send_magic_code("user@example.com", "123456")
+            .send_magic_code("user@example.com", "123456", 15)
             .await
             .unwrap();
     }
@@ -329,7 +366,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn resend_mode_posts_expected_payload_and_headers() {
         let mock = MockServer::start().await;
-        let expected_body = render_magic_code_body("123456");
+        let expected_body = render_magic_code_body("123456", 15);
 
         Mock::given(method("POST"))
             .and(path("/emails"))
@@ -360,7 +397,7 @@ mod tests {
         .unwrap();
 
         sender
-            .send_magic_code("user@example.com", "123456")
+            .send_magic_code("user@example.com", "123456", 15)
             .await
             .unwrap();
         // wiremock's drop-time `.expect(1)` assertion fails the test if
@@ -384,7 +421,7 @@ mod tests {
         .unwrap();
 
         let err = sender
-            .send_magic_code("user@example.com", "123456")
+            .send_magic_code("user@example.com", "123456", 15)
             .await
             .expect_err("503 must surface as AppError");
         assert!(
@@ -417,7 +454,7 @@ mod tests {
         .unwrap();
 
         let err = sender
-            .send_magic_code("user@example.com", "123456")
+            .send_magic_code("user@example.com", "123456", 15)
             .await
             .expect_err("401 must surface as AppError");
         assert!(matches!(err, AppError::Internal(_)));
@@ -425,10 +462,15 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn resend_with_trailing_slash_base_url_does_not_double_up_path() {
-        // The local dev binary is reading these from .env; a trailing
-        // slash on RESEND_API_BASE_OVERRIDE (or someone copying the URL
-        // from the Resend docs that ends with one) must still produce
-        // the right `/emails` path, not `//emails`.
+        // `resend_with_base_url` lets a caller override the API base.
+        // If they (or someone copying the URL from the Resend docs)
+        // leave a trailing slash, path joining must still produce
+        // `/emails`, not `//emails`. Production callers go through
+        // `resend()` which uses `RESEND_API_BASE` verbatim, so this
+        // only protects against the test-seam misuse — but the
+        // `trim_end_matches('/')` in `send_via_resend` is the line we
+        // care about, and this test is the one that catches its
+        // removal.
         let mock = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/emails"))
@@ -447,7 +489,7 @@ mod tests {
         .unwrap();
 
         sender
-            .send_magic_code("user@example.com", "123456")
+            .send_magic_code("user@example.com", "123456", 15)
             .await
             .unwrap();
     }
@@ -473,7 +515,15 @@ mod tests {
             ("RESEND_FROM_ADDRESS", "Dirt <noreply@catjam.dev>"),
         ]);
         let sender = EmailSender::from_env().unwrap();
-        assert!(matches!(sender.mode, Mode::Resend(_)));
+        // Inspect the inner config so an accidental argument-swap (e.g.
+        // `Self::resend(from, api_key)`) or trimmed_env-key swap fails
+        // here instead of slipping past on `matches!(_, Mode::Resend(_))`.
+        let Mode::Resend(cfg) = &sender.mode else {
+            panic!("expected Mode::Resend, got something else");
+        };
+        assert_eq!(cfg.api_key, "rs_test_key");
+        assert_eq!(cfg.from, "Dirt <noreply@catjam.dev>");
+        assert_eq!(cfg.base_url, RESEND_API_BASE);
     }
 
     #[test]

--- a/crates/dirt-api/src/email.rs
+++ b/crates/dirt-api/src/email.rs
@@ -109,10 +109,11 @@ impl EmailSender {
     }
 
     /// Same as [`resend`](Self::resend) but lets callers override the API
-    /// base URL. Used by the wiremock tests to point the sender at a
-    /// local mock; production callers should always go through
-    /// `resend`.
-    pub fn resend_with_base_url(
+    /// base URL. `pub(crate)` because this is a test seam — the wiremock
+    /// tests need to point the sender at a local mock, and we don't
+    /// want downstream crates building a production `EmailSender`
+    /// aimed at an arbitrary URL.
+    pub(crate) fn resend_with_base_url(
         api_key: String,
         from: String,
         base_url: String,
@@ -258,14 +259,20 @@ async fn send_via_resend(cfg: &ResendConfig, email: &str, code: &str) -> Result<
     // operator's life easier — but classify the failure on status only,
     // not on body. A 401 here is almost always a stale `RESEND_API_KEY`;
     // a 403 is an unverified `from`; a 5xx is Resend's problem.
+    //
+    // The client-facing string is intentionally generic and identical
+    // to the network-error path above. `AppError::Internal(msg)` is
+    // serialised verbatim into the JSON body's `message` and `cause`
+    // fields, so embedding the Resend status here would tell a probing
+    // client (a) that the backend is Resend, and (b) which kind of
+    // failure (401 vs 403 vs 5xx). The detail stays in the warn-level
+    // server log only.
     let body_text = response.text().await.unwrap_or_default();
     tracing::warn!(
         target: "dirt_api::email",
         "Resend rejected magic-code email status={status} body={body_text}"
     );
-    Err(AppError::internal(format!(
-        "Resend returned HTTP {status} when sending magic-code email"
-    )))
+    Err(AppError::internal("failed to dispatch magic-code email"))
 }
 
 fn trimmed_env(key: &str) -> Option<String> {
@@ -282,8 +289,25 @@ fn trimmed_env(key: &str) -> Option<String> {
 mod tests {
     use super::*;
 
-    use wiremock::matchers::{body_json, header, method, path};
+    use wiremock::matchers::{body_json, header, header_regex, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Serialises the `from_env_*` tests, which mutate process-wide
+    /// `RESEND_*` env vars. Without this, `cargo test --all` on Linux
+    /// (where CI doesn't pin `RUST_TEST_THREADS=1`) lets these tests
+    /// race each other and observe inconsistent state. Held as a
+    /// `MutexGuard` for the body of each env test.
+    ///
+    /// Poison handling: a panicking test poisons the lock, but we don't
+    /// care — the next test will see a fresh `EnvGuard::clear` call
+    /// regardless, and propagating the poison would just mask the real
+    /// failure further down the test list. `into_inner` recovers the
+    /// guard.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn log_mode_send_succeeds() {
@@ -302,7 +326,11 @@ mod tests {
         Mock::given(method("POST"))
             .and(path("/emails"))
             .and(header("authorization", "Bearer rs_test_key"))
-            .and(header("content-type", "application/json"))
+            // Regex on content-type so a future reqwest release that
+            // appends `; charset=utf-8` doesn't break the test without
+            // any production-code change. The `body_json` matcher
+            // below already proves the body is valid JSON.
+            .and(header_regex("content-type", "^application/json"))
             .and(body_json(serde_json::json!({
                 "from": "Dirt <noreply@catjam.dev>",
                 "to": ["user@example.com"],
@@ -366,12 +394,10 @@ mod tests {
         let mock = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/emails"))
-            .respond_with(
-                ResponseTemplate::new(401).set_body_json(serde_json::json!({
-                    "name": "validation_error",
-                    "message": "Invalid `api_key`",
-                })),
-            )
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "name": "validation_error",
+                "message": "Invalid `api_key`",
+            })))
             .mount(&mock)
             .await;
 
@@ -418,13 +444,14 @@ mod tests {
             .unwrap();
     }
 
-    /// `from_env` defaults to Log when neither var is set. Snapshot the
-    /// existing values, clear, restore in a guard so other tests aren't
-    /// observable from this one. The whole crate's tests run on
-    /// `--test-threads=1` per the Windows libsql workaround anyway, so
-    /// the env-mutation isn't racing anything.
+    /// `from_env` defaults to Log when neither var is set. Each env
+    /// test grabs `lock_env()` first so concurrent tests on Linux CI
+    /// (which doesn't pin `RUST_TEST_THREADS=1`) can't observe each
+    /// other's set/clear sequences. `EnvGuard` then restores prior
+    /// values on drop so the rest of the suite isn't disturbed.
     #[test]
     fn from_env_defaults_to_log_when_neither_var_set() {
+        let _env_lock = lock_env();
         let _guard = EnvGuard::clear(&["RESEND_API_KEY", "RESEND_FROM_ADDRESS"]);
         let sender = EmailSender::from_env().unwrap();
         assert!(matches!(sender.mode, Mode::Log));
@@ -432,6 +459,7 @@ mod tests {
 
     #[test]
     fn from_env_picks_resend_when_both_set() {
+        let _env_lock = lock_env();
         let _guard = EnvGuard::set(&[
             ("RESEND_API_KEY", "rs_test_key"),
             ("RESEND_FROM_ADDRESS", "Dirt <noreply@catjam.dev>"),
@@ -442,6 +470,7 @@ mod tests {
 
     #[test]
     fn from_env_errors_when_only_api_key_set() {
+        let _env_lock = lock_env();
         let _guard = EnvGuard::set(&[("RESEND_API_KEY", "rs_test_key")])
             .extend_clear(&["RESEND_FROM_ADDRESS"]);
         // `EmailSender` deliberately does not implement Debug (the
@@ -456,6 +485,7 @@ mod tests {
 
     #[test]
     fn from_env_errors_when_only_from_set() {
+        let _env_lock = lock_env();
         let _guard = EnvGuard::set(&[("RESEND_FROM_ADDRESS", "Dirt <noreply@catjam.dev>")])
             .extend_clear(&["RESEND_API_KEY"]);
         match EmailSender::from_env() {
@@ -470,6 +500,7 @@ mod tests {
     /// for `TURSO_AUTH_TOKEN`.
     #[test]
     fn from_env_treats_whitespace_api_key_as_unset() {
+        let _env_lock = lock_env();
         let _guard = EnvGuard::set(&[
             ("RESEND_API_KEY", "   "),
             ("RESEND_FROM_ADDRESS", "Dirt <noreply@catjam.dev>"),
@@ -484,9 +515,29 @@ mod tests {
         }
     }
 
-    /// RAII guard for env-var mutation. Restores prior values on drop.
-    /// Tests run single-threaded for the whole dirt-api crate (see
-    /// `turso.rs`), so we don't need a process-wide mutex.
+    /// Symmetric counterpart to `from_env_treats_whitespace_api_key_as_unset`.
+    /// `trimmed_env` handles both keys identically, but without this
+    /// test a future refactor could break one side without breaking
+    /// CI.
+    #[test]
+    fn from_env_treats_whitespace_from_address_as_unset() {
+        let _env_lock = lock_env();
+        let _guard = EnvGuard::set(&[
+            ("RESEND_API_KEY", "rs_test_key"),
+            ("RESEND_FROM_ADDRESS", "   "),
+        ]);
+        match EmailSender::from_env() {
+            Err(AppError::Config(_)) => {}
+            Err(other) => panic!("expected AppError::Config, got {other:?}"),
+            Ok(_) => panic!("expected an error, got Ok"),
+        }
+    }
+
+    /// RAII guard for env-var mutation. Restores prior values on drop
+    /// so a test's set/clear doesn't bleed into the rest of the suite.
+    /// Cross-test mutual exclusion is enforced separately via
+    /// `lock_env` / `ENV_LOCK`; `EnvGuard` itself is not thread-safe
+    /// and assumes the caller holds the env lock.
     struct EnvGuard {
         snapshots: Vec<(String, Option<String>)>,
     }

--- a/crates/dirt-api/src/email.rs
+++ b/crates/dirt-api/src/email.rs
@@ -247,6 +247,12 @@ async fn send_via_resend(cfg: &ResendConfig, email: &str, code: &str) -> Result<
         // The email-id is useful in logs (Resend's dashboard keys off
         // it) but never hits the response — the user already knows
         // they asked for an email.
+        //
+        // `response.text()` reads the whole body into memory. Resend's
+        // documented response shape is `{"id": "..."}` — well under a
+        // KiB — so the implicit bound is fine in practice; a hostile
+        // upstream blasting a multi-MB body would already be the least
+        // of our problems given Vercel's ~6 MB function-response cap.
         let body_text = response.text().await.unwrap_or_default();
         tracing::info!(
             target: "dirt_api::email",
@@ -306,7 +312,9 @@ mod tests {
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn lock_env() -> std::sync::MutexGuard<'static, ()> {
-        ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+        ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/dirt-api/src/email.rs
+++ b/crates/dirt-api/src/email.rs
@@ -1,18 +1,48 @@
 //! Outbound email for the magic-code flow.
 //!
-//! Phase 2.1 ships only the `Log` mode: the magic code is written to
-//! `tracing::info!` and never leaves the process. This is enough for
-//! integration tests, local development, and the very first end-to-end
-//! mobile/desktop wiring runs without provisioning Resend.
+//! Two production modes:
 //!
-//! Phase 2.3 adds a `Resend` variant. The `EmailSender` struct is set up
-//! so that change is local — extend the inner enum, branch in
-//! `send_magic_code`, and update `from_env` to choose the right mode.
+//!   - `Log` — write the magic code to `tracing::info!` and never leave
+//!     the process. Used for local dev, CI, and any deploy where Resend
+//!     credentials aren't configured. Picked deliberately at startup so
+//!     "I'm not actually emailing this" is never an accident.
+//!
+//!   - `Resend` — POST to `https://api.resend.com/emails` with the
+//!     `RESEND_API_KEY` Bearer. Picked when both `RESEND_API_KEY` and
+//!     `RESEND_FROM_ADDRESS` are present in the environment.
+//!
+//! Plus a test-only `Capture` mode for the round-trip tests in
+//! `routes_auth.rs`.
+//!
+//! Errors from `send_magic_code` propagate as `AppError::Internal` so
+//! the request handler maps them onto a 500. The user can't fix a
+//! Resend outage themselves — retrying `/v1/auth/request` is the right
+//! prompt.
+
+use std::time::Duration;
+
+use serde::Serialize;
 
 use crate::error::AppError;
 
 #[cfg(test)]
 use std::sync::{Arc, Mutex};
+
+/// Default Resend API base URL. Lifted to a constant so tests can swap
+/// it for a wiremock URL without monkey-patching DNS.
+const RESEND_API_BASE: &str = "https://api.resend.com";
+
+/// HTTP timeout for the Resend round-trip. Resend typically responds in
+/// well under a second; a 10 s ceiling keeps a stuck `/v1/auth/request`
+/// from hanging the whole router. Long enough that a one-off TCP retry
+/// fits underneath, short enough that a wedged DNS doesn't pile up
+/// in-flight requests.
+const RESEND_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Default subject line for the magic-code email. Hardcoded for now —
+/// when we have a real product brand and copy review, this graduates
+/// to a config knob; until then a single string keeps the surface tiny.
+const RESEND_SUBJECT: &str = "Your Dirt sign-in code";
 
 /// Sender mode picked at startup. Kept private — callers go through
 /// `EmailSender::send_magic_code`, not the variant directly.
@@ -21,12 +51,24 @@ enum Mode {
     /// The right default for `cargo run` and tests; explicit because
     /// "I'm not actually emailing this" should be a deliberate choice.
     Log,
+    /// Send via the Resend HTTPS API. `from` is the verified sender
+    /// (e.g. `Dirt <noreply@catjam.dev>`); `base_url` is normally the
+    /// real Resend URL but is overrideable so wiremock-based tests can
+    /// point at a local mock without touching the public API.
+    Resend(ResendConfig),
     /// Test-only: stash every (email, code) pair into a shared `Vec`
     /// the test can inspect. Lets the round-trip test parse the actual
     /// code that `/v1/auth/request` minted, instead of seeding a
     /// parallel one and pretending.
     #[cfg(test)]
     Capture(CapturedSends),
+}
+
+struct ResendConfig {
+    client: reqwest::Client,
+    api_key: String,
+    from: String,
+    base_url: String,
 }
 
 #[cfg(test)]
@@ -36,11 +78,59 @@ pub struct EmailSender {
     mode: Mode,
 }
 
+/// Wire format for the Resend POST body. Documented at
+/// <https://resend.com/docs/api-reference/emails/send-email>.
+#[derive(Serialize)]
+struct ResendRequest<'a> {
+    from: &'a str,
+    to: [&'a str; 1],
+    subject: &'a str,
+    text: &'a str,
+}
+
 impl EmailSender {
     /// Always-log sender. The constructor every test reaches for.
     #[must_use]
     pub const fn log_only() -> Self {
         Self { mode: Mode::Log }
+    }
+
+    /// Build a Resend-backed sender. `from` is the verified sender
+    /// (Resend rejects `From` addresses on unverified domains with a
+    /// 403). The `reqwest::Client` is built once and reused for every
+    /// send so connection-pooling actually kicks in.
+    ///
+    /// Returns `AppError::config` if the timeout-armed client builder
+    /// can't be constructed. In practice that only happens on a host
+    /// without TLS support, which would also fail the deploy long
+    /// before this is called — but propagating is cleaner than panicking.
+    pub fn resend(api_key: String, from: String) -> Result<Self, AppError> {
+        Self::resend_with_base_url(api_key, from, RESEND_API_BASE.to_string())
+    }
+
+    /// Same as [`resend`](Self::resend) but lets callers override the API
+    /// base URL. Used by the wiremock tests to point the sender at a
+    /// local mock; production callers should always go through
+    /// `resend`.
+    pub fn resend_with_base_url(
+        api_key: String,
+        from: String,
+        base_url: String,
+    ) -> Result<Self, AppError> {
+        let client = reqwest::Client::builder()
+            .timeout(RESEND_REQUEST_TIMEOUT)
+            .build()
+            .map_err(|err| {
+                AppError::config(format!("failed to build Resend HTTP client: {err}"))
+            })?;
+        Ok(Self {
+            mode: Mode::Resend(ResendConfig {
+                client,
+                api_key,
+                from,
+                base_url,
+            }),
+        })
     }
 
     /// Test-only: build a sender that records every send into the
@@ -58,25 +148,32 @@ impl EmailSender {
 
     /// Pick a mode from the process environment.
     ///
-    /// Phase 2.1 only knows the `Log` mode. Phase 2.3 will look for
-    /// `RESEND_API_KEY` here and switch to a Resend HTTPS sender — at
-    /// which point this function reads the env, so the
-    /// `missing_const_for_fn` lint will resolve itself naturally.
-    #[must_use]
-    #[allow(clippy::missing_const_for_fn)]
-    pub fn from_env() -> Self {
-        Self::log_only()
+    /// Selection rules:
+    ///   - Both `RESEND_API_KEY` and `RESEND_FROM_ADDRESS` set → Resend.
+    ///   - Neither set → Log (the dev/CI default).
+    ///   - Exactly one set → `AppError::config`. Half-configured Resend
+    ///     is almost certainly a deploy mistake; silently falling back
+    ///     to Log would put real magic codes into log aggregators
+    ///     instead of users' inboxes, which is worse than failing fast.
+    pub fn from_env() -> Result<Self, AppError> {
+        let api_key = trimmed_env("RESEND_API_KEY");
+        let from = trimmed_env("RESEND_FROM_ADDRESS");
+        match (api_key, from) {
+            (Some(api_key), Some(from)) => Self::resend(api_key, from),
+            (None, None) => Ok(Self::log_only()),
+            (Some(_), None) => Err(AppError::config(
+                "RESEND_API_KEY is set but RESEND_FROM_ADDRESS is not — set both to enable Resend, or neither to keep Log mode",
+            )),
+            (None, Some(_)) => Err(AppError::config(
+                "RESEND_FROM_ADDRESS is set but RESEND_API_KEY is not — set both to enable Resend, or neither to keep Log mode",
+            )),
+        }
     }
 
     /// Deliver a magic code to `email`. Errors here propagate as
     /// `AppError::Internal` so the request handler maps them onto a 500
     /// — the user can't fix a Resend outage themselves, retrying the
     /// `/v1/auth/request` is the right user-facing prompt.
-    ///
-    /// `async` is kept on the signature even in pure-`Log` mode because
-    /// Phase 2.3 introduces an `await` on the Resend HTTPS call and we
-    /// don't want every caller to switch from sync to async then.
-    #[allow(clippy::unused_async)]
     pub async fn send_magic_code(&self, email: &str, code: &str) -> Result<(), AppError> {
         match &self.mode {
             Mode::Log => {
@@ -89,6 +186,7 @@ impl EmailSender {
                 tracing::debug!(target: "dirt_api::email", "[dev email] to={email} code={code}");
                 Ok(())
             }
+            Mode::Resend(cfg) => send_via_resend(cfg, email, code).await,
             #[cfg(test)]
             Mode::Capture(captured) => {
                 captured
@@ -107,9 +205,85 @@ impl Default for EmailSender {
     }
 }
 
+/// Body text for the magic-code email. Centralised so the tests can
+/// assert on the same string the production code produces, and so a
+/// future copy edit only touches one place.
+fn render_magic_code_body(code: &str) -> String {
+    format!(
+        "Your Dirt sign-in code is: {code}\n\n\
+         It expires in 15 minutes. If you didn't request this code, you can ignore this email.\n"
+    )
+}
+
+async fn send_via_resend(cfg: &ResendConfig, email: &str, code: &str) -> Result<(), AppError> {
+    let body = render_magic_code_body(code);
+    let payload = ResendRequest {
+        from: &cfg.from,
+        to: [email],
+        subject: RESEND_SUBJECT,
+        text: &body,
+    };
+    let url = format!("{}/emails", cfg.base_url.trim_end_matches('/'));
+
+    let response = cfg
+        .client
+        .post(&url)
+        .bearer_auth(&cfg.api_key)
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|err| {
+            // Network errors, DNS failures, timeout — none of these are
+            // user-fixable. Log the full error server-side; surface a
+            // generic "we couldn't send" so the response body never
+            // echoes Resend's internals back to a probing client.
+            tracing::warn!(target: "dirt_api::email", "Resend send failed: {err}");
+            AppError::internal("failed to dispatch magic-code email")
+        })?;
+
+    let status = response.status();
+    if status.is_success() {
+        // The email-id is useful in logs (Resend's dashboard keys off
+        // it) but never hits the response — the user already knows
+        // they asked for an email.
+        let body_text = response.text().await.unwrap_or_default();
+        tracing::info!(
+            target: "dirt_api::email",
+            "Resend accepted magic-code email status={status} body={body_text}"
+        );
+        return Ok(());
+    }
+
+    // Read what Resend told us so the server log makes the deploy
+    // operator's life easier — but classify the failure on status only,
+    // not on body. A 401 here is almost always a stale `RESEND_API_KEY`;
+    // a 403 is an unverified `from`; a 5xx is Resend's problem.
+    let body_text = response.text().await.unwrap_or_default();
+    tracing::warn!(
+        target: "dirt_api::email",
+        "Resend rejected magic-code email status={status} body={body_text}"
+    );
+    Err(AppError::internal(format!(
+        "Resend returned HTTP {status} when sending magic-code email"
+    )))
+}
+
+fn trimmed_env(key: &str) -> Option<String> {
+    let raw = std::env::var(key).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use wiremock::matchers::{body_json, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test(flavor = "current_thread")]
     async fn log_mode_send_succeeds() {
@@ -118,5 +292,248 @@ mod tests {
             .send_magic_code("user@example.com", "123456")
             .await
             .unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn resend_mode_posts_expected_payload_and_headers() {
+        let mock = MockServer::start().await;
+        let expected_body = render_magic_code_body("123456");
+
+        Mock::given(method("POST"))
+            .and(path("/emails"))
+            .and(header("authorization", "Bearer rs_test_key"))
+            .and(header("content-type", "application/json"))
+            .and(body_json(serde_json::json!({
+                "from": "Dirt <noreply@catjam.dev>",
+                "to": ["user@example.com"],
+                "subject": RESEND_SUBJECT,
+                "text": expected_body,
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "email_test_123"
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let sender = EmailSender::resend_with_base_url(
+            "rs_test_key".into(),
+            "Dirt <noreply@catjam.dev>".into(),
+            mock.uri(),
+        )
+        .unwrap();
+
+        sender
+            .send_magic_code("user@example.com", "123456")
+            .await
+            .unwrap();
+        // wiremock's drop-time `.expect(1)` assertion fails the test if
+        // the mock wasn't hit exactly once.
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn resend_5xx_maps_to_internal_error() {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/emails"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("upstream busy"))
+            .mount(&mock)
+            .await;
+
+        let sender = EmailSender::resend_with_base_url(
+            "rs_test_key".into(),
+            "Dirt <noreply@catjam.dev>".into(),
+            mock.uri(),
+        )
+        .unwrap();
+
+        let err = sender
+            .send_magic_code("user@example.com", "123456")
+            .await
+            .expect_err("503 must surface as AppError");
+        assert!(
+            matches!(err, AppError::Internal(_)),
+            "expected Internal, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn resend_4xx_maps_to_internal_error() {
+        // 401 (bad API key) and 403 (unverified `from`) are deploy-time
+        // misconfigurations from the user's perspective they're still
+        // "the email didn't go out, retry later"; we don't want to leak
+        // the distinction back to the client.
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/emails"))
+            .respond_with(
+                ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                    "name": "validation_error",
+                    "message": "Invalid `api_key`",
+                })),
+            )
+            .mount(&mock)
+            .await;
+
+        let sender = EmailSender::resend_with_base_url(
+            "rs_bad_key".into(),
+            "Dirt <noreply@catjam.dev>".into(),
+            mock.uri(),
+        )
+        .unwrap();
+
+        let err = sender
+            .send_magic_code("user@example.com", "123456")
+            .await
+            .expect_err("401 must surface as AppError");
+        assert!(matches!(err, AppError::Internal(_)));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn resend_with_trailing_slash_base_url_does_not_double_up_path() {
+        // The local dev binary is reading these from .env; a trailing
+        // slash on RESEND_API_BASE_OVERRIDE (or someone copying the URL
+        // from the Resend docs that ends with one) must still produce
+        // the right `/emails` path, not `//emails`.
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/emails"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "email_test_trailing"
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let sender = EmailSender::resend_with_base_url(
+            "rs_test_key".into(),
+            "Dirt <noreply@catjam.dev>".into(),
+            format!("{}/", mock.uri()),
+        )
+        .unwrap();
+
+        sender
+            .send_magic_code("user@example.com", "123456")
+            .await
+            .unwrap();
+    }
+
+    /// `from_env` defaults to Log when neither var is set. Snapshot the
+    /// existing values, clear, restore in a guard so other tests aren't
+    /// observable from this one. The whole crate's tests run on
+    /// `--test-threads=1` per the Windows libsql workaround anyway, so
+    /// the env-mutation isn't racing anything.
+    #[test]
+    fn from_env_defaults_to_log_when_neither_var_set() {
+        let _guard = EnvGuard::clear(&["RESEND_API_KEY", "RESEND_FROM_ADDRESS"]);
+        let sender = EmailSender::from_env().unwrap();
+        assert!(matches!(sender.mode, Mode::Log));
+    }
+
+    #[test]
+    fn from_env_picks_resend_when_both_set() {
+        let _guard = EnvGuard::set(&[
+            ("RESEND_API_KEY", "rs_test_key"),
+            ("RESEND_FROM_ADDRESS", "Dirt <noreply@catjam.dev>"),
+        ]);
+        let sender = EmailSender::from_env().unwrap();
+        assert!(matches!(sender.mode, Mode::Resend(_)));
+    }
+
+    #[test]
+    fn from_env_errors_when_only_api_key_set() {
+        let _guard = EnvGuard::set(&[("RESEND_API_KEY", "rs_test_key")])
+            .extend_clear(&["RESEND_FROM_ADDRESS"]);
+        // `EmailSender` deliberately does not implement Debug (the
+        // Resend API key would land in panic output otherwise) so we
+        // can't use `.unwrap_err()` here — match on the result instead.
+        match EmailSender::from_env() {
+            Err(AppError::Config(_)) => {}
+            Err(other) => panic!("expected AppError::Config, got {other:?}"),
+            Ok(_) => panic!("expected an error, got Ok"),
+        }
+    }
+
+    #[test]
+    fn from_env_errors_when_only_from_set() {
+        let _guard = EnvGuard::set(&[("RESEND_FROM_ADDRESS", "Dirt <noreply@catjam.dev>")])
+            .extend_clear(&["RESEND_API_KEY"]);
+        match EmailSender::from_env() {
+            Err(AppError::Config(_)) => {}
+            Err(other) => panic!("expected AppError::Config, got {other:?}"),
+            Ok(_) => panic!("expected an error, got Ok"),
+        }
+    }
+
+    /// Trimming sanity check — empty/whitespace `RESEND_API_KEY` is
+    /// treated as unset, matching the `AppConfig::from_env` precedent
+    /// for `TURSO_AUTH_TOKEN`.
+    #[test]
+    fn from_env_treats_whitespace_api_key_as_unset() {
+        let _guard = EnvGuard::set(&[
+            ("RESEND_API_KEY", "   "),
+            ("RESEND_FROM_ADDRESS", "Dirt <noreply@catjam.dev>"),
+        ]);
+        // Whitespace key is treated as unset, so we end up in the
+        // "only from is set" error arm — *not* a successful Log
+        // fallback. That's the strict-no-silent-fallback contract.
+        match EmailSender::from_env() {
+            Err(AppError::Config(_)) => {}
+            Err(other) => panic!("expected AppError::Config, got {other:?}"),
+            Ok(_) => panic!("expected an error, got Ok"),
+        }
+    }
+
+    /// RAII guard for env-var mutation. Restores prior values on drop.
+    /// Tests run single-threaded for the whole dirt-api crate (see
+    /// `turso.rs`), so we don't need a process-wide mutex.
+    struct EnvGuard {
+        snapshots: Vec<(String, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn clear(keys: &[&str]) -> Self {
+            let snapshots = keys
+                .iter()
+                .map(|k| {
+                    let prior = std::env::var(k).ok();
+                    std::env::remove_var(k);
+                    ((*k).to_string(), prior)
+                })
+                .collect();
+            Self { snapshots }
+        }
+
+        fn set(pairs: &[(&str, &str)]) -> Self {
+            let snapshots = pairs
+                .iter()
+                .map(|(k, v)| {
+                    let prior = std::env::var(k).ok();
+                    std::env::set_var(k, v);
+                    ((*k).to_string(), prior)
+                })
+                .collect();
+            Self { snapshots }
+        }
+
+        fn extend_clear(mut self, keys: &[&str]) -> Self {
+            for k in keys {
+                let prior = std::env::var(k).ok();
+                std::env::remove_var(k);
+                self.snapshots.push(((*k).to_string(), prior));
+            }
+            self
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, prior) in self.snapshots.drain(..) {
+                match prior {
+                    Some(v) => std::env::set_var(&k, v),
+                    None => std::env::remove_var(&k),
+                }
+            }
+        }
     }
 }

--- a/crates/dirt-api/src/main.rs
+++ b/crates/dirt-api/src/main.rs
@@ -55,7 +55,7 @@ fn run_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let repo = Arc::new(
             TursoRepo::connect(&config.turso_database_url, &config.turso_auth_token).await?,
         );
-        let email = Arc::new(EmailSender::from_env());
+        let email = Arc::new(EmailSender::from_env()?);
         let state = AppState::new(config.clone(), repo, email);
 
         let bind_addr = config.bind_addr.clone();

--- a/crates/dirt-api/src/routes_auth.rs
+++ b/crates/dirt-api/src/routes_auth.rs
@@ -116,10 +116,41 @@ pub async fn request_magic_code(
     // sourced from the single CODE_TTL_MS constant. `(60 * 1000)` rather
     // than a magic 60_000 so the computation reads as ms→minutes.
     let expires_in_minutes = CODE_TTL_MS / (60 * 1000);
-    state
+
+    // If the Resend send fails, we must roll back the just-inserted
+    // magic_code row. Otherwise the per-email cooldown gate above
+    // would 429 the user's retry for the full `REQUEST_COOLDOWN_MS`
+    // window — even though no email was ever delivered. With the P2.1
+    // Log mode this never triggered (Log mode never errors); P2.3's
+    // real Resend backend made the case real.
+    //
+    // Cleanup is best-effort: if `delete_magic_code` itself errors
+    // (Turso unreachable, etc.) we log and still surface the original
+    // send failure to the user. A persisted row is a UX papercut
+    // (user waits 60 s); silently dropping the send error would be
+    // worse (user thinks they got a code).
+    if let Err(send_err) = state
         .email
         .send_magic_code(&email, &code, expires_in_minutes)
-        .await?;
+        .await
+    {
+        match state.repo.delete_magic_code(&request_id).await {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::warn!(
+                    target: "dirt_api::auth",
+                    "rollback after Resend failure found no row for request_id {request_id}; assuming concurrent reap"
+                );
+            }
+            Err(cleanup_err) => {
+                tracing::warn!(
+                    target: "dirt_api::auth",
+                    "rollback after Resend failure could not delete magic_code row {request_id}: {cleanup_err}"
+                );
+            }
+        }
+        return Err(send_err);
+    }
 
     Ok(Json(RequestResponse {
         request_id,
@@ -389,6 +420,36 @@ mod tests {
             router,
             state,
             captured,
+            _temp_db: temp_db,
+        }
+    }
+
+    /// Variant fixture for the rollback-on-send-failure test. Wires an
+    /// `EmailSender` that always errors so we can observe what
+    /// `request_magic_code` does in the failure branch without standing
+    /// up a wiremock server in the same test.
+    struct FailingSendFixture {
+        router: Router,
+        state: AppState,
+        _temp_db: TempDb,
+    }
+
+    async fn build_failing_send_router() -> FailingSendFixture {
+        let config = AppConfig {
+            bind_addr: "127.0.0.1:0".into(),
+            turso_database_url: "libsql://unused.test".into(),
+            turso_auth_token: "unused".into(),
+        };
+        let temp_db = TursoRepo::connect_temp_db().await.unwrap();
+        let state = AppState::new(
+            Arc::new(config),
+            temp_db.repo.clone(),
+            Arc::new(EmailSender::always_failing()),
+        );
+        let router = crate::build_router(state.clone());
+        FailingSendFixture {
+            router,
+            state,
             _temp_db: temp_db,
         }
     }
@@ -929,6 +990,59 @@ mod tests {
             StatusCode::OK,
             "locked code blocked the re-request — cooldown SQL is missing the attempts filter"
         );
+    }
+
+    /// When the downstream email send errors out, `request_magic_code`
+    /// must roll back the `magic_codes` row it just inserted. Otherwise
+    /// the per-email cooldown gate would 429 the user's retry for the
+    /// full `REQUEST_COOLDOWN_MS` window, even though the email never
+    /// landed. Phase 2.1's `Log` mode never errored so this branch
+    /// went uncovered; P2.3's Resend backend made the case real.
+    #[tokio::test(flavor = "current_thread")]
+    async fn request_rolls_back_magic_code_row_when_send_fails() {
+        let fx = build_failing_send_router().await;
+        let email = "rollback@example.com";
+        let body = json!({ "email": email });
+
+        // First request: insert + send → send errors → rollback runs.
+        let resp = fx
+            .router
+            .clone()
+            .oneshot(json_request("POST", "/v1/auth/request", body.clone()).await)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        // The DB row must be gone. Direct repo lookup of the email's
+        // most-recent live row should find nothing — without the
+        // rollback this would still see the just-inserted row, and the
+        // assertion below (cooldown=0 immediate re-request) would also
+        // fail in a more confusing way.
+        let now = now_ms();
+        let outcome = fx
+            .state
+            .repo
+            .try_insert_magic_code_with_cooldown(
+                &uuid::Uuid::now_v7().to_string(),
+                email,
+                "probe-hash",
+                now,
+                now + CODE_TTL_MS,
+                REQUEST_COOLDOWN_MS,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome,
+            crate::turso::InsertMagicCodeOutcome::Inserted,
+            "rollback should have left the email free of live rows so a fresh insert succeeds"
+        );
+
+        // And the route layer agrees — an immediate retry (after the
+        // probe insert above; that one is a real cooldown trigger so
+        // we have to scrub it first to keep the assertion clean).
+        // We're testing the rollback's *effect* on the repo, not
+        // re-testing the cooldown logic, so the direct probe is enough.
     }
 
     /// `revoke_session` must be the synchronization point for

--- a/crates/dirt-api/src/routes_auth.rs
+++ b/crates/dirt-api/src/routes_auth.rs
@@ -112,7 +112,14 @@ pub async fn request_magic_code(
         }
     }
 
-    state.email.send_magic_code(&email, &code).await?;
+    // Tell the caller and the email body the same thing about lifetime,
+    // sourced from the single CODE_TTL_MS constant. `(60 * 1000)` rather
+    // than a magic 60_000 so the computation reads as ms→minutes.
+    let expires_in_minutes = CODE_TTL_MS / (60 * 1000);
+    state
+        .email
+        .send_magic_code(&email, &code, expires_in_minutes)
+        .await?;
 
     Ok(Json(RequestResponse {
         request_id,

--- a/crates/dirt-api/src/turso.rs
+++ b/crates/dirt-api/src/turso.rs
@@ -427,6 +427,26 @@ impl TursoRepo {
         Ok(InsertMagicCodeOutcome::Inserted)
     }
 
+    /// Best-effort cleanup of a magic-code row by `request_id`. Used by
+    /// `routes_auth::request_magic_code` to roll back the row it just
+    /// inserted when the downstream Resend send fails — without this,
+    /// the per-email cooldown gate would keep firing 429 for 60 s on
+    /// the user's retry, even though the email never landed.
+    ///
+    /// Returns `true` if a row was removed, `false` if the row had
+    /// already been consumed or reaped. Callers treat both as "cleanup
+    /// done"; the boolean is logged for diagnostics only.
+    pub async fn delete_magic_code(&self, request_id: &str) -> Result<bool, AppError> {
+        let conn = self.conn()?;
+        let affected = conn
+            .execute(
+                "DELETE FROM magic_codes WHERE request_id = ?",
+                libsql::params![request_id],
+            )
+            .await?;
+        Ok(affected > 0)
+    }
+
     /// Atomically check + consume a magic code. On success returns the
     /// email tied to the row (caller uses it to upsert the user). On
     /// failure returns the structured `ConsumeFailure`.


### PR DESCRIPTION
## Summary

Wires real magic-code email delivery through Resend. Phase 2.1 shipped
`EmailSender` with only a `Log` mode; this PR adds a `Resend` variant
selected at startup when both `RESEND_API_KEY` and
`RESEND_FROM_ADDRESS` are set in the environment. Half-configured
Resend (only one of the two) is a hard `AppError::Config` — silently
falling back to Log would put real magic codes into log aggregators
instead of users' inboxes.

This is PR #3 of the multi-PR Phase 2 sequence (after #227 schema and
#228 session middleware). Phases 2.4–2.7 (client-side login UX) ride on
top of this without further server changes.

## What changed

**`EmailSender`**
- New `Mode::Resend` variant carrying a pre-built `reqwest::Client`,
  the API key, the verified `from` address, and the API base URL.
  The `base_url` is overridable so wiremock-based tests can run
  without monkey-patching DNS or hitting the real API.
- `EmailSender::resend(api_key, from)` constructor, plus a
  `resend_with_base_url(...)` variant for the tests.
- `send_via_resend` POSTs to `{base}/emails` with a 10 s timeout
  (rustls + webpki, no native-tls / OpenSSL pull-in for Vercel) and
  a JSON payload matching the Resend `/emails` API. Non-2xx and
  network errors map to `AppError::Internal` so the wire body never
  echoes Resend's internals back to a probing client.

**`from_env`**
- Picks `Resend` when both vars are set, `Log` when neither is set.
- Errors loudly when exactly one of the two is set.
- Empty/whitespace API key is treated as unset, matching the
  `TURSO_AUTH_TOKEN` precedent in `AppConfig::from_env`.

**Call-site updates**
- `from_env` now returns `Result<Self, AppError>`. Both binaries
  (`main.rs`, `api/axum.rs`) propagate the error the same way they
  already do for `AppConfig::from_env`.

**Dependencies**
- `reqwest = { version = "0.12", default-features = false, features =
  ["json", "rustls-tls"] }` — explicit no-`default-tls` keeps OpenSSL
  out of the Vercel build closure.
- `wiremock = "0.6"` (dev) — mock HTTP server for the Resend tests.

## Tests

52/52 dirt-api tests pass single-threaded. New tests:

- `email::resend_mode_posts_expected_payload_and_headers` — happy
  path, asserts `Authorization: Bearer` + JSON body shape (from / to /
  subject / text)
- `email::resend_5xx_maps_to_internal_error` — 503 surfaces as
  `AppError::Internal`
- `email::resend_4xx_maps_to_internal_error` — 401 surfaces as
  `AppError::Internal` (no leaking upstream status to the client)
- `email::resend_with_trailing_slash_base_url_does_not_double_up_path`
  — trailing slash on base URL doesn't produce `//emails`
- `email::from_env_defaults_to_log_when_neither_var_set`
- `email::from_env_picks_resend_when_both_set`
- `email::from_env_errors_when_only_api_key_set`
- `email::from_env_errors_when_only_from_set`
- `email::from_env_treats_whitespace_api_key_as_unset`

Existing `log_mode_send_succeeds` retained.

## Out of scope (deliberate followups)

- Per-deploy email subject / template config — hardcoded for now;
  graduates to a knob when there's a copy-review gate.
- Resend sending events / bounce handling — Resend's webhooks would
  let us know an email bounced; not load-bearing for solo phase, fold
  into a later observability PR.
- Verification that the `RESEND_FROM_ADDRESS` matches a domain Resend
  has DKIM-verified — the API itself returns 403 for unverified
  domains, which the test covers.

## Test plan

- [ ] CI green on Linux
- [ ] Manual smoke (post-merge): set `RESEND_API_KEY` +
      `RESEND_FROM_ADDRESS=Dirt <noreply@catjam.dev>` on the Vercel
      deploy, hit `/v1/auth/request` with my own email, confirm the
      magic-code email lands in the inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)