### PR TITLE
Phase 2.7: mobile login + Android KeyStore token store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,12 +1910,15 @@ dependencies = [
  "dirs",
  "dirt-core",
  "dotenvy",
+ "jni",
+ "ndk-context",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/dirt-mobile/Cargo.toml
+++ b/crates/dirt-mobile/Cargo.toml
@@ -40,11 +40,25 @@ thiserror.workspace = true
 [target.'cfg(target_os = "android")'.dependencies]
 dioxus = { workspace = true, features = ["mobile"] }
 dioxus-primitives = { git = "https://github.com/DioxusLabs/components", version = "0.0.1", default-features = false }
+# JNI bridge for the Android-side `TokenStore`. `ndk-context` exposes the
+# JavaVM + Activity handles the Dioxus mobile runtime publishes; `jni`
+# is the Rust binding to Android's Java APIs (KeyStore + AndroidX
+# EncryptedSharedPreferences). Android-only — host builds use the
+# file-backed fallback under `cfg(not(target_os = "android"))`.
+jni = "0.21"
+ndk-context = "0.1"
 
 [build-dependencies]
 dotenvy = "0.15"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+
+[dev-dependencies]
+# `services::sync_worker` tests construct a `SessionApiClient` against
+# a mock HTTP server to exercise the refresh-on-401 path end-to-end
+# (mirrors the dirt-desktop dev-deps so a developer running
+# `cargo test -p dirt-mobile` on Windows / Linux gets the same checks).
+wiremock = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/dirt-mobile/Dioxus.toml
+++ b/crates/dirt-mobile/Dioxus.toml
@@ -1,3 +1,14 @@
 [application]
 android_manifest = "android/AndroidManifest.xml"
 android_main_activity = "android/MainActivity.kt"
+
+# Pull AndroidX Security into the generated APK so the JNI-backed
+# `EncryptedPrefsTokenStore` can call `MasterKey.Builder` and
+# `EncryptedSharedPreferences.create`. Phase 2.7 of the auth migration
+# stores the magic-link session bearer here rather than in an env var.
+# Version is the most recent stable pre-1.1; the API has been frozen
+# since 1.0 so any 1.1.x build is wire-compatible with the JNI bridge.
+[android]
+gradle_dependencies = [
+    "androidx.security:security-crypto:1.1.0-alpha06",
+]

--- a/crates/dirt-mobile/src/app_shell.rs
+++ b/crates/dirt-mobile/src/app_shell.rs
@@ -3,9 +3,9 @@
 //! Owns startup wiring: open the local DB, build an [`AuthClient`] +
 //! [`DefaultTokenStore`] from the build-baked bootstrap (and provide
 //! both via context as [`AuthDeps`]), hydrate any pre-existing session
-//! from the EncryptedSharedPreferences slot, spawn the auto-sync worker
-//! if a token is present, and drain the worker's `SyncEvent` mpsc into
-//! Dioxus signals on the UI side.
+//! from the `EncryptedSharedPreferences` slot, spawn the auto-sync
+//! worker if a token is present, and drain the worker's `SyncEvent`
+//! mpsc into Dioxus signals on the UI side.
 //!
 //! Auth is opt-in in the same sense as desktop: a missing or
 //! never-saved token leaves `SyncStatus::Offline` and does NOT park
@@ -88,7 +88,7 @@ pub fn AppShell() -> Element {
     let mut store_w = store;
     let mut sync_status_w = sync_status;
     let mut sync_issue_w = sync_issue;
-    let mut last_sync_at_w = last_sync_at;
+    let last_sync_at_w = last_sync_at;
     let mut notes_w = notes;
     let mut signed_in_w = signed_in;
     let mut session_client_w = session_client;
@@ -184,7 +184,7 @@ pub fn AppShell() -> Element {
 ///
 /// `token_store` is always populated — `DefaultTokenStore::open` is
 /// fallible on Android (the master-key materialization talks to the
-/// KeyStore) so a failure here is logged + surfaced through the
+/// `KeyStore`) so a failure here is logged + surfaced through the
 /// Account row by leaving `auth_client` / `api_base_url` populated but
 /// the token store unconstructable. We don't have a "no token store"
 /// state in `AuthDeps` because every binary needs to be able to clear
@@ -299,7 +299,7 @@ pub(crate) fn spawn_session_worker(
 }
 
 /// Sentinel `TokenStore` produced when the real store fails to open at
-/// startup (Android KeyStore unreachable, AndroidX class not found,
+/// startup (Android `KeyStore` unreachable, `AndroidX` class not found,
 /// etc.). Every call returns the cached failure message so the
 /// Account row surfaces the same diagnostic on every interaction
 /// rather than silently behaving as "no slot exists".
@@ -308,7 +308,7 @@ struct SentinelTokenStore {
 }
 
 impl SentinelTokenStore {
-    fn new(reason: String) -> Self {
+    const fn new(reason: String) -> Self {
         Self { reason }
     }
 }

--- a/crates/dirt-mobile/src/app_shell.rs
+++ b/crates/dirt-mobile/src/app_shell.rs
@@ -1,35 +1,54 @@
 //! Mobile app shell.
 //!
-//! Owns startup wiring: open the local DB, build the `ApiClient` from
-//! `DIRT_API_BASE_URL` (env override or build-baked) + `DIRT_CLIENT_TOKEN`
-//! (env-only — never baked), spawn the sync worker, and drain the
-//! worker's `SyncEvent` mpsc into Dioxus signals on the UI side.
+//! Owns startup wiring: open the local DB, build an [`AuthClient`] +
+//! [`DefaultTokenStore`] from the build-baked bootstrap (and provide
+//! both via context as [`AuthDeps`]), hydrate any pre-existing session
+//! from the EncryptedSharedPreferences slot, spawn the auto-sync worker
+//! if a token is present, and drain the worker's `SyncEvent` mpsc into
+//! Dioxus signals on the UI side.
+//!
+//! Auth is opt-in in the same sense as desktop: a missing or
+//! never-saved token leaves `SyncStatus::Offline` and does NOT park
+//! `SyncStatus::Error`. The user can sign in via Settings → Account
+//! when they want sync; the magic-link request / verify flow lives in
+//! [`crate::views::settings`].
 //!
 //! Sync is fully background: there is no manual "Sync now" button.
-//! Mutation sites (the editor's save/delete handlers) call
-//! `AppState::trigger_sync()` after a successful local write, the
-//! worker debounces a burst of edits into one round-trip, and the
-//! status banner reflects whatever the worker most recently emitted.
-//!
-//! Misconfiguration is loud: a missing or empty `DIRT_CLIENT_TOKEN`
-//! parks `SyncStatus::Error` and a human-readable message in
-//! `sync_issue`. The list view surfaces both so the user can fix env
-//! setup instead of running silently offline.
+//! Mutation sites (the editor's save / delete handlers) call
+//! [`crate::state::AppState::trigger_sync`] after a successful local
+//! write; the worker debounces a burst of edits into one round-trip,
+//! and the status banner reflects whatever the worker most recently
+//! emitted.
 
 use std::sync::Arc;
 
 use dioxus::prelude::*;
-use dirt_core::sync::api_client::ApiClient;
+use dirt_core::auth::{AuthClient, StoredToken};
+use dirt_core::sync::session_client::SessionApiClient;
 
 use crate::bootstrap_config::{load_bootstrap_config, BootstrapConfig};
 use crate::data::MobileNoteStore;
+use crate::services::auth_store::DefaultTokenStore;
 use crate::services::{spawn_sync_worker, SyncEvent, SyncWorkerHandle};
-use crate::state::{AppState, SyncStatus, View};
+use crate::state::{AppState, AuthDeps, SyncStatus, View};
 use crate::ui::MOBILE_UI_STYLES;
-use crate::views::{Editor, List};
+use crate::views::{Editor, List, Settings};
+
+/// Keyring service identifier for the mobile session token. Matches
+/// the values used in `dirt-cli` and `dirt-desktop` so the trio share
+/// one logical slot — see `reference_keyring_slot.md` in the auto-
+/// memory store and the module-level comment on
+/// [`dirt_core::auth::keyring_store`].
+const SESSION_PREFS_NAME: &str = "dev.dirt.session";
+/// Per-user discriminator inside the preferences file. Solo phase
+/// uses a static `"default"`; multi-user / multi-account would pivot
+/// to a user identifier.
+const SESSION_PREFS_KEY: &str = "default";
 
 #[component]
 pub fn AppShell() -> Element {
+    let bootstrap = load_bootstrap_config();
+
     let notes = use_signal(Vec::new);
     let selected_note_id = use_signal(|| None);
     let view = use_signal(|| View::List);
@@ -38,6 +57,15 @@ pub fn AppShell() -> Element {
     let last_sync_at = use_signal(|| None::<i64>);
     let store: Signal<Option<Arc<MobileNoteStore>>> = use_signal(|| None);
     let sync_worker: Signal<Option<SyncWorkerHandle>> = use_signal(|| None);
+    let signed_in: Signal<Option<StoredToken>> = use_signal(|| None);
+    let session_client: Signal<Option<Arc<SessionApiClient>>> = use_signal(|| None);
+
+    // Auth deps are built once at startup — mobile bootstrap is
+    // build-time-baked, so unlike desktop there's no async manifest
+    // resolver to wait on. Failures to construct the `TokenStore` here
+    // park the deps with `token_store = None`-equivalent behaviour:
+    // the actual error is logged and surfaces through the Account row.
+    let auth_deps_signal: Signal<AuthDeps> = use_signal(|| build_auth_deps(&bootstrap));
 
     use_context_provider(|| AppState {
         notes,
@@ -48,18 +76,22 @@ pub fn AppShell() -> Element {
         last_sync_at,
         store,
         sync_worker,
+        signed_in,
+        session_client,
     });
+    use_context_provider(|| auth_deps_signal);
 
     // One-shot startup. `use_resource` only re-fires if a tracked
     // signal changes; `init_started` keeps the dance idempotent so
     // repeated re-renders don't try to spawn the worker again.
     let mut init_started = use_signal(|| false);
     let mut store_w = store;
-    let mut sync_worker_w = sync_worker;
     let mut sync_status_w = sync_status;
     let mut sync_issue_w = sync_issue;
     let mut last_sync_at_w = last_sync_at;
     let mut notes_w = notes;
+    let mut signed_in_w = signed_in;
+    let mut session_client_w = session_client;
 
     let _init = use_resource(move || async move {
         if init_started() {
@@ -90,41 +122,36 @@ pub fn AppShell() -> Element {
 
         store_w.set(Some(opened.clone()));
 
-        let bootstrap = load_bootstrap_config();
-        match build_api_client(&bootstrap) {
-            Ok(api) => {
-                let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<SyncEvent>();
-                let handle = spawn_sync_worker(opened.clone(), Arc::new(api), tx);
-                sync_worker_w.set(Some(handle));
-
-                // Drain status events into signals. Using a separate
-                // task here (rather than polling) keeps the UI thread
-                // free of mpsc work and means the status updates land
-                // as soon as the worker emits them.
-                let store_for_refresh = opened.clone();
-                spawn(async move {
-                    while let Some(event) = rx.recv().await {
-                        match event {
-                            SyncEvent::Status(status) => sync_status_w.set(status),
-                            SyncEvent::Issue(issue) => sync_issue_w.set(issue),
-                            SyncEvent::LastSync(ts) => {
-                                last_sync_at_w.set(Some(ts));
-                                // A successful sync may have applied
-                                // pulled rows; refresh the list so
-                                // remote changes show up without a
-                                // manual reload.
-                                if let Ok(refreshed) = store_for_refresh.list_notes().await {
-                                    notes_w.set(refreshed);
-                                }
-                            }
-                        }
-                    }
-                });
-
+        let deps = auth_deps_signal.read().clone();
+        match hydrate_session(&deps) {
+            Ok(Some(session)) => {
+                let stored = deps.token_store.load().ok().flatten();
+                signed_in_w.set(stored);
+                let session_arc = Arc::new(session);
+                session_client_w.set(Some(session_arc.clone()));
+                spawn_session_worker(
+                    opened.clone(),
+                    session_arc,
+                    sync_worker,
+                    sync_status_w,
+                    sync_issue_w,
+                    last_sync_at_w,
+                    notes_w,
+                );
                 tracing::info!("Mobile sync worker spawned");
             }
+            Ok(None) => {
+                // No token in the EncryptedSharedPreferences slot — sync
+                // is opt-in. Leave the worker unspawned and the status
+                // at Offline; the user can sign in via Settings →
+                // Account when they want sync.
+                signed_in_w.set(None);
+                session_client_w.set(None);
+                sync_status_w.set(SyncStatus::Offline);
+                sync_issue_w.set(None);
+            }
             Err(error) => {
-                tracing::error!("Sync worker not started: {error}");
+                tracing::error!("Session hydrate failed: {error}");
                 sync_status_w.set(SyncStatus::Error);
                 sync_issue_w.set(Some(error));
             }
@@ -147,35 +174,161 @@ pub fn AppShell() -> Element {
             match current_view {
                 View::List => rsx! { List {} },
                 View::Editor => rsx! { Editor {} },
+                View::Settings => rsx! { Settings {} },
             }
         }
     }
 }
 
-/// Resolve API base URL + client token at app launch.
+/// Build the [`AuthDeps`] context value from the bootstrap manifest.
 ///
-/// `DIRT_API_BASE_URL` falls back to the build-baked bootstrap value so
-/// a packaged APK works without runtime env config. `DIRT_CLIENT_TOKEN`
-/// is runtime-only — baking a bearer token into a binary that ships to
-/// users is a non-starter. A missing or empty token is a hard error:
-/// the worker won't start, the banner shows `Error`, and the user has
-/// to fix their environment rather than the app silently running
-/// without sync.
-fn build_api_client(bootstrap: &BootstrapConfig) -> Result<ApiClient, String> {
-    let base_url = std::env::var("DIRT_API_BASE_URL")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
-        .or_else(|| bootstrap.dirt_api_base_url.clone())
-        .ok_or_else(|| {
-            "DIRT_API_BASE_URL is not configured (set it in the environment or in .env.client at build time).".to_string()
-        })?;
+/// `token_store` is always populated — `DefaultTokenStore::open` is
+/// fallible on Android (the master-key materialization talks to the
+/// KeyStore) so a failure here is logged + surfaced through the
+/// Account row by leaving `auth_client` / `api_base_url` populated but
+/// the token store unconstructable. We don't have a "no token store"
+/// state in `AuthDeps` because every binary needs to be able to clear
+/// the slot on logout — instead, a construction failure parks the
+/// store as a sentinel that reports `Backend` on every call.
+fn build_auth_deps(bootstrap: &BootstrapConfig) -> AuthDeps {
+    let api_base_url = bootstrap
+        .dirt_api_base_url
+        .as_deref()
+        .filter(|value| !value.trim().is_empty());
 
-    let token = std::env::var("DIRT_CLIENT_TOKEN")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| {
-            "DIRT_CLIENT_TOKEN is not set in the environment — sync cannot run without a bearer token.".to_string()
-        })?;
+    let (auth_client, normalized_url) =
+        api_base_url.map_or((None, None), |url| match AuthClient::new(url) {
+            Ok(client) => {
+                let normalized = client.base_url().to_string();
+                (Some(Arc::new(client)), Some(normalized))
+            }
+            Err(err) => {
+                tracing::error!("AuthClient build failed for `{url}`: {err}");
+                (None, None)
+            }
+        });
 
-    ApiClient::new(base_url, token).map_err(|err| format!("invalid sync configuration: {err}"))
+    let token_store: Arc<dyn dirt_core::auth::TokenStore> =
+        match DefaultTokenStore::open(SESSION_PREFS_NAME, SESSION_PREFS_KEY) {
+            Ok(store) => Arc::new(store),
+            Err(err) => {
+                // Falling all the way back to no-store would silently
+                // break the Account row (no way to save / clear), so
+                // surface it loudly. The Settings view checks for
+                // `auth_client.is_none()` AND walks the store on each
+                // operation, so the store-backed error will reach the
+                // user as a Backend message on first interaction.
+                tracing::error!("DefaultTokenStore::open failed: {err}");
+                Arc::new(SentinelTokenStore::new(err.to_string()))
+            }
+        };
+
+    AuthDeps {
+        auth_client,
+        token_store,
+        api_base_url: normalized_url,
+    }
+}
+
+/// Try to hydrate a `SessionApiClient` from the configured `TokenStore`.
+///
+/// Returns `Ok(None)` when sync is unconfigured (no auth client / no
+/// base URL — sync just isn't available, not a loud failure) or when
+/// the keyring slot is empty (user hasn't logged in yet). `Err(msg)`
+/// is reserved for real misconfigurations the user should see in the
+/// UI (malformed base URL, keyring backend failure).
+fn hydrate_session(deps: &AuthDeps) -> Result<Option<SessionApiClient>, String> {
+    let Some(auth_client) = deps.auth_client.as_ref() else {
+        return Ok(None);
+    };
+    let Some(base_url) = deps.api_base_url.as_ref() else {
+        return Ok(None);
+    };
+    SessionApiClient::from_store(
+        base_url.clone(),
+        (**auth_client).clone(),
+        deps.token_store.clone(),
+    )
+    .map_err(|err| err.to_string())
+}
+
+/// Spawn the sync worker and the UI-bridge consumer that drains its
+/// status channel into Dioxus signals. Factored out so login / logout
+/// flows in [`crate::views::settings`] can call into the same setup
+/// path without duplicating the channel wiring.
+// Reachable only from `app_shell.rs` and `views/settings.rs`, but
+// routed through the (private) module — so `pub` would be misleadingly
+// broad. The `redundant_pub_crate` lint would prefer plain `pub`
+// because the enclosing module is private; we override it because the
+// `pub(crate)` is documenting *intent* (callable anywhere inside
+// dirt-mobile) rather than just satisfying the type checker.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) fn spawn_session_worker(
+    store: Arc<MobileNoteStore>,
+    session: Arc<SessionApiClient>,
+    mut sync_worker_signal: Signal<Option<SyncWorkerHandle>>,
+    mut sync_status_signal: Signal<SyncStatus>,
+    mut sync_issue_signal: Signal<Option<String>>,
+    mut last_sync_at_signal: Signal<Option<i64>>,
+    mut notes_signal: Signal<Vec<dirt_core::models::Note>>,
+) {
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<SyncEvent>();
+    let handle = spawn_sync_worker(store.clone(), session, tx);
+    sync_worker_signal.set(Some(handle));
+
+    // The mobile shell rebroadcasts pull-applied updates by re-listing
+    // notes after every successful sync — same behaviour the previous
+    // mobile sync wiring had. Without this the UI freezes its initial
+    // snapshot and a pull-only sync (from a desktop edit) wouldn't show
+    // up without a manual reload.
+    let store_for_refresh = store;
+    spawn(async move {
+        while let Some(event) = rx.recv().await {
+            match event {
+                SyncEvent::Status(status) => sync_status_signal.set(status),
+                SyncEvent::Issue(issue) => sync_issue_signal.set(issue),
+                SyncEvent::LastSync(ts) => {
+                    last_sync_at_signal.set(Some(ts));
+                    if let Ok(refreshed) = store_for_refresh.list_notes().await {
+                        notes_signal.set(refreshed);
+                    }
+                }
+            }
+        }
+    });
+}
+
+/// Sentinel `TokenStore` produced when the real store fails to open at
+/// startup (Android KeyStore unreachable, AndroidX class not found,
+/// etc.). Every call returns the cached failure message so the
+/// Account row surfaces the same diagnostic on every interaction
+/// rather than silently behaving as "no slot exists".
+struct SentinelTokenStore {
+    reason: String,
+}
+
+impl SentinelTokenStore {
+    fn new(reason: String) -> Self {
+        Self { reason }
+    }
+}
+
+impl dirt_core::auth::TokenStore for SentinelTokenStore {
+    fn load(&self) -> dirt_core::auth::TokenStoreResult<Option<dirt_core::auth::StoredToken>> {
+        Err(dirt_core::auth::TokenStoreError::Backend(
+            self.reason.clone(),
+        ))
+    }
+
+    fn save(&self, _token: &dirt_core::auth::StoredToken) -> dirt_core::auth::TokenStoreResult<()> {
+        Err(dirt_core::auth::TokenStoreError::Backend(
+            self.reason.clone(),
+        ))
+    }
+
+    fn clear(&self) -> dirt_core::auth::TokenStoreResult<()> {
+        Err(dirt_core::auth::TokenStoreError::Backend(
+            self.reason.clone(),
+        ))
+    }
 }

--- a/crates/dirt-mobile/src/app_shell.rs
+++ b/crates/dirt-mobile/src/app_shell.rs
@@ -33,6 +33,7 @@ use crate::services::{spawn_sync_worker, SyncEvent, SyncWorkerHandle};
 use crate::state::{AppState, AuthDeps, SyncStatus, View};
 use crate::ui::MOBILE_UI_STYLES;
 use crate::views::{Editor, List, Settings};
+use tokio::sync::mpsc::UnboundedSender;
 
 /// Keyring service identifier for the mobile session token. Matches
 /// the values used in `dirt-cli` and `dirt-desktop` so the trio share
@@ -59,6 +60,7 @@ pub fn AppShell() -> Element {
     let sync_worker: Signal<Option<SyncWorkerHandle>> = use_signal(|| None);
     let signed_in: Signal<Option<StoredToken>> = use_signal(|| None);
     let session_client: Signal<Option<Arc<SessionApiClient>>> = use_signal(|| None);
+    let events_tx: Signal<Option<UnboundedSender<SyncEvent>>> = use_signal(|| None);
 
     // Auth deps are built once at startup — mobile bootstrap is
     // build-time-baked, so unlike desktop there's no async manifest
@@ -78,6 +80,7 @@ pub fn AppShell() -> Element {
         sync_worker,
         signed_in,
         session_client,
+        events_tx,
     });
     use_context_provider(|| auth_deps_signal);
 
@@ -88,10 +91,11 @@ pub fn AppShell() -> Element {
     let mut store_w = store;
     let mut sync_status_w = sync_status;
     let mut sync_issue_w = sync_issue;
-    let last_sync_at_w = last_sync_at;
+    let mut last_sync_at_w = last_sync_at;
     let mut notes_w = notes;
     let mut signed_in_w = signed_in;
     let mut session_client_w = session_client;
+    let mut events_tx_w = events_tx;
 
     let _init = use_resource(move || async move {
         if init_started() {
@@ -122,6 +126,36 @@ pub fn AppShell() -> Element {
 
         store_w.set(Some(opened.clone()));
 
+        // Build the long-lived `SyncEvent` bridge here so the drainer
+        // attaches to `AppShell`'s scope (the root). A previous version
+        // created the channel + drainer inside `spawn_session_worker`,
+        // which meant the drainer inherited the scope of *whatever
+        // component called the helper* — for re-spawns from Settings
+        // after sign-in that scope was the Settings view, so navigating
+        // back to the list cancelled the drainer and silently dropped
+        // every subsequent worker event.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<SyncEvent>();
+        events_tx_w.set(Some(tx.clone()));
+
+        // Drainer task. Captures the signals + a store ref by clone so
+        // the worker can also list freshly-pulled notes back into the
+        // UI on every successful sync.
+        let store_for_refresh = opened.clone();
+        spawn(async move {
+            while let Some(event) = rx.recv().await {
+                match event {
+                    SyncEvent::Status(status) => sync_status_w.set(status),
+                    SyncEvent::Issue(issue) => sync_issue_w.set(issue),
+                    SyncEvent::LastSync(ts) => {
+                        last_sync_at_w.set(Some(ts));
+                        if let Ok(refreshed) = store_for_refresh.list_notes().await {
+                            notes_w.set(refreshed);
+                        }
+                    }
+                }
+            }
+        });
+
         let deps = auth_deps_signal.read().clone();
         match hydrate_session(&deps) {
             Ok(Some(session)) => {
@@ -129,22 +163,15 @@ pub fn AppShell() -> Element {
                 signed_in_w.set(stored);
                 let session_arc = Arc::new(session);
                 session_client_w.set(Some(session_arc.clone()));
-                spawn_session_worker(
-                    opened.clone(),
-                    session_arc,
-                    sync_worker,
-                    sync_status_w,
-                    sync_issue_w,
-                    last_sync_at_w,
-                    notes_w,
-                );
+                spawn_session_worker(opened.clone(), session_arc, tx, sync_worker);
                 tracing::info!("Mobile sync worker spawned");
             }
             Ok(None) => {
                 // No token in the EncryptedSharedPreferences slot — sync
                 // is opt-in. Leave the worker unspawned and the status
                 // at Offline; the user can sign in via Settings →
-                // Account when they want sync.
+                // Account when they want sync. `tx` is preserved on the
+                // signal so the post-login spawn can pick it up.
                 signed_in_w.set(None);
                 session_client_w.set(None);
                 sync_status_w.set(SyncStatus::Offline);
@@ -252,10 +279,18 @@ fn hydrate_session(deps: &AuthDeps) -> Result<Option<SessionApiClient>, String> 
     .map_err(|err| err.to_string())
 }
 
-/// Spawn the sync worker and the UI-bridge consumer that drains its
-/// status channel into Dioxus signals. Factored out so login / logout
-/// flows in [`crate::views::settings`] can call into the same setup
-/// path without duplicating the channel wiring.
+/// Spawn the sync worker against an existing `SyncEvent` channel.
+///
+/// The channel + drainer are owned by [`AppShell`] (so the drainer
+/// task lives in the root scope); this helper just plugs a new worker
+/// into the existing pipe. Each call takes a fresh clone of the
+/// long-lived sender — when the worker shuts down (sign-out) its
+/// sender drops, but `AppShell` keeps its own clone so the drainer
+/// stays alive for the next sign-in.
+///
+/// Factored out (rather than inlined) so login / logout flows in
+/// [`crate::views::settings`] can call it without duplicating the
+/// sender-clone dance.
 // Reachable only from `app_shell.rs` and `views/settings.rs`, but
 // routed through the (private) module — so `pub` would be misleadingly
 // broad. The `redundant_pub_crate` lint would prefer plain `pub`
@@ -266,36 +301,11 @@ fn hydrate_session(deps: &AuthDeps) -> Result<Option<SessionApiClient>, String> 
 pub(crate) fn spawn_session_worker(
     store: Arc<MobileNoteStore>,
     session: Arc<SessionApiClient>,
+    events_tx: UnboundedSender<SyncEvent>,
     mut sync_worker_signal: Signal<Option<SyncWorkerHandle>>,
-    mut sync_status_signal: Signal<SyncStatus>,
-    mut sync_issue_signal: Signal<Option<String>>,
-    mut last_sync_at_signal: Signal<Option<i64>>,
-    mut notes_signal: Signal<Vec<dirt_core::models::Note>>,
 ) {
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<SyncEvent>();
-    let handle = spawn_sync_worker(store.clone(), session, tx);
+    let handle = spawn_sync_worker(store, session, events_tx);
     sync_worker_signal.set(Some(handle));
-
-    // The mobile shell rebroadcasts pull-applied updates by re-listing
-    // notes after every successful sync — same behaviour the previous
-    // mobile sync wiring had. Without this the UI freezes its initial
-    // snapshot and a pull-only sync (from a desktop edit) wouldn't show
-    // up without a manual reload.
-    let store_for_refresh = store;
-    spawn(async move {
-        while let Some(event) = rx.recv().await {
-            match event {
-                SyncEvent::Status(status) => sync_status_signal.set(status),
-                SyncEvent::Issue(issue) => sync_issue_signal.set(issue),
-                SyncEvent::LastSync(ts) => {
-                    last_sync_at_signal.set(Some(ts));
-                    if let Ok(refreshed) = store_for_refresh.list_notes().await {
-                        notes_signal.set(refreshed);
-                    }
-                }
-            }
-        }
-    });
 }
 
 /// Sentinel `TokenStore` produced when the real store fails to open at

--- a/crates/dirt-mobile/src/services/auth_flow.rs
+++ b/crates/dirt-mobile/src/services/auth_flow.rs
@@ -1,0 +1,459 @@
+//! Pure auth-flow helpers (validate / describe / perform), extracted
+//! from `views::settings` so they run on the host under `cargo test`.
+//!
+//! `views::settings` lives behind `#[cfg(target_os = "android")]`
+//! because the Dioxus `#[component]` macros only compile against the
+//! mobile dioxus dep. The helpers in this module have no Dioxus
+//! dependency — they take `AuthDeps` and return data — so they can
+//! exercise the request / verify / logout edges against a wiremock
+//! server without an Android emulator. Match the desktop shape one-for-
+//! one so a future shared library can drop them into both.
+
+use std::sync::Arc;
+
+use dirt_core::auth::{AuthError, StoredToken, TokenStoreError};
+use dirt_core::sync::session_client::SessionApiClient;
+
+use crate::state::AuthDeps;
+
+/// Outcome of `verify_magic_code` + downstream persistence + session
+/// client construction. The UI layer matches on this to either drive
+/// the post-login worker startup or surface a Failure message.
+pub enum LoginOutcome {
+    Success(StoredToken, Arc<SessionApiClient>),
+    Failure(String),
+}
+
+pub enum LogoutOutcome {
+    Success,
+    Failure(String),
+}
+
+/// `POST /v1/auth/request` against the magic-link endpoint and return
+/// the resulting `request_id` (which the UI feeds into the verify
+/// step). Wraps `AuthError` into a user-facing string so the UI doesn't
+/// need to match on the full taxonomy.
+pub async fn send_magic_code(deps: &AuthDeps, email: &str) -> Result<String, String> {
+    let auth = deps
+        .auth_client
+        .as_ref()
+        .ok_or_else(|| "Sign-in is unavailable: DIRT_API_BASE_URL not configured.".to_string())?;
+    match auth.request_magic_code(email).await {
+        Ok(resp) => Ok(resp.request_id),
+        Err(err) => Err(describe_auth_error(&err)),
+    }
+}
+
+/// `POST /v1/auth/verify` with the user-entered 6-digit code, persist
+/// the resulting `StoredToken`, and build a `SessionApiClient` ready
+/// for the sync worker.
+pub async fn perform_verify(deps: &AuthDeps, request_id: &str, code: &str) -> LoginOutcome {
+    let Some(auth) = deps.auth_client.as_ref() else {
+        return LoginOutcome::Failure(
+            "Sign-in is unavailable: DIRT_API_BASE_URL not configured.".into(),
+        );
+    };
+    let resp = match auth.verify_magic_code(request_id, code).await {
+        Ok(resp) => resp,
+        Err(err) => return LoginOutcome::Failure(describe_auth_error(&err)),
+    };
+    let stored: StoredToken = resp.into();
+    if let Err(err) = deps.token_store.save(&stored) {
+        return LoginOutcome::Failure(describe_store_error(&err));
+    }
+    let Some(base_url) = deps.api_base_url.clone() else {
+        return LoginOutcome::Failure(
+            "Sign-in succeeded but the API base URL is missing — sync cannot start.".into(),
+        );
+    };
+    match SessionApiClient::from_store(base_url, (**auth).clone(), deps.token_store.clone()) {
+        Ok(Some(session)) => LoginOutcome::Success(stored, Arc::new(session)),
+        Ok(None) => LoginOutcome::Failure(
+            "Token was saved but the keystore read back empty. Try signing in again.".into(),
+        ),
+        Err(err) => LoginOutcome::Failure(format!("Could not build sync client: {err}")),
+    }
+}
+
+/// Revoke the server-side session, then clear the local slot.
+///
+/// Reads the *freshest* bearer from the store rather than reusing a
+/// snapshot — silent refresh in the sync worker rotates the token
+/// without touching the UI's `signed_in` signal, so a stale snapshot
+/// would `POST /v1/auth/logout` with an already-revoked token, receive
+/// `SESSION_EXPIRED`, treat that as success, and leave the live token
+/// on the server until it expired naturally.
+///
+/// Refuses to clear the local slot when `auth_client` is `None` — the
+/// only way to reach that branch is a CLI / desktop login → mobile
+/// open sequence where `DIRT_API_BASE_URL` is missing on the mobile
+/// side. Silently wiping local would orphan the server session past
+/// the point where the user has any handle to revoke it.
+pub async fn perform_logout(deps: &AuthDeps) -> LogoutOutcome {
+    let current = match deps.token_store.load() {
+        Ok(Some(token)) => token,
+        Ok(None) => return LogoutOutcome::Success,
+        Err(err) => return LogoutOutcome::Failure(describe_store_error(&err)),
+    };
+
+    let Some(auth) = deps.auth_client.as_ref() else {
+        return LogoutOutcome::Failure(
+            "Cannot sign out: DIRT_API_BASE_URL is not configured on this app, \
+             so the server session can't be revoked. Rebuild the APK with the \
+             base URL set, or run `dirt auth logout` from the CLI."
+                .into(),
+        );
+    };
+
+    match auth.logout_session(&current.session_token).await {
+        Ok(()) | Err(AuthError::SessionExpired(_)) => {}
+        Err(other) => {
+            return LogoutOutcome::Failure(describe_auth_error(&other));
+        }
+    }
+    if let Err(err) = deps.token_store.clear() {
+        return LogoutOutcome::Failure(format!(
+            "Server revoke succeeded but local clear failed: {}. \
+             Retry once the keystore is reachable.",
+            describe_store_error(&err)
+        ));
+    }
+    LogoutOutcome::Success
+}
+
+/// Sanity-check an email before hitting the server. We don't try to
+/// fully parse RFC 5322 — the server validates definitively; this just
+/// catches the trivial empty / no-`@` cases inline so the user sees the
+/// error without a network round trip.
+pub fn validate_email(email: &str) -> Result<(), String> {
+    if email.is_empty() {
+        return Err("Enter an email address.".into());
+    }
+    if !email.contains('@') {
+        return Err("Email must contain '@'.".into());
+    }
+    Ok(())
+}
+
+pub fn validate_code(code: &str) -> Result<(), String> {
+    if code.len() != 6 || !code.chars().all(|c| c.is_ascii_digit()) {
+        return Err("Code must be exactly 6 digits.".into());
+    }
+    Ok(())
+}
+
+pub fn describe_auth_error(err: &AuthError) -> String {
+    match err {
+        AuthError::InvalidConfiguration(msg) => format!("Configuration error: {msg}"),
+        AuthError::Network(msg) => format!("Network error: {msg}. Check your connection."),
+        AuthError::InvalidEmail(msg) => format!("Invalid email: {msg}"),
+        AuthError::InvalidCode(msg) => {
+            format!("Invalid code: {msg}. Request a new code if it has expired.")
+        }
+        AuthError::SessionExpired(msg) => format!("Session expired: {msg}. Sign in again."),
+        AuthError::RateLimited {
+            message,
+            retry_after_secs,
+        } => retry_after_secs.as_ref().map_or_else(
+            || format!("Rate limited ({message}). Try again in a moment."),
+            |secs| format!("Rate limited ({message}). Retry in {secs}s."),
+        ),
+        AuthError::BadRequest { code, message } => {
+            format!("Request rejected ({code}): {message}")
+        }
+        AuthError::ServerUnavailable(msg) => format!("Server unavailable: {msg}"),
+        AuthError::ServerError { status, message } => {
+            format!("Server error ({status}): {message}")
+        }
+        AuthError::Decode(msg) => format!("Server response was not understood: {msg}"),
+    }
+}
+
+pub fn describe_store_error(err: &TokenStoreError) -> String {
+    match err {
+        TokenStoreError::Backend(msg) => format!("keystore backend error: {msg}"),
+        TokenStoreError::Serialize(msg) => format!("stored token serialize error: {msg}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dirt_core::auth::{AuthClient, MemoryTokenStore, TokenStore};
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // ---- Pure validation helpers. ----
+
+    #[test]
+    fn validate_email_rejects_empty() {
+        assert!(validate_email("").is_err());
+    }
+
+    #[test]
+    fn validate_email_rejects_missing_at() {
+        let err = validate_email("user.example.com").unwrap_err();
+        assert!(err.contains("'@'"));
+    }
+
+    #[test]
+    fn validate_email_accepts_basic_address() {
+        validate_email("user@example.com").unwrap();
+    }
+
+    #[test]
+    fn validate_code_requires_six_digits() {
+        for bad in ["", "12345", "1234567", "12345a", "abcdef"] {
+            assert!(validate_code(bad).is_err(), "{bad} should be rejected");
+        }
+        validate_code("000000").unwrap();
+        validate_code("123456").unwrap();
+    }
+
+    #[test]
+    fn describe_auth_error_includes_retry_hint_when_present() {
+        let err = AuthError::RateLimited {
+            message: "slow down".into(),
+            retry_after_secs: Some(45),
+        };
+        let described = describe_auth_error(&err);
+        assert!(described.contains("Retry in 45s"));
+    }
+
+    #[test]
+    fn describe_auth_error_falls_back_when_no_retry_hint() {
+        let err = AuthError::RateLimited {
+            message: "slow down".into(),
+            retry_after_secs: None,
+        };
+        let described = describe_auth_error(&err);
+        assert!(described.contains("Try again in a moment"));
+    }
+
+    #[test]
+    fn describe_store_error_distinguishes_variants() {
+        assert!(
+            describe_store_error(&TokenStoreError::Backend("keystore offline".into()))
+                .contains("keystore backend")
+        );
+        assert!(
+            describe_store_error(&TokenStoreError::Serialize("bad json".into()))
+                .contains("serialize")
+        );
+    }
+
+    // ---- Flow integration via wiremock (mirrors desktop). ----
+
+    fn deps_for(server: &MockServer, store: Arc<dyn TokenStore>) -> AuthDeps {
+        let auth = AuthClient::new(server.uri()).expect("auth client should build for mock");
+        let base_url = auth.base_url().to_string();
+        AuthDeps {
+            auth_client: Some(Arc::new(auth)),
+            token_store: store,
+            api_base_url: Some(base_url),
+        }
+    }
+
+    fn empty_store() -> Arc<MemoryTokenStore> {
+        Arc::new(MemoryTokenStore::new())
+    }
+
+    /// Happy-path `send_magic_code` → returns the server's `request_id`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn send_magic_code_returns_request_id_on_200() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/request"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "request_id": "req-abc",
+                "expires_at_ms": 9_999_999i64,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let deps = deps_for(&server, empty_store());
+        let req_id = send_magic_code(&deps, "user@example.com").await.unwrap();
+        assert_eq!(req_id, "req-abc");
+    }
+
+    /// Missing `AuthClient` (no `DIRT_API_BASE_URL`) must surface a
+    /// clear "unavailable" message rather than panicking.
+    #[tokio::test(flavor = "current_thread")]
+    async fn send_magic_code_reports_missing_auth_client() {
+        let deps = AuthDeps {
+            auth_client: None,
+            token_store: empty_store(),
+            api_base_url: None,
+        };
+        let err = send_magic_code(&deps, "user@example.com")
+            .await
+            .unwrap_err();
+        assert!(err.contains("Sign-in is unavailable"));
+    }
+
+    /// Happy-path verify → token persisted + Success.
+    #[tokio::test(flavor = "current_thread")]
+    async fn perform_verify_persists_token_and_returns_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/verify"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "session_token": "tok-new",
+                "session_id": "sid-new",
+                "user_id": "uid-1",
+                "email": "user@example.com",
+                "expires_at_ms": 9_999_999i64,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let store = empty_store();
+        let deps = deps_for(&server, store.clone());
+        let outcome = perform_verify(&deps, "req-abc", "123456").await;
+        match outcome {
+            LoginOutcome::Success(token, _session) => {
+                assert_eq!(token.session_token, "tok-new");
+                assert_eq!(token.email, "user@example.com");
+                // Persistence side effect:
+                let loaded = store.load().unwrap().unwrap();
+                assert_eq!(loaded.session_token, "tok-new");
+            }
+            LoginOutcome::Failure(reason) => panic!("expected success, got: {reason}"),
+        }
+    }
+
+    /// Server returns `INVALID_CODE` → flow translates into a Failure
+    /// outcome with the user-facing copy from `describe_auth_error`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn perform_verify_returns_failure_on_invalid_code() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/verify"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "error": {
+                    "code": "INVALID_CODE",
+                    "message": "Code did not match",
+                    "cause": "Code did not match",
+                    "fix": "Re-enter the code or request a new one.",
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let store = empty_store();
+        let deps = deps_for(&server, store.clone());
+        let outcome = perform_verify(&deps, "req-abc", "999999").await;
+        match outcome {
+            LoginOutcome::Failure(msg) => assert!(msg.contains("Invalid code")),
+            LoginOutcome::Success(..) => panic!("expected failure"),
+        }
+        // No persistence side effect on failure:
+        assert!(store.load().unwrap().is_none());
+    }
+
+    /// Logout reads the *freshest* bearer from the store and POSTs it
+    /// to `/v1/auth/logout`. `AuthClient::logout_session` accepts 204
+    /// No Content as success; the test mirrors that contract.
+    #[tokio::test(flavor = "current_thread")]
+    async fn perform_logout_revokes_freshest_stored_token() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/logout"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let store = Arc::new(MemoryTokenStore::with_initial(StoredToken {
+            session_token: "refreshed-tok".into(),
+            session_id: "sid".into(),
+            user_id: "uid".into(),
+            email: "user@example.com".into(),
+            expires_at_ms: 9_999_999,
+        }));
+        let deps = deps_for(&server, store.clone());
+
+        match perform_logout(&deps).await {
+            LogoutOutcome::Success => {}
+            LogoutOutcome::Failure(reason) => panic!("expected success, got: {reason}"),
+        }
+        // Slot must be cleared after successful revoke.
+        assert!(store.load().unwrap().is_none());
+    }
+
+    /// `SESSION_EXPIRED` on logout means the server already considers
+    /// the session dead — still a success from the user's POV; we just
+    /// clear the local slot.
+    #[tokio::test(flavor = "current_thread")]
+    async fn perform_logout_treats_session_expired_as_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/logout"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": {
+                    "code": "SESSION_EXPIRED",
+                    "message": "session token is invalid or expired",
+                    "cause": "session token is invalid or expired",
+                    "fix": "Sign in again to obtain a fresh session token.",
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let store = Arc::new(MemoryTokenStore::with_initial(StoredToken {
+            session_token: "stale-tok".into(),
+            session_id: "sid".into(),
+            user_id: "uid".into(),
+            email: "user@example.com".into(),
+            expires_at_ms: 1,
+        }));
+        let deps = deps_for(&server, store.clone());
+
+        match perform_logout(&deps).await {
+            LogoutOutcome::Success => assert!(store.load().unwrap().is_none()),
+            LogoutOutcome::Failure(reason) => panic!("expected success, got: {reason}"),
+        }
+    }
+
+    /// Logout without `auth_client` (CLI / desktop logged in but
+    /// mobile's `DIRT_API_BASE_URL` is unset) must refuse to clear the
+    /// local slot. A silent wipe would orphan the live server session.
+    #[tokio::test(flavor = "current_thread")]
+    async fn perform_logout_refuses_when_auth_client_missing() {
+        let store = Arc::new(MemoryTokenStore::with_initial(StoredToken {
+            session_token: "tok".into(),
+            session_id: "sid".into(),
+            user_id: "uid".into(),
+            email: "user@example.com".into(),
+            expires_at_ms: 9_999_999,
+        }));
+        let deps = AuthDeps {
+            auth_client: None,
+            token_store: store.clone(),
+            api_base_url: None,
+        };
+
+        match perform_logout(&deps).await {
+            LogoutOutcome::Failure(msg) => {
+                assert!(msg.contains("DIRT_API_BASE_URL"));
+                // Slot must be preserved so the CLI can still revoke.
+                assert!(store.load().unwrap().is_some());
+            }
+            LogoutOutcome::Success => panic!("expected failure (auth_client missing)"),
+        }
+    }
+
+    /// Logout on an empty store is a no-op success (nothing to revoke).
+    #[tokio::test(flavor = "current_thread")]
+    async fn perform_logout_succeeds_when_store_already_empty() {
+        let server = MockServer::start().await;
+        let deps = deps_for(&server, empty_store());
+        match perform_logout(&deps).await {
+            LogoutOutcome::Success => {}
+            LogoutOutcome::Failure(reason) => panic!("expected success, got: {reason}"),
+        }
+    }
+}

--- a/crates/dirt-mobile/src/services/auth_store.rs
+++ b/crates/dirt-mobile/src/services/auth_store.rs
@@ -37,7 +37,13 @@ mod host_impl;
 #[cfg(target_os = "android")]
 pub use android_impl::EncryptedPrefsTokenStore as DefaultTokenStore;
 
+// On the host (`cargo test` on Windows / Linux) nothing in the binary
+// actually calls `DefaultTokenStore::open` — `app_shell` is android-only
+// and the auth_flow tests construct stores directly via `MemoryTokenStore`
+// — so the alias is technically unused. Keep it visible so a future host
+// integration test could reach for it; suppress the warning explicitly.
 #[cfg(not(target_os = "android"))]
+#[allow(unused_imports)]
 pub use host_impl::FileTokenStore as DefaultTokenStore;
 
 /// Shared JSON codec for both impls. Pulled out so the unit tests can

--- a/crates/dirt-mobile/src/services/auth_store.rs
+++ b/crates/dirt-mobile/src/services/auth_store.rs
@@ -1,0 +1,100 @@
+//! Persistent session-token storage for the mobile shell.
+//!
+//! Two implementations live behind a `cfg(target_os = ...)` split:
+//!
+//!   - **Android** (`EncryptedPrefsTokenStore`) wraps `AndroidX`
+//!     `EncryptedSharedPreferences` via JNI. The master key is generated
+//!     inside the Android `KeyStore` (hardware-backed where available)
+//!     under the `androidx_security_crypto` alias the framework owns;
+//!     the bearer is encrypted with that key (AES-256/GCM for values,
+//!     AES-256/SIV for the preference key) and lives in an app-private
+//!     `SharedPreferences` file. The `service` argument becomes the
+//!     preference file name; the `account` argument becomes the key
+//!     inside it — matching the desktop keyring convention so the
+//!     `(service, account) = ("dev.dirt.session", "default")` slot has
+//!     one logical meaning across binaries.
+//!
+//!   - **Host** (`FileTokenStore`) writes the `StoredToken` JSON to a
+//!     local file. It only ships when the crate is *built for the host
+//!     target* — i.e. under `cargo test -p dirt-mobile`. The Android
+//!     build target never includes it, so a packaged APK cannot
+//!     accidentally fall back to unencrypted storage.
+//!
+//! Both implementations expose the same `open(service, account)`
+//! constructor and implement [`dirt_core::auth::TokenStore`], so the
+//! rest of the mobile shell only refers to [`DefaultTokenStore`].
+
+#![cfg_attr(not(target_os = "android"), allow(dead_code))]
+
+use dirt_core::auth::{StoredToken, TokenStoreError, TokenStoreResult};
+
+#[cfg(target_os = "android")]
+mod android_impl;
+
+#[cfg(not(target_os = "android"))]
+mod host_impl;
+
+#[cfg(target_os = "android")]
+pub use android_impl::EncryptedPrefsTokenStore as DefaultTokenStore;
+
+#[cfg(not(target_os = "android"))]
+pub use host_impl::FileTokenStore as DefaultTokenStore;
+
+/// Shared JSON codec for both impls. Pulled out so the unit tests can
+/// exercise the serialize / parse edge without touching either backend
+/// (matches the pattern in `dirt-core::auth::keyring_store`).
+pub(super) fn parse_token_blob(json: &str) -> TokenStoreResult<StoredToken> {
+    serde_json::from_str(json).map_err(|err| TokenStoreError::Serialize(err.to_string()))
+}
+
+pub(super) fn serialize_token_blob(token: &StoredToken) -> TokenStoreResult<String> {
+    serde_json::to_string(token).map_err(|err| TokenStoreError::Serialize(err.to_string()))
+}
+
+/// Convenience constructor for the `Backend` error variant — both
+/// platforms wrap a lot of IO / JNI errors and the call sites get
+/// significantly shorter when they don't have to spell out the variant.
+pub(super) const fn backend(msg: String) -> TokenStoreError {
+    TokenStoreError::Backend(msg)
+}
+
+#[cfg(test)]
+mod codec_tests {
+    use super::*;
+
+    fn sample() -> StoredToken {
+        StoredToken {
+            session_token: "tok".into(),
+            session_id: "sid".into(),
+            user_id: "uid".into(),
+            email: "user@example.com".into(),
+            expires_at_ms: 123,
+        }
+    }
+
+    /// Schema-drift canary: parse and serialize must round-trip. If a
+    /// future `StoredToken` field rename breaks this, every consumer
+    /// (Android prefs, host file, desktop keyring) silently fails to
+    /// rehydrate at startup.
+    #[test]
+    fn serialize_then_parse_round_trips() {
+        let blob = serialize_token_blob(&sample()).unwrap();
+        let parsed = parse_token_blob(&blob).unwrap();
+        assert_eq!(parsed, sample());
+    }
+
+    #[test]
+    fn parse_rejects_malformed_json() {
+        let err = parse_token_blob("not json").unwrap_err();
+        assert!(matches!(err, TokenStoreError::Serialize(_)));
+    }
+
+    /// Older blob with missing fields: must classify as Serialize so the
+    /// caller treats the slot as empty and forces a fresh sign-in, the
+    /// same recovery the desktop keyring path uses.
+    #[test]
+    fn parse_rejects_wrong_shape() {
+        let err = parse_token_blob("{}").unwrap_err();
+        assert!(matches!(err, TokenStoreError::Serialize(_)));
+    }
+}

--- a/crates/dirt-mobile/src/services/auth_store/android_impl.rs
+++ b/crates/dirt-mobile/src/services/auth_store/android_impl.rs
@@ -1,0 +1,317 @@
+//! Android-side `TokenStore` backed by `EncryptedSharedPreferences`.
+//!
+//! All JNI ceremony lives in this module so the rest of the mobile
+//! shell stays platform-neutral. The `unsafe_code` allow is scoped here
+//! and audited: we only construct a `JavaVM` from the raw pointer the
+//! Dioxus mobile runtime publishes through `ndk_context`, and only
+//! reify the Activity `JObject` from the same source.
+//!
+//! Threading: each method attaches the current thread (which is fine to
+//! call repeatedly — `attach_current_thread` is a no-op when the thread
+//! is already attached, and returns an `AttachGuard` that detaches on
+//! drop only if it actually did the attach). The `prefs` global ref is
+//! shared across threads via the `Sync` impl on `GlobalRef`.
+
+#![allow(unsafe_code)]
+
+use jni::objects::{GlobalRef, JObject, JString, JValue};
+use jni::JavaVM;
+
+use dirt_core::auth::{StoredToken, TokenStore, TokenStoreResult};
+
+use super::{backend, parse_token_blob, serialize_token_blob};
+
+/// AndroidX EncryptedSharedPreferences-backed token store.
+///
+/// Constructed once at app startup; cheap to clone (the `JavaVM` and
+/// `GlobalRef` are reference-counted handles).
+pub struct EncryptedPrefsTokenStore {
+    /// `JavaVM` handle obtained from `ndk_context`. `JavaVM` is `Send +
+    /// Sync` because each call attaches the current thread on demand.
+    vm: JavaVM,
+    /// Global reference to the `android.content.SharedPreferences`
+    /// instance returned by `EncryptedSharedPreferences.create`. Held
+    /// for the lifetime of the store so the JVM doesn't GC it.
+    prefs: GlobalRef,
+    /// The key (account) we read / write inside the preferences file.
+    pref_key: String,
+}
+
+impl std::fmt::Debug for EncryptedPrefsTokenStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Mirror the desktop `KeyringTokenStore::Debug` shape: surface
+        // the slot identifier (useful for diagnosing "which user is
+        // this") but never the encrypted blob.
+        f.debug_struct("EncryptedPrefsTokenStore")
+            .field("pref_key", &self.pref_key)
+            .finish_non_exhaustive()
+    }
+}
+
+impl EncryptedPrefsTokenStore {
+    /// Open the EncryptedSharedPreferences file `service` and bind the
+    /// store to the `account` key inside it. Building the store touches
+    /// the Android KeyStore once (to materialize / unwrap the master
+    /// key) so a failure here surfaces immediately rather than at the
+    /// first load.
+    pub fn open(service: &str, account: &str) -> TokenStoreResult<Self> {
+        let ctx = ndk_context::android_context();
+
+        // SAFETY: `ndk_context::android_context` returns the
+        // process-global VM pointer the Android runtime publishes via
+        // `JNI_OnLoad`; `JavaVM::from_raw` expects exactly that. The
+        // pointer is valid for the lifetime of the process.
+        let vm = unsafe { JavaVM::from_raw(ctx.vm().cast()) }
+            .map_err(|err| backend(format!("invalid JavaVM handle: {err}")))?;
+
+        let mut env = vm
+            .attach_current_thread()
+            .map_err(|err| backend(format!("attach JVM thread: {err}")))?;
+
+        // SAFETY: `ctx.context()` returns the host Activity / Application
+        // jobject that ndk_context received from the runtime; reifying
+        // it as a `JObject` for a single JNIEnv invocation is sound.
+        let activity = unsafe { JObject::from_raw(ctx.context().cast()) };
+
+        let master_key = build_master_key(&mut env, &activity)?;
+        let prefs = create_encrypted_prefs(&mut env, &activity, service, &master_key)?;
+        let prefs_ref = env
+            .new_global_ref(prefs)
+            .map_err(|err| backend(format!("global ref for SharedPreferences: {err}")))?;
+
+        Ok(Self {
+            vm,
+            prefs: prefs_ref,
+            pref_key: account.to_string(),
+        })
+    }
+}
+
+impl TokenStore for EncryptedPrefsTokenStore {
+    fn load(&self) -> TokenStoreResult<Option<StoredToken>> {
+        let mut env = self
+            .vm
+            .attach_current_thread()
+            .map_err(|err| backend(format!("attach JVM thread: {err}")))?;
+
+        let key = env
+            .new_string(&self.pref_key)
+            .map_err(|err| backend(format!("alloc pref key string: {err}")))?;
+        let null_default = JObject::null();
+
+        let value = env
+            .call_method(
+                self.prefs.as_obj(),
+                "getString",
+                "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
+                &[JValue::Object(&key), JValue::Object(&null_default)],
+            )
+            .map_err(|err| backend(format!("SharedPreferences.getString: {err}")))?
+            .l()
+            .map_err(|err| backend(format!("getString return value: {err}")))?;
+
+        if value.is_null() {
+            return Ok(None);
+        }
+
+        let jstr = JString::from(value);
+        let json: String = env
+            .get_string(&jstr)
+            .map_err(|err| backend(format!("decode prefs string: {err}")))?
+            .into();
+        Ok(Some(parse_token_blob(&json)?))
+    }
+
+    fn save(&self, token: &StoredToken) -> TokenStoreResult<()> {
+        let json = serialize_token_blob(token)?;
+        let mut env = self
+            .vm
+            .attach_current_thread()
+            .map_err(|err| backend(format!("attach JVM thread: {err}")))?;
+
+        let editor = env
+            .call_method(
+                self.prefs.as_obj(),
+                "edit",
+                "()Landroid/content/SharedPreferences$Editor;",
+                &[],
+            )
+            .map_err(|err| backend(format!("SharedPreferences.edit: {err}")))?
+            .l()
+            .map_err(|err| backend(format!("edit return value: {err}")))?;
+
+        let key = env
+            .new_string(&self.pref_key)
+            .map_err(|err| backend(format!("alloc pref key string: {err}")))?;
+        let value = env
+            .new_string(&json)
+            .map_err(|err| backend(format!("alloc pref value string: {err}")))?;
+
+        env.call_method(
+            &editor,
+            "putString",
+            "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
+            &[JValue::Object(&key), JValue::Object(&value)],
+        )
+        .map_err(|err| backend(format!("Editor.putString: {err}")))?;
+
+        commit_editor(&mut env, &editor)
+    }
+
+    fn clear(&self) -> TokenStoreResult<()> {
+        let mut env = self
+            .vm
+            .attach_current_thread()
+            .map_err(|err| backend(format!("attach JVM thread: {err}")))?;
+
+        let editor = env
+            .call_method(
+                self.prefs.as_obj(),
+                "edit",
+                "()Landroid/content/SharedPreferences$Editor;",
+                &[],
+            )
+            .map_err(|err| backend(format!("SharedPreferences.edit: {err}")))?
+            .l()
+            .map_err(|err| backend(format!("edit return value: {err}")))?;
+
+        let key = env
+            .new_string(&self.pref_key)
+            .map_err(|err| backend(format!("alloc pref key string: {err}")))?;
+
+        env.call_method(
+            &editor,
+            "remove",
+            "(Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
+            &[JValue::Object(&key)],
+        )
+        .map_err(|err| backend(format!("Editor.remove: {err}")))?;
+
+        commit_editor(&mut env, &editor)
+    }
+}
+
+// ---- Helpers (JNI ceremony pulled out so the trait impls stay readable). ----
+
+fn build_master_key<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    activity: &JObject<'_>,
+) -> TokenStoreResult<JObject<'a>> {
+    // new MasterKey.Builder(context)
+    let builder = env
+        .new_object(
+            "androidx/security/crypto/MasterKey$Builder",
+            "(Landroid/content/Context;)V",
+            &[JValue::Object(activity)],
+        )
+        .map_err(|err| backend(format!("new MasterKey.Builder: {err}")))?;
+
+    // KeyScheme.AES256_GCM static field.
+    let key_scheme = env
+        .get_static_field(
+            "androidx/security/crypto/MasterKey$KeyScheme",
+            "AES256_GCM",
+            "Landroidx/security/crypto/MasterKey$KeyScheme;",
+        )
+        .map_err(|err| backend(format!("KeyScheme.AES256_GCM lookup: {err}")))?
+        .l()
+        .map_err(|err| backend(format!("KeyScheme cast: {err}")))?;
+
+    // builder.setKeyScheme(AES256_GCM) → returns the same builder
+    let with_scheme = env
+        .call_method(
+            &builder,
+            "setKeyScheme",
+            "(Landroidx/security/crypto/MasterKey$KeyScheme;)Landroidx/security/crypto/MasterKey$Builder;",
+            &[JValue::Object(&key_scheme)],
+        )
+        .map_err(|err| backend(format!("Builder.setKeyScheme: {err}")))?
+        .l()
+        .map_err(|err| backend(format!("setKeyScheme cast: {err}")))?;
+
+    // builder.build() → MasterKey
+    let master_key = env
+        .call_method(
+            &with_scheme,
+            "build",
+            "()Landroidx/security/crypto/MasterKey;",
+            &[],
+        )
+        .map_err(|err| backend(format!("Builder.build: {err}")))?
+        .l()
+        .map_err(|err| backend(format!("MasterKey cast: {err}")))?;
+
+    Ok(master_key)
+}
+
+fn create_encrypted_prefs<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    activity: &JObject<'_>,
+    file_name: &str,
+    master_key: &JObject<'_>,
+) -> TokenStoreResult<JObject<'a>> {
+    let name = env
+        .new_string(file_name)
+        .map_err(|err| backend(format!("alloc prefs file name: {err}")))?;
+
+    // PrefKeyEncryptionScheme.AES256_SIV
+    let pref_key_scheme = env
+        .get_static_field(
+            "androidx/security/crypto/EncryptedSharedPreferences$PrefKeyEncryptionScheme",
+            "AES256_SIV",
+            "Landroidx/security/crypto/EncryptedSharedPreferences$PrefKeyEncryptionScheme;",
+        )
+        .map_err(|err| backend(format!("PrefKeyEncryptionScheme.AES256_SIV: {err}")))?
+        .l()
+        .map_err(|err| backend(format!("PrefKeyEncryptionScheme cast: {err}")))?;
+
+    // PrefValueEncryptionScheme.AES256_GCM
+    let pref_value_scheme = env
+        .get_static_field(
+            "androidx/security/crypto/EncryptedSharedPreferences$PrefValueEncryptionScheme",
+            "AES256_GCM",
+            "Landroidx/security/crypto/EncryptedSharedPreferences$PrefValueEncryptionScheme;",
+        )
+        .map_err(|err| backend(format!("PrefValueEncryptionScheme.AES256_GCM: {err}")))?
+        .l()
+        .map_err(|err| backend(format!("PrefValueEncryptionScheme cast: {err}")))?;
+
+    // Static call: EncryptedSharedPreferences.create(ctx, name, masterKey, keyScheme, valueScheme)
+    let prefs = env
+        .call_static_method(
+            "androidx/security/crypto/EncryptedSharedPreferences",
+            "create",
+            "(Landroid/content/Context;Ljava/lang/String;Landroidx/security/crypto/MasterKey;Landroidx/security/crypto/EncryptedSharedPreferences$PrefKeyEncryptionScheme;Landroidx/security/crypto/EncryptedSharedPreferences$PrefValueEncryptionScheme;)Landroid/content/SharedPreferences;",
+            &[
+                JValue::Object(activity),
+                JValue::Object(&name),
+                JValue::Object(master_key),
+                JValue::Object(&pref_key_scheme),
+                JValue::Object(&pref_value_scheme),
+            ],
+        )
+        .map_err(|err| backend(format!("EncryptedSharedPreferences.create: {err}")))?
+        .l()
+        .map_err(|err| backend(format!("EncryptedSharedPreferences cast: {err}")))?;
+
+    Ok(prefs)
+}
+
+/// `SharedPreferences.Editor.commit()` returns a `boolean` — `true` on a
+/// successful disk write. We use `commit()` rather than `apply()` so the
+/// failure mode surfaces to the caller; `apply()` writes asynchronously
+/// and a failure would never reach the `TokenStore` consumer.
+fn commit_editor(env: &mut jni::JNIEnv<'_>, editor: &JObject<'_>) -> TokenStoreResult<()> {
+    let ok = env
+        .call_method(editor, "commit", "()Z", &[])
+        .map_err(|err| backend(format!("Editor.commit: {err}")))?
+        .z()
+        .map_err(|err| backend(format!("commit return value: {err}")))?;
+    if ok {
+        Ok(())
+    } else {
+        Err(backend(
+            "SharedPreferences.commit returned false (disk write rejected)".into(),
+        ))
+    }
+}

--- a/crates/dirt-mobile/src/services/auth_store/android_impl.rs
+++ b/crates/dirt-mobile/src/services/auth_store/android_impl.rs
@@ -21,7 +21,7 @@ use dirt_core::auth::{StoredToken, TokenStore, TokenStoreResult};
 
 use super::{backend, parse_token_blob, serialize_token_blob};
 
-/// AndroidX EncryptedSharedPreferences-backed token store.
+/// `AndroidX` `EncryptedSharedPreferences`-backed token store.
 ///
 /// Constructed once at app startup; cheap to clone (the `JavaVM` and
 /// `GlobalRef` are reference-counted handles).
@@ -49,11 +49,11 @@ impl std::fmt::Debug for EncryptedPrefsTokenStore {
 }
 
 impl EncryptedPrefsTokenStore {
-    /// Open the EncryptedSharedPreferences file `service` and bind the
-    /// store to the `account` key inside it. Building the store touches
-    /// the Android KeyStore once (to materialize / unwrap the master
-    /// key) so a failure here surfaces immediately rather than at the
-    /// first load.
+    /// Open the `EncryptedSharedPreferences` file `service` and bind
+    /// the store to the `account` key inside it. Building the store
+    /// touches the Android `KeyStore` once (to materialize / unwrap the
+    /// master key) so a failure here surfaces immediately rather than
+    /// at the first load.
     pub fn open(service: &str, account: &str) -> TokenStoreResult<Self> {
         let ctx = ndk_context::android_context();
 
@@ -64,20 +64,27 @@ impl EncryptedPrefsTokenStore {
         let vm = unsafe { JavaVM::from_raw(ctx.vm().cast()) }
             .map_err(|err| backend(format!("invalid JavaVM handle: {err}")))?;
 
-        let mut env = vm
-            .attach_current_thread()
-            .map_err(|err| backend(format!("attach JVM thread: {err}")))?;
+        // Inner scope owns the `AttachGuard`. The guard borrows `vm`
+        // (so it can detach on drop), so we cannot move `vm` into
+        // `Self` while the guard is still alive — explicitly bounding
+        // the borrow with this block lets the guard drop before the
+        // `Ok(Self { vm, .. })` construction below.
+        let prefs_ref = {
+            let mut env = vm
+                .attach_current_thread()
+                .map_err(|err| backend(format!("attach JVM thread: {err}")))?;
 
-        // SAFETY: `ctx.context()` returns the host Activity / Application
-        // jobject that ndk_context received from the runtime; reifying
-        // it as a `JObject` for a single JNIEnv invocation is sound.
-        let activity = unsafe { JObject::from_raw(ctx.context().cast()) };
+            // SAFETY: `ctx.context()` returns the host Activity /
+            // Application jobject that ndk_context received from the
+            // runtime; reifying it as a `JObject` for a single JNIEnv
+            // invocation is sound.
+            let activity = unsafe { JObject::from_raw(ctx.context().cast()) };
 
-        let master_key = build_master_key(&mut env, &activity)?;
-        let prefs = create_encrypted_prefs(&mut env, &activity, service, &master_key)?;
-        let prefs_ref = env
-            .new_global_ref(prefs)
-            .map_err(|err| backend(format!("global ref for SharedPreferences: {err}")))?;
+            let master_key = build_master_key(&mut env, &activity)?;
+            let prefs = create_encrypted_prefs(&mut env, &activity, service, &master_key)?;
+            env.new_global_ref(prefs)
+                .map_err(|err| backend(format!("global ref for SharedPreferences: {err}")))?
+        };
 
         Ok(Self {
             vm,

--- a/crates/dirt-mobile/src/services/auth_store/host_impl.rs
+++ b/crates/dirt-mobile/src/services/auth_store/host_impl.rs
@@ -1,0 +1,256 @@
+//! Host-side `TokenStore` used by `cargo test` on Windows / Linux.
+//!
+//! Never compiled into the Android APK — the `cfg(not(target_os =
+//! "android"))` gate in `super` makes sure of that — so this code has no
+//! security model beyond filesystem permissions. The Android shell only
+//! cross-compiles via `cargo check --target x86_64-linux-android`, which
+//! picks the `EncryptedPrefsTokenStore` path instead.
+//!
+//! Stored layout is a single JSON file per `(service, account)` slot at
+//! `<data_dir>/dirt-host-mock/<service>__<account>.json`. The path
+//! contains the slot identifiers literally so a developer can poke at
+//! the stored value during tests / manual debugging.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+#[cfg(test)]
+use dirt_core::auth::TokenStoreError;
+use dirt_core::auth::{StoredToken, TokenStore, TokenStoreResult};
+
+use super::{backend, parse_token_blob, serialize_token_blob};
+
+/// File-backed `TokenStore`. The unencrypted JSON layout matches what
+/// the desktop keyring stores in its slot (also unencrypted-from-our-POV
+/// since the OS keyring owns the encryption), so a test can dump one and
+/// inspect it with `jq`.
+pub struct FileTokenStore {
+    path: PathBuf,
+}
+
+impl std::fmt::Debug for FileTokenStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileTokenStore")
+            .field("path", &self.path)
+            .finish()
+    }
+}
+
+impl FileTokenStore {
+    /// Open the slot for `(service, account)` under the user data dir.
+    /// The directory is created lazily on first `save`; this constructor
+    /// does not touch the filesystem so a test path that doesn't yet
+    /// exist is fine.
+    //
+    // The `Result` return type is here for signature compatibility with
+    // the Android `EncryptedPrefsTokenStore::open`, whose master-key
+    // materialization is genuinely fallible (JNI / KeyStore can refuse).
+    // Keeping both `open` signatures identical lets `app_shell` and the
+    // settings flow handle construction errors uniformly across the
+    // cfg-split — that's the whole reason the alias `DefaultTokenStore`
+    // exists. So `unnecessary_wraps` is a false positive here.
+    #[allow(clippy::unnecessary_wraps)]
+    pub fn open(service: &str, account: &str) -> TokenStoreResult<Self> {
+        let base = dirs::data_dir()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("dirt-host-mock");
+        Ok(Self {
+            path: base.join(slot_filename(service, account)),
+        })
+    }
+
+    /// Test-only constructor letting the caller pin the storage path
+    /// (typically a `tempfile::TempDir` join). Production code paths go
+    /// through [`open`].
+    #[cfg(test)]
+    #[must_use]
+    pub const fn with_path(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    /// Inspect the resolved on-disk path. Useful in tests that need to
+    /// poke the file directly (e.g. simulating a corrupted blob).
+    #[cfg(test)]
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl TokenStore for FileTokenStore {
+    fn load(&self) -> TokenStoreResult<Option<StoredToken>> {
+        match fs::read_to_string(&self.path) {
+            Ok(json) => Ok(Some(parse_token_blob(&json)?)),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(backend(format!("read {}: {err}", self.path.display()))),
+        }
+    }
+
+    fn save(&self, token: &StoredToken) -> TokenStoreResult<()> {
+        let json = serialize_token_blob(token)?;
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|err| backend(format!("create {}: {err}", parent.display())))?;
+        }
+        fs::write(&self.path, json)
+            .map_err(|err| backend(format!("write {}: {err}", self.path.display())))
+    }
+
+    fn clear(&self) -> TokenStoreResult<()> {
+        match fs::remove_file(&self.path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(backend(format!("remove {}: {err}", self.path.display()))),
+        }
+    }
+}
+
+fn slot_filename(service: &str, account: &str) -> String {
+    // Path-segment safe encoding: replace anything weird with `_` so a
+    // colon in a service name doesn't blow up on Windows (which rejects
+    // `:` in file paths). Keep the encoding obvious so a human reading
+    // the dir can map back to the slot.
+    let safe = |s: &str| -> String {
+        s.chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_') {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect()
+    };
+    format!("{}__{}.json", safe(service), safe(account))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_token() -> StoredToken {
+        StoredToken {
+            session_token: "tok".into(),
+            session_id: "sid".into(),
+            user_id: "uid".into(),
+            email: "user@example.com".into(),
+            expires_at_ms: 123,
+        }
+    }
+
+    fn temp_store() -> (tempfile_lite::TempDir, FileTokenStore) {
+        let dir = tempfile_lite::TempDir::new("dirt-host-store-test").unwrap();
+        let store = FileTokenStore::with_path(dir.path().join("slot.json"));
+        (dir, store)
+    }
+
+    #[test]
+    fn load_returns_none_when_file_missing() {
+        let (_dir, store) = temp_store();
+        assert!(store.load().unwrap().is_none());
+    }
+
+    #[test]
+    fn save_then_load_roundtrips() {
+        let (_dir, store) = temp_store();
+        store.save(&sample_token()).unwrap();
+        let loaded = store.load().unwrap().unwrap();
+        assert_eq!(loaded, sample_token());
+    }
+
+    #[test]
+    fn save_overwrites_previous_blob() {
+        let (_dir, store) = temp_store();
+        store.save(&sample_token()).unwrap();
+        // `StoredToken` implements `Drop` (via `ZeroizeOnDrop`) so the
+        // `..sample_token()` struct-update sugar is rejected: it would
+        // partially-move the source. Build the rotated token explicitly.
+        let updated = StoredToken {
+            session_token: "rotated".into(),
+            session_id: "sid".into(),
+            user_id: "uid".into(),
+            email: "user@example.com".into(),
+            expires_at_ms: 123,
+        };
+        store.save(&updated).unwrap();
+        let loaded = store.load().unwrap().unwrap();
+        assert_eq!(loaded.session_token, "rotated");
+    }
+
+    #[test]
+    fn clear_removes_existing_file() {
+        let (_dir, store) = temp_store();
+        store.save(&sample_token()).unwrap();
+        store.clear().unwrap();
+        assert!(store.load().unwrap().is_none());
+    }
+
+    #[test]
+    fn clear_is_idempotent_when_already_empty() {
+        let (_dir, store) = temp_store();
+        store.clear().unwrap(); // Pre-empty.
+        store.save(&sample_token()).unwrap();
+        store.clear().unwrap();
+        store.clear().unwrap(); // Second clear must not fail.
+        assert!(store.load().unwrap().is_none());
+    }
+
+    #[test]
+    fn load_classifies_malformed_blob_as_serialize_error() {
+        let (_dir, store) = temp_store();
+        // Force a corrupted blob into the slot to simulate an out-of-band
+        // write (or a future schema mismatch). The caller treats this as
+        // "force a fresh sign-in", same as the desktop keyring contract.
+        std::fs::write(store.path(), "not json at all").unwrap();
+        let err = store.load().unwrap_err();
+        assert!(matches!(err, TokenStoreError::Serialize(_)));
+    }
+
+    #[test]
+    fn slot_filename_escapes_unsafe_chars() {
+        // Colons are illegal in Windows file paths; the encoder must
+        // map them to `_` so the test running on Windows doesn't blow
+        // up before the assertion.
+        assert_eq!(
+            slot_filename("dev.dirt.session", "default"),
+            "dev.dirt.session__default.json"
+        );
+        assert_eq!(slot_filename("a:b/c", "x"), "a_b_c__x.json");
+    }
+
+    /// Minimal stand-in for the `tempfile` crate so the mobile crate
+    /// doesn't pick up a workspace dep just for one test module. Wraps
+    /// `std::env::temp_dir()` with a randomized subdirectory; cleans up
+    /// on drop.
+    mod tempfile_lite {
+        use std::fs;
+        use std::path::{Path, PathBuf};
+
+        pub struct TempDir(PathBuf);
+
+        impl TempDir {
+            pub fn new(prefix: &str) -> std::io::Result<Self> {
+                // 96 bits of entropy from the process clock keeps the
+                // suffix short and collision-free for the test lifetime.
+                let nanos = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or(0);
+                let path = std::env::temp_dir().join(format!("{prefix}-{nanos}"));
+                fs::create_dir_all(&path)?;
+                Ok(Self(path))
+            }
+
+            pub fn path(&self) -> &Path {
+                &self.0
+            }
+        }
+
+        impl Drop for TempDir {
+            fn drop(&mut self) {
+                let _ = fs::remove_dir_all(&self.0);
+            }
+        }
+    }
+}

--- a/crates/dirt-mobile/src/services/mod.rs
+++ b/crates/dirt-mobile/src/services/mod.rs
@@ -9,7 +9,10 @@ pub mod auth_flow;
 pub mod auth_store;
 pub mod sync_worker;
 
-#[cfg_attr(not(target_os = "android"), allow(unused_imports))]
-pub use auth_store::DefaultTokenStore;
+// `DefaultTokenStore` is reached via its module path in `app_shell.rs`
+// (`crate::services::auth_store::DefaultTokenStore`) so a top-level
+// re-export here would be unused. Left commented as a marker that the
+// alias lives one level deeper if a future caller needs a shorter path.
+// pub use auth_store::DefaultTokenStore;
 #[cfg_attr(not(target_os = "android"), allow(unused_imports))]
 pub use sync_worker::{spawn_sync_worker, SyncEvent, SyncWorkerHandle};

--- a/crates/dirt-mobile/src/services/mod.rs
+++ b/crates/dirt-mobile/src/services/mod.rs
@@ -5,7 +5,11 @@
 //! and the actor lives on the tokio side.
 #![cfg_attr(not(target_os = "android"), allow(dead_code))]
 
+pub mod auth_flow;
+pub mod auth_store;
 pub mod sync_worker;
 
+#[cfg_attr(not(target_os = "android"), allow(unused_imports))]
+pub use auth_store::DefaultTokenStore;
 #[cfg_attr(not(target_os = "android"), allow(unused_imports))]
 pub use sync_worker::{spawn_sync_worker, SyncEvent, SyncWorkerHandle};

--- a/crates/dirt-mobile/src/services/sync_worker.rs
+++ b/crates/dirt-mobile/src/services/sync_worker.rs
@@ -1,55 +1,55 @@
 //! Auto-sync background worker for the mobile shell.
 //!
-//! Mirrors `dirt-desktop/src/services/sync_worker.rs` — the triggers,
-//! the debounce, the backoff schedule, and the `SyncOutcome` taxonomy
-//! are identical. The only differences live at the edges:
+//! Mirrors `dirt-desktop/src/services/sync_worker.rs` — triggers,
+//! debounce, backoff schedule, and the `SyncOutcome` taxonomy are
+//! identical, including the silent-refresh path on 401. The only
+//! mobile-specific tweak is the periodic cadence: 60 s instead of
+//! desktop's 30 s, because mobile radio wake-ups carry a bigger battery
+//! cost than a plugged-in desktop and the post-mutation kick already
+//! covers user-driven activity.
 //!
-//!   * the worker is bound to `MobileNoteStore` (which derefs to the
-//!     core `DatabaseService` the engine wants), and
-//!   * the periodic cadence is loosened a little, since mobile devices
-//!     pay a bigger battery cost for each wake-up than a plugged-in
-//!     desktop.
-//!
-//! Sync runs on three triggers:
+//! Triggers:
 //!
 //!   1. **Startup.** Once, immediately after the worker spawns. Pulls
 //!      anything that landed remotely while the app was closed.
 //!   2. **Periodic timer.** Every [`PERIODIC_INTERVAL`] regardless of
-//!      activity. Catches changes pushed by other devices that don't
-//!      generate a local trigger.
+//!      activity.
 //!   3. **Post-mutation kick.** Mutation sites call
-//!      [`SyncWorkerHandle::trigger`] after a successful DB write. The
-//!      worker debounces by [`POST_MUTATION_DEBOUNCE`] so a burst of
-//!      keystrokes coalesces into a single sync rather than one per
-//!      keypress.
+//!      [`SyncWorkerHandle::trigger`] after a successful DB write; a
+//!      [`POST_MUTATION_DEBOUNCE`] window collapses bursts.
 //!
-//! `tokio::sync::Notify` collapses multiple `notify_one()` calls into a
-//! single `notified()` permit, so the debounce is naturally idempotent.
+//! Auth refresh: on a 401 the worker calls
+//! [`SessionApiClient::refresh`] to silently rotate the bearer. A
+//! successful refresh swaps the inner client in place and the next
+//! cycle uses the new token; a `SESSION_EXPIRED` refresh failure parks
+//! the worker until an explicit kick (after the user logs back in via
+//! the Account row in Settings).
 //!
-//! Status reaches the UI through an unbounded `mpsc` channel. Dioxus
-//! signals aren't `Send`, so a consumer task on the UI side drains the
-//! channel and writes the signals there; the worker stays cleanly on
-//! the tokio side.
+//! Shutdown: `SyncWorkerHandle::shutdown` is async — it flips the
+//! shutdown flag, unparks the worker, and awaits the spawned tokio
+//! task. The login / logout flows in `views::settings` rely on the
+//! await so a newly-spawned worker can't race the previous one's
+//! in-flight `sync_once`.
 #![cfg_attr(not(target_os = "android"), allow(dead_code))]
 
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use dirt_core::sync::api_client::{ApiClient, ApiClientError};
+use dirt_core::sync::api_client::ApiClientError;
 use dirt_core::sync::engine::{SyncEngine, SyncEngineError};
+use dirt_core::sync::session_client::{SessionApiClient, SessionRefreshError};
 use dirt_core::SOLO_USER_ID;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::Notify;
+use tokio::task::JoinHandle;
 
 use crate::data::MobileNoteStore;
 use crate::state::SyncStatus;
 
 /// Cadence of the periodic timer when no other triggers fire.
 ///
-/// 60 s on mobile vs desktop's 30 s — mobile radio wake-ups are
-/// expensive, and the post-mutation kick already covers user-driven
-/// activity. Cross-device propagation latency is bounded by this for
-/// the idle case.
+/// 60 s on mobile vs desktop's 30 s — see module docs.
 pub const PERIODIC_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Time the worker waits after a mutation kick to coalesce additional
@@ -57,9 +57,9 @@ pub const PERIODIC_INTERVAL: Duration = Duration::from_secs(60);
 pub const POST_MUTATION_DEBOUNCE: Duration = Duration::from_millis(1_500);
 
 /// Backoff schedule applied after a failed sync cycle. Indexed by the
-/// consecutive-failure count (capped at the last entry); the periodic
-/// timer is replaced with these durations until the next success
-/// resets the counter.
+/// consecutive-failure count (capped at the last entry). Matches the
+/// desktop schedule so a user with both apps installed sees the same
+/// recovery curve on either side.
 const BACKOFF_SCHEDULE: &[Duration] = &[
     Duration::from_secs(5),
     Duration::from_secs(15),
@@ -67,11 +67,18 @@ const BACKOFF_SCHEDULE: &[Duration] = &[
     Duration::from_secs(300),
 ];
 
-/// Handle held by mutation sites so they can poke the worker without
-/// taking a lock or reaching into the worker's internal state.
+/// Handle held by mutation sites and the login / logout flows.
+///
+/// The inner `JoinHandle` lives behind a `Mutex<Option<_>>` so the
+/// *first* `shutdown().await` consumes it; subsequent calls see `None`
+/// and return immediately. `shutdown_existing_worker` (in
+/// `views::settings`) is idempotent across login / logout transitions
+/// and relies on this.
 #[derive(Clone)]
 pub struct SyncWorkerHandle {
     notify: Arc<Notify>,
+    shutdown: Arc<AtomicBool>,
+    join: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
 impl SyncWorkerHandle {
@@ -80,6 +87,33 @@ impl SyncWorkerHandle {
     /// collapse into one extra sync cycle.
     pub fn trigger(&self) {
         self.notify.notify_one();
+    }
+
+    /// Signal the worker to exit and wait for any in-flight `sync_once`
+    /// to complete before returning. The await is critical — without it
+    /// a fresh worker spawned right after can race a still-executing
+    /// push from the previous session.
+    ///
+    /// Idempotent: calling twice on the same handle returns immediately
+    /// the second time (the `JoinHandle` is already gone).
+    pub async fn shutdown(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        // Unpark a parked worker so it can observe the flag immediately
+        // instead of waiting for the next mutation kick.
+        self.notify.notify_one();
+        let join = self
+            .join
+            .lock()
+            .expect("sync worker join slot poisoned")
+            .take();
+        if let Some(handle) = join {
+            // `JoinHandle::await` returns `Err` if the task panicked.
+            // We ignore that — the worker only logs and the runtime
+            // already surfaces the panic via tracing — but we still
+            // wait so a panicked worker can't drag its `Arc<store>`
+            // into a race with the newly spawned one.
+            let _ = handle.await;
+        }
     }
 }
 
@@ -96,44 +130,60 @@ pub enum SyncEvent {
     LastSync(i64),
 }
 
-/// Spawn a background sync worker bound to `(store, api)` and return a
-/// handle the rest of the app can use to kick it. The worker runs
-/// until the process exits.
+/// Spawn a background sync worker bound to `(store, session)` and
+/// return a handle the rest of the app can use to kick it. The worker
+/// runs until the process exits or `SyncWorkerHandle::shutdown` is
+/// called (the latter happens on sign-out).
 pub fn spawn_sync_worker(
     store: Arc<MobileNoteStore>,
-    api: Arc<ApiClient>,
+    session: Arc<SessionApiClient>,
     events: UnboundedSender<SyncEvent>,
 ) -> SyncWorkerHandle {
     let notify = Arc::new(Notify::new());
-    let handle = SyncWorkerHandle {
-        notify: notify.clone(),
-    };
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let notify_for_task = notify.clone();
+    let shutdown_for_task = shutdown.clone();
 
-    tokio::spawn(async move {
-        run_loop(store, api, notify, events).await;
+    let task = tokio::spawn(async move {
+        run_loop(store, session, notify_for_task, shutdown_for_task, events).await;
     });
 
-    handle
+    SyncWorkerHandle {
+        notify,
+        shutdown,
+        join: Arc::new(Mutex::new(Some(task))),
+    }
 }
 
 async fn run_loop(
     store: Arc<MobileNoteStore>,
-    api: Arc<ApiClient>,
+    session: Arc<SessionApiClient>,
     notify: Arc<Notify>,
+    shutdown: Arc<AtomicBool>,
     events: UnboundedSender<SyncEvent>,
 ) {
+    if shutdown.load(Ordering::SeqCst) {
+        return;
+    }
+
     // Trigger 1: startup sync.
-    let initial = sync_once(&store, &api, &events).await;
+    let initial = sync_once(&store, &session, &events).await;
     let mut consecutive_failures = match initial {
         SyncOutcome::Ok => 0,
         SyncOutcome::Failed => 1,
         SyncOutcome::Permanent => {
-            park_until_kick(&notify).await;
+            park_until_kick(&notify, &shutdown).await;
+            if shutdown.load(Ordering::SeqCst) {
+                return;
+            }
             0
         }
     };
 
     loop {
+        if shutdown.load(Ordering::SeqCst) {
+            return;
+        }
         let periodic_delay = if consecutive_failures == 0 {
             PERIODIC_INTERVAL
         } else {
@@ -143,13 +193,16 @@ async fn run_loop(
         let outcome = tokio::select! {
             // Trigger 2: periodic timer (or backoff timer when failing).
             () = tokio::time::sleep(periodic_delay) => {
-                sync_once(&store, &api, &events).await
+                if shutdown.load(Ordering::SeqCst) { return; }
+                sync_once(&store, &session, &events).await
             }
             // Trigger 3: post-mutation kick. Debounce so a burst of
             // edits coalesces into one sync.
             () = notify.notified() => {
+                if shutdown.load(Ordering::SeqCst) { return; }
                 tokio::time::sleep(POST_MUTATION_DEBOUNCE).await;
-                sync_once(&store, &api, &events).await
+                if shutdown.load(Ordering::SeqCst) { return; }
+                sync_once(&store, &session, &events).await
             }
         };
 
@@ -157,14 +210,20 @@ async fn run_loop(
             SyncOutcome::Ok => 0,
             SyncOutcome::Failed => consecutive_failures.saturating_add(1),
             SyncOutcome::Permanent => {
-                park_until_kick(&notify).await;
+                park_until_kick(&notify, &shutdown).await;
+                if shutdown.load(Ordering::SeqCst) {
+                    return;
+                }
                 0
             }
         };
     }
 }
 
-async fn park_until_kick(notify: &Notify) {
+async fn park_until_kick(notify: &Notify, shutdown: &AtomicBool) {
+    if shutdown.load(Ordering::SeqCst) {
+        return;
+    }
     notify.notified().await;
 }
 
@@ -172,13 +231,14 @@ async fn park_until_kick(notify: &Notify) {
 enum SyncOutcome {
     Ok,
     Failed,
-    /// The error will keep failing under retry — surface to the user
-    /// and stop scheduling automatic attempts. Currently triggered by
-    /// `Unauthorized`.
+    /// The error will keep failing under retry (terminal token state
+    /// past silent-refresh) — surface to the user and stop scheduling
+    /// automatic attempts.
     Permanent,
 }
 
 fn backoff_for(consecutive_failures: u32) -> Duration {
+    // First failure (n=1) → BACKOFF_SCHEDULE[0]; clamps at the last entry.
     let idx = consecutive_failures
         .saturating_sub(1)
         .min(u32::try_from(BACKOFF_SCHEDULE.len() - 1).unwrap_or(u32::MAX)) as usize;
@@ -187,11 +247,14 @@ fn backoff_for(consecutive_failures: u32) -> Duration {
 
 async fn sync_once(
     store: &MobileNoteStore,
-    api: &ApiClient,
+    session: &SessionApiClient,
     events: &UnboundedSender<SyncEvent>,
 ) -> SyncOutcome {
     let _ = events.send(SyncEvent::Status(SyncStatus::Syncing));
-    let engine = SyncEngine::new(store, api, SOLO_USER_ID);
+    let api = session.current();
+    // `MobileNoteStore` derefs to the core `DatabaseService` the engine
+    // expects, so rustc reborrows automatically.
+    let engine = SyncEngine::new(store, &api, SOLO_USER_ID);
     match engine.run_once().await {
         Ok(report) => {
             tracing::info!(
@@ -206,47 +269,104 @@ async fn sync_once(
             SyncOutcome::Ok
         }
         Err(err) => {
+            if matches!(&err, SyncEngineError::Api(ApiClientError::Unauthorized(_))) {
+                // Drop the snapshot Arc before refreshing — not load-
+                // bearing (refresh takes the inner RwLock regardless),
+                // just frees the old client before the next cycle
+                // snapshots the refreshed one.
+                drop(api);
+                return handle_unauthorized(session, events).await;
+            }
             tracing::error!("Sync failed: {err}");
             let _ = events.send(SyncEvent::Status(SyncStatus::Error));
             let _ = events.send(SyncEvent::Issue(Some(err.to_string())));
-            if is_permanent(&err) {
-                SyncOutcome::Permanent
-            } else {
-                SyncOutcome::Failed
-            }
+            SyncOutcome::Failed
         }
     }
 }
 
-const fn is_permanent(err: &SyncEngineError) -> bool {
-    matches!(err, SyncEngineError::Api(ApiClientError::Unauthorized(_)))
+/// Handle a 401 from the sync engine by attempting silent refresh.
+///
+/// Mirrors desktop. On success the worker returns `Failed` (not `Ok`)
+/// so the loop immediately schedules another sync cycle — `Failed`
+/// ramps backoff, but the first retry runs after only 5 s and uses the
+/// fresh bearer, so the user-visible recovery is fast. On a permanent
+/// refresh failure the keyring (here: `EncryptedPrefsTokenStore`) has
+/// been cleared inside `refresh`; we surface a re-auth nudge through
+/// `sync_issue` and park the worker.
+async fn handle_unauthorized(
+    session: &SessionApiClient,
+    events: &UnboundedSender<SyncEvent>,
+) -> SyncOutcome {
+    match session.refresh().await {
+        Ok(()) => {
+            tracing::info!("Sync token refreshed silently after 401");
+            // Don't surface a UI error — the user shouldn't notice the
+            // background refresh. Mark Failed so we retry quickly with
+            // the new client on the next cycle.
+            SyncOutcome::Failed
+        }
+        Err(SessionRefreshError::SessionExpired(_) | SessionRefreshError::NoToken) => {
+            let _ = events.send(SyncEvent::Status(SyncStatus::Error));
+            let _ = events.send(SyncEvent::Issue(Some(
+                "Your session has expired. Sign in again to resume sync.".into(),
+            )));
+            SyncOutcome::Permanent
+        }
+        Err(other) => {
+            tracing::warn!("Token refresh failed transiently: {other}");
+            let _ = events.send(SyncEvent::Status(SyncStatus::Error));
+            let _ = events.send(SyncEvent::Issue(Some(format!(
+                "Sync refresh failed: {other}"
+            ))));
+            SyncOutcome::Failed
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dirt_core::auth::{AuthClient, MemoryTokenStore, StoredToken, TokenStore};
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    #[test]
-    fn unauthorized_classifies_as_permanent() {
-        let err = SyncEngineError::Api(ApiClientError::Unauthorized("bad token".into()));
-        assert!(is_permanent(&err));
+    const REFRESH_PATH: &str = "/v1/auth/refresh";
+
+    fn seeded_store(token: &str) -> Arc<MemoryTokenStore> {
+        Arc::new(MemoryTokenStore::with_initial(StoredToken {
+            session_token: token.into(),
+            session_id: "sid-old".into(),
+            user_id: "uid-1".into(),
+            email: "user@example.com".into(),
+            expires_at_ms: 1,
+        }))
+    }
+
+    fn session_for(server: &MockServer, store: Arc<dyn TokenStore>) -> SessionApiClient {
+        let auth = AuthClient::new(server.uri()).expect("auth client should build for mock");
+        SessionApiClient::from_store(server.uri(), auth, store)
+            .expect("session client should build")
+            .expect("seeded store should hydrate a session")
+    }
+
+    fn drain_events(rx: &mut tokio::sync::mpsc::UnboundedReceiver<SyncEvent>) -> Vec<SyncEvent> {
+        let mut out = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            out.push(event);
+        }
+        out
     }
 
     #[test]
-    fn transient_errors_stay_failed() {
-        let cases = [
-            SyncEngineError::Api(ApiClientError::Network("timeout".into())),
-            SyncEngineError::Api(ApiClientError::ServerUnavailable("turso down".into())),
-            SyncEngineError::Api(ApiClientError::ServerError {
-                status: 500,
-                message: "boom".into(),
-            }),
-            SyncEngineError::PushIncomplete { acked: 0, sent: 1 },
-            SyncEngineError::Decode("contract drift".into()),
-        ];
-        for err in cases {
-            assert!(!is_permanent(&err), "{err} should not be permanent");
-        }
+    fn unauthorized_classification_routes_through_refresh() {
+        // Sanity check that the `is_permanent`-shaped logic from the
+        // pre-Phase-2.7 worker is gone: a plain 401 from `sync_once` is
+        // no longer terminal on its own; it gets routed to
+        // `handle_unauthorized` which decides based on the refresh
+        // response. The wiremock tests below cover the three branches.
+        let _ = SyncEngineError::Api(ApiClientError::Unauthorized("dummy".into()));
     }
 
     #[test]
@@ -255,7 +375,131 @@ mod tests {
         assert_eq!(backoff_for(2), Duration::from_secs(15));
         assert_eq!(backoff_for(3), Duration::from_secs(60));
         assert_eq!(backoff_for(4), Duration::from_secs(300));
+        // Past the end of the schedule it stays at the cap.
         assert_eq!(backoff_for(5), Duration::from_secs(300));
         assert_eq!(backoff_for(99), Duration::from_secs(300));
+    }
+
+    /// 401 from sync + a successful `/v1/auth/refresh` should return
+    /// `Failed` (so the worker loops back quickly with the new bearer)
+    /// and must NOT emit a UI-facing error event — the refresh is
+    /// supposed to be invisible to the user.
+    #[tokio::test(flavor = "current_thread")]
+    async fn handle_unauthorized_returns_failed_on_successful_refresh() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(REFRESH_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "session_token": "new-token",
+                "session_id": "sid-new",
+                "expires_at_ms": 9_999_999,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let store_concrete = seeded_store("old-token");
+        let store: Arc<dyn TokenStore> = store_concrete.clone();
+        let session = session_for(&server, store);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<SyncEvent>();
+
+        let outcome = handle_unauthorized(&session, &tx).await;
+        assert_eq!(outcome, SyncOutcome::Failed);
+
+        // Silent refresh: the worker should not push an Error onto the
+        // status channel. (The caller already enqueued Syncing before
+        // calling handle_unauthorized; we just confirm no extra noise.)
+        assert!(
+            drain_events(&mut rx).is_empty(),
+            "successful refresh must not emit user-visible status events"
+        );
+
+        // And the new bearer must be persisted to the store so the next
+        // sync cycle picks it up.
+        assert_eq!(
+            store_concrete.load().unwrap().unwrap().session_token,
+            "new-token"
+        );
+    }
+
+    /// 401 from sync + `SESSION_EXPIRED` on refresh is the terminal
+    /// state — the worker must surface the "Sign in again" copy and
+    /// return `Permanent` so the loop parks instead of hammering the
+    /// server forever.
+    #[tokio::test(flavor = "current_thread")]
+    async fn handle_unauthorized_returns_permanent_on_session_expired() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(REFRESH_PATH))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": {
+                    "code": "SESSION_EXPIRED",
+                    "message": "session token is invalid or expired",
+                    "cause": "session token is invalid or expired",
+                    "fix": "Sign in again to obtain a fresh session token.",
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let store_concrete = seeded_store("dead-token");
+        let store: Arc<dyn TokenStore> = store_concrete.clone();
+        let session = session_for(&server, store);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<SyncEvent>();
+
+        let outcome = handle_unauthorized(&session, &tx).await;
+        assert_eq!(outcome, SyncOutcome::Permanent);
+
+        let events = drain_events(&mut rx);
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, SyncEvent::Status(SyncStatus::Error))),
+            "expected Error status event, got {events:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, SyncEvent::Issue(Some(msg)) if msg.contains("Sign in again"))),
+            "expected 'Sign in again' issue message, got {events:?}"
+        );
+
+        // SessionApiClient::refresh clears the store on SESSION_EXPIRED.
+        assert!(store_concrete.load().unwrap().is_none());
+    }
+
+    /// 401 from sync + a transient 503 on refresh should classify as
+    /// `Failed` (worker keeps retrying under backoff) and surface a
+    /// distinct "Sync refresh failed" message — separate from the
+    /// permanent "Sign in again" copy so a future log filter can tell
+    /// them apart.
+    #[tokio::test(flavor = "current_thread")]
+    async fn handle_unauthorized_returns_failed_on_transient_refresh_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(REFRESH_PATH))
+            .respond_with(ResponseTemplate::new(503).set_body_string("turso down"))
+            .mount(&server)
+            .await;
+
+        let store_concrete = seeded_store("still-valid");
+        let store: Arc<dyn TokenStore> = store_concrete.clone();
+        let session = session_for(&server, store);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<SyncEvent>();
+
+        let outcome = handle_unauthorized(&session, &tx).await;
+        assert_eq!(outcome, SyncOutcome::Failed);
+
+        let events = drain_events(&mut rx);
+        assert!(
+            events.iter().any(
+                |e| matches!(e, SyncEvent::Issue(Some(msg)) if msg.contains("Sync refresh failed"))
+            ),
+            "expected 'Sync refresh failed' issue message, got {events:?}"
+        );
+
+        // Transient failure must not clear the store — the credential
+        // may still be valid; the worker will retry under backoff.
+        assert!(store_concrete.load().unwrap().is_some());
     }
 }

--- a/crates/dirt-mobile/src/state.rs
+++ b/crates/dirt-mobile/src/state.rs
@@ -6,13 +6,17 @@
 //! therefore android-only.
 #![cfg_attr(not(target_os = "android"), allow(dead_code))]
 
-#[cfg(target_os = "android")]
 use std::sync::Arc;
 
 #[cfg(target_os = "android")]
 use dioxus::prelude::Signal;
 #[cfg(target_os = "android")]
+use dirt_core::auth::StoredToken;
+use dirt_core::auth::{AuthClient, TokenStore};
+#[cfg(target_os = "android")]
 use dirt_core::models::{Note, NoteId};
+#[cfg(target_os = "android")]
+use dirt_core::sync::session_client::SessionApiClient;
 
 #[cfg(target_os = "android")]
 use crate::data::MobileNoteStore;
@@ -46,6 +50,31 @@ pub enum View {
     /// Editor is open for a specific note, or for a new draft when
     /// `selected_note_id` is `None`.
     Editor,
+    /// Settings panel (Account row in P2.7; more tabs may follow).
+    Settings,
+}
+
+/// Auth dependencies that live for the lifetime of the process.
+///
+/// Same shape as `dirt-desktop`'s `AuthDeps`: `Clone` (inner handles are
+/// all `Arc`-shaped) so the type threads cheaply through Dioxus
+/// context. Held in its own context (`Signal<AuthDeps>`) so the Account
+/// row reads it without depending on the dozen unrelated note-side
+/// signals on `AppState`.
+#[derive(Clone)]
+pub struct AuthDeps {
+    /// HTTP client for `/v1/auth/*`. `None` when no API base URL is
+    /// available — the Account row surfaces a config error rather than
+    /// silently failing.
+    pub auth_client: Option<Arc<AuthClient>>,
+    /// Persistent token store. Always present — on Android this is the
+    /// JNI-backed `EncryptedPrefsTokenStore`, on the host (tests) it's
+    /// the file-based `FileTokenStore`. Construction does not touch the
+    /// platform store until a load / save / clear actually fires.
+    pub token_store: Arc<dyn TokenStore>,
+    /// Normalized API base URL used to (re)build `SessionApiClient`
+    /// after login. `None` mirrors `auth_client.is_none()`.
+    pub api_base_url: Option<String>,
 }
 
 /// Context object passed via `use_context_provider` to every component.
@@ -63,14 +92,22 @@ pub struct AppState {
     pub last_sync_at: Signal<Option<i64>>,
     pub store: Signal<Option<Arc<MobileNoteStore>>>,
     pub sync_worker: Signal<Option<SyncWorkerHandle>>,
+    /// Currently signed-in user, if any. Source of truth for "is the
+    /// user signed in"; the Account row in Settings reads this.
+    pub signed_in: Signal<Option<StoredToken>>,
+    /// Refreshing session API client. Present iff `signed_in` is
+    /// present; the sync worker holds its own `Arc<SessionApiClient>`
+    /// so swapping this signal doesn't kill the running worker.
+    pub session_client: Signal<Option<Arc<SessionApiClient>>>,
 }
 
 #[cfg(target_os = "android")]
 impl AppState {
     /// Kick the sync worker so a pending mutation reaches the server
-    /// quickly. No-op when the worker isn't running (misconfigured
-    /// env). Mutation sites call this after a successful DB write so
-    /// the worker debounces local edits into a single sync cycle.
+    /// quickly. No-op when the worker isn't running (signed out,
+    /// misconfigured env). Mutation sites call this after a successful
+    /// DB write so the worker debounces local edits into a single
+    /// sync cycle.
     pub fn trigger_sync(&self) {
         if let Some(handle) = (self.sync_worker)().as_ref() {
             handle.trigger();

--- a/crates/dirt-mobile/src/state.rs
+++ b/crates/dirt-mobile/src/state.rs
@@ -17,11 +17,13 @@ use dirt_core::auth::{AuthClient, TokenStore};
 use dirt_core::models::{Note, NoteId};
 #[cfg(target_os = "android")]
 use dirt_core::sync::session_client::SessionApiClient;
+#[cfg(target_os = "android")]
+use tokio::sync::mpsc::UnboundedSender;
 
 #[cfg(target_os = "android")]
 use crate::data::MobileNoteStore;
 #[cfg(target_os = "android")]
-use crate::services::SyncWorkerHandle;
+use crate::services::{SyncEvent, SyncWorkerHandle};
 
 /// Coarse sync status surfaced to the UI by the worker.
 ///
@@ -99,6 +101,19 @@ pub struct AppState {
     /// present; the sync worker holds its own `Arc<SessionApiClient>`
     /// so swapping this signal doesn't kill the running worker.
     pub session_client: Signal<Option<Arc<SessionApiClient>>>,
+    /// Long-lived [`SyncEvent`] sender shared by every worker spawn
+    /// (startup-hydrate, post-login). Owned by `AppShell` along with
+    /// the corresponding drainer task — both live in the root scope,
+    /// so the bridge from worker → UI signals stays alive when the
+    /// user navigates between List / Editor / Settings.
+    ///
+    /// A previous version spawned the drainer inside
+    /// `spawn_session_worker`, but Dioxus' `spawn` attaches the task
+    /// to the *calling* component's scope. When the Settings view
+    /// re-spawned the worker after sign-in and the user navigated
+    /// back to the list, the drainer was cancelled — leaving the
+    /// worker alive but its status events silently dropped.
+    pub events_tx: Signal<Option<UnboundedSender<SyncEvent>>>,
 }
 
 #[cfg(target_os = "android")]

--- a/crates/dirt-mobile/src/views/list.rs
+++ b/crates/dirt-mobile/src/views/list.rs
@@ -27,15 +27,24 @@ pub fn List() -> Element {
 
             SyncBanner { status, issue: issue.clone() }
 
-            UiButton {
-                r#type: "button",
-                block: true,
-                variant: ButtonVariant::Primary,
-                onclick: move |_| {
-                    state.selected_note_id.set(None);
-                    state.view.set(View::Editor);
-                },
-                "New note"
+            div {
+                style: "display: flex; gap: 8px;",
+                UiButton {
+                    r#type: "button",
+                    block: true,
+                    variant: ButtonVariant::Primary,
+                    onclick: move |_| {
+                        state.selected_note_id.set(None);
+                        state.view.set(View::Editor);
+                    },
+                    "New note"
+                }
+                UiButton {
+                    r#type: "button",
+                    variant: ButtonVariant::Secondary,
+                    onclick: move |_| state.view.set(View::Settings),
+                    "Settings"
+                }
             }
         }
 

--- a/crates/dirt-mobile/src/views/mod.rs
+++ b/crates/dirt-mobile/src/views/mod.rs
@@ -5,6 +5,8 @@
 
 mod editor;
 mod list;
+mod settings;
 
 pub use editor::Editor;
 pub use list::List;
+pub use settings::Settings;

--- a/crates/dirt-mobile/src/views/settings.rs
+++ b/crates/dirt-mobile/src/views/settings.rs
@@ -89,6 +89,15 @@ pub fn Settings() -> Element {
                             busy.set(true);
                             message.set(None);
                             spawn(async move {
+                                // Shut down (and await) the worker *before*
+                                // talking to the server. Otherwise a parallel
+                                // `sync_once` that hits a 401 can call
+                                // `session.refresh()` mid-logout and persist
+                                // a fresh token to the store after
+                                // `perform_logout` has cleared it — leaving
+                                // the device "signed in" while the UI claims
+                                // it's signed out.
+                                shutdown_existing_worker(state.sync_worker).await;
                                 let outcome = perform_logout(&deps_for_task).await;
                                 apply_logout_outcome(outcome, state, &mut message).await;
                                 busy.set(false);
@@ -406,25 +415,23 @@ async fn apply_login_outcome(
             state.session_client.set(Some(session.clone()));
 
             let store = state.store.read().clone();
-            if let Some(store) = store {
-                spawn_session_worker(
-                    store,
-                    session,
-                    state.sync_worker,
-                    state.sync_status,
-                    state.sync_issue,
-                    state.last_sync_at,
-                    state.notes,
-                );
-            } else {
-                // Local DB isn't ready yet — extremely unlikely (the
-                // Settings view can't open before the DB hydrates) but
-                // worth a loud error rather than silently skipping
-                // worker startup.
-                state.sync_status.set(SyncStatus::Error);
-                state.sync_issue.set(Some(
-                    "Local database is not ready; sync worker not started.".into(),
-                ));
+            let events_tx = state.events_tx.read().clone();
+            match (store, events_tx) {
+                (Some(store), Some(events_tx)) => {
+                    spawn_session_worker(store, session, events_tx, state.sync_worker);
+                }
+                // Either the local DB or the long-lived event bridge is
+                // missing. Both should be present by the time the
+                // Settings view is reachable (they're hydrated in
+                // `AppShell`'s startup `use_resource`), so this is a
+                // hard error — surface loudly rather than silently
+                // skipping worker startup.
+                _ => {
+                    state.sync_status.set(SyncStatus::Error);
+                    state.sync_issue.set(Some(
+                        "Local database / sync bridge not ready; sync worker not started.".into(),
+                    ));
+                }
             }
 
             email_input.set(String::new());
@@ -439,6 +446,13 @@ async fn apply_login_outcome(
 }
 
 // See the rationale on [`apply_login_outcome`].
+//
+// Logout shuts the worker down *before* this runs (in the on_logout
+// handler) — so this function does not call `shutdown_existing_worker`.
+// Calling it again here would be a no-op (the handle has been removed
+// from the signal already), but documenting the ordering up front keeps
+// future refactors honest: the shutdown must happen ahead of
+// `perform_logout` to close the refresh-after-revoke race.
 #[allow(clippy::large_types_passed_by_value)]
 async fn apply_logout_outcome(
     outcome: LogoutOutcome,
@@ -447,7 +461,6 @@ async fn apply_logout_outcome(
 ) {
     match outcome {
         LogoutOutcome::Success => {
-            shutdown_existing_worker(state.sync_worker).await;
             state.signed_in.set(None);
             state.session_client.set(None);
             state.sync_status.set(SyncStatus::Offline);

--- a/crates/dirt-mobile/src/views/settings.rs
+++ b/crates/dirt-mobile/src/views/settings.rs
@@ -1,0 +1,475 @@
+//! Mobile Settings → Account view.
+//!
+//! Account-only for Phase 2.7. Theme / Sync / Window tabs are explicitly
+//! out of scope; mobile inherits the OS theme and there's no window
+//! geometry to manage on Android. The flow mirrors desktop's Account
+//! row exactly so a future shared UI library can collapse them into one
+//! component once the styling is unified:
+//!
+//!   1. User enters email → `POST /v1/auth/request` returns a
+//!      `request_id` and emails a 6-digit code.
+//!   2. User enters the code → `POST /v1/auth/verify` swaps it for a
+//!      `StoredToken` which we persist via the injected `TokenStore`.
+//!   3. On success we hydrate a `SessionApiClient` and spawn the sync
+//!      worker so background pull / push kicks off immediately — the
+//!      user doesn't need to restart the app.
+//!
+//! Sign-out reverses the steps: revoke the bearer server-side, clear
+//! the stored slot, shut the worker down, and reset the sync status
+//! signals to Offline. The shutdown is awaited (see
+//! `shutdown_existing_worker`) so a freshly spawned worker after
+//! re-login cannot race the previous one's in-flight `sync_once`.
+
+use dioxus::prelude::*;
+
+use crate::app_shell::spawn_session_worker;
+use crate::services::auth_flow::{
+    perform_logout, perform_verify, send_magic_code, validate_code, validate_email, LoginOutcome,
+    LogoutOutcome,
+};
+use crate::services::SyncWorkerHandle;
+use crate::state::{AppState, AuthDeps, SyncStatus, View};
+use crate::ui::{ButtonVariant, UiButton};
+
+/// Discriminator for the inline status banner.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MessageKind {
+    Info,
+    Error,
+}
+
+#[component]
+pub fn Settings() -> Element {
+    let state = use_context::<AppState>();
+    let auth_deps_signal = use_context::<Signal<AuthDeps>>();
+    // Snapshot once per render. `auth_deps_signal` re-renders the
+    // component when its inner value changes — same pattern desktop
+    // uses to keep the snapshot fresh after bootstrap resolves.
+    let auth_deps_snapshot = auth_deps_signal.read().clone();
+
+    let mut email_input = use_signal(String::new);
+    let mut code_input = use_signal(String::new);
+    let mut request_id: Signal<Option<String>> = use_signal(|| None);
+    let mut busy = use_signal(|| false);
+    let mut message: Signal<Option<(MessageKind, String)>> = use_signal(|| None);
+
+    let signed_in_value = (state.signed_in)();
+    let mut view_signal = state.view;
+    let deps_signal = auth_deps_signal;
+
+    rsx! {
+        div {
+            style: "padding: 12px 16px; display: flex; flex-direction: column; gap: 12px;",
+
+            // Header with a back button so a single-screen mobile shell
+            // can return to the list without a hardware back button being
+            // the only escape hatch (Android does have one, but the
+            // affordance shouldn't depend on it).
+            div {
+                style: "display: flex; align-items: center; gap: 8px;",
+                UiButton {
+                    r#type: "button",
+                    variant: ButtonVariant::Secondary,
+                    onclick: move |_| view_signal.set(View::List),
+                    "← Back"
+                }
+                h2 {
+                    style: "margin: 0; font-size: 18px; font-weight: 600;",
+                    "Settings"
+                }
+            }
+
+            match &signed_in_value {
+                Some(token) => rsx! {
+                    SignedInPanel {
+                        email: token.email.clone(),
+                        busy: busy(),
+                        on_logout: move |_| {
+                            let deps_for_task = deps_signal.read().clone();
+                            busy.set(true);
+                            message.set(None);
+                            spawn(async move {
+                                let outcome = perform_logout(&deps_for_task).await;
+                                apply_logout_outcome(outcome, state, &mut message).await;
+                                busy.set(false);
+                            });
+                        },
+                    }
+                },
+                None => rsx! {
+                    SignedOutPanel {
+                        auth_available: auth_deps_snapshot.auth_client.is_some(),
+                        api_base_url: auth_deps_snapshot.api_base_url.clone(),
+                        email_input: email_input(),
+                        on_email_input: move |value: String| email_input.set(value),
+                        code_input: code_input(),
+                        on_code_input: move |value: String| {
+                            // Drop non-digits + cap to 6 so paste-with-spaces
+                            // produces a clean OTP. Non-digits get dropped
+                            // silently — they're never valid in a code.
+                            let cleaned: String = value
+                                .chars()
+                                .filter(char::is_ascii_digit)
+                                .take(6)
+                                .collect();
+                            code_input.set(cleaned);
+                        },
+                        has_request_id: request_id().is_some(),
+                        on_send_code: move |_| {
+                            let email = email_input().trim().to_string();
+                            if let Err(reason) = validate_email(&email) {
+                                message.set(Some((MessageKind::Error, reason)));
+                                return;
+                            }
+                            let deps_for_task = deps_signal.read().clone();
+                            busy.set(true);
+                            message.set(None);
+                            spawn(async move {
+                                match send_magic_code(&deps_for_task, &email).await {
+                                    Ok(req_id) => {
+                                        request_id.set(Some(req_id));
+                                        message.set(Some((
+                                            MessageKind::Info,
+                                            format!("Code sent to {email}. Check your inbox."),
+                                        )));
+                                    }
+                                    Err(err) => {
+                                        request_id.set(None);
+                                        message.set(Some((MessageKind::Error, err)));
+                                    }
+                                }
+                                busy.set(false);
+                            });
+                        },
+                        on_verify_code: move |_| {
+                            let Some(req_id) = request_id() else {
+                                message.set(Some((
+                                    MessageKind::Error,
+                                    "Send a code first.".into(),
+                                )));
+                                return;
+                            };
+                            let code = code_input();
+                            if let Err(reason) = validate_code(&code) {
+                                message.set(Some((MessageKind::Error, reason)));
+                                return;
+                            }
+                            let deps_for_task = deps_signal.read().clone();
+                            busy.set(true);
+                            message.set(None);
+                            spawn(async move {
+                                let outcome = perform_verify(&deps_for_task, &req_id, &code).await;
+                                apply_login_outcome(
+                                    outcome,
+                                    state,
+                                    &mut email_input,
+                                    &mut code_input,
+                                    &mut request_id,
+                                    &mut message,
+                                )
+                                .await;
+                                busy.set(false);
+                            });
+                        },
+                        busy: busy(),
+                    }
+                },
+            }
+
+            if let Some((kind, text)) = message() {
+                MessageBanner { kind, text }
+            }
+        }
+    }
+}
+
+#[component]
+fn SignedInPanel(email: String, busy: bool, on_logout: EventHandler<MouseEvent>) -> Element {
+    rsx! {
+        div {
+            style: "
+                display: flex;
+                flex-direction: column;
+                gap: 10px;
+                padding: 14px;
+                border: 1px solid #e5e7eb;
+                border-radius: 12px;
+                background: #ffffff;
+            ",
+            p {
+                style: "margin: 0; font-weight: 600; color: #111827;",
+                "Account"
+            }
+            p {
+                style: "margin: 0; font-size: 13px; color: #6b7280;",
+                "Signed in as {email}"
+            }
+            UiButton {
+                r#type: "button",
+                block: true,
+                variant: ButtonVariant::Secondary,
+                disabled: busy,
+                onclick: move |event| on_logout.call(event),
+                if busy { "Signing out..." } else { "Sign out" }
+            }
+            p {
+                style: "margin: 0; font-size: 12px; color: #9ca3af; line-height: 1.4;",
+                "Sign out to stop syncing this device and revoke the session."
+            }
+        }
+    }
+}
+
+#[component]
+fn SignedOutPanel(
+    auth_available: bool,
+    api_base_url: Option<String>,
+    email_input: String,
+    on_email_input: EventHandler<String>,
+    code_input: String,
+    on_code_input: EventHandler<String>,
+    has_request_id: bool,
+    on_send_code: EventHandler<MouseEvent>,
+    on_verify_code: EventHandler<MouseEvent>,
+    busy: bool,
+) -> Element {
+    if !auth_available {
+        return rsx! {
+            div {
+                style: "
+                    padding: 14px;
+                    border: 1px solid #fecaca;
+                    border-radius: 12px;
+                    background: #fef2f2;
+                    color: #b91c1c;
+                    font-size: 13px;
+                    line-height: 1.4;
+                ",
+                "Sign-in is unavailable — DIRT_API_BASE_URL is not configured. \
+                 Set it in the mobile bootstrap config (.env.client at build \
+                 time) and rebuild the app."
+            }
+        };
+    }
+
+    let server_hint = api_base_url
+        .as_deref()
+        .map(|url| format!("Backend: {url}"))
+        .unwrap_or_default();
+
+    rsx! {
+        div {
+            style: "
+                display: flex;
+                flex-direction: column;
+                gap: 10px;
+                padding: 14px;
+                border: 1px solid #e5e7eb;
+                border-radius: 12px;
+                background: #ffffff;
+            ",
+            p {
+                style: "margin: 0; font-weight: 600; color: #111827;",
+                "Email"
+            }
+            p {
+                style: "margin: 0; font-size: 12px; color: #6b7280; line-height: 1.4;",
+                "We'll send a one-time 6-digit code."
+            }
+            input {
+                r#type: "email",
+                inputmode: "email",
+                placeholder: "you@example.com",
+                value: "{email_input}",
+                disabled: busy || has_request_id,
+                style: "
+                    width: 100%;
+                    padding: 10px 12px;
+                    border: 1px solid #d1d5db;
+                    border-radius: 10px;
+                    font-size: 15px;
+                    box-sizing: border-box;
+                ",
+                oninput: move |event| on_email_input.call(event.value()),
+            }
+            UiButton {
+                r#type: "button",
+                block: true,
+                variant: ButtonVariant::Secondary,
+                disabled: busy,
+                onclick: move |event| on_send_code.call(event),
+                if has_request_id { "Resend code" } else { "Send code" }
+            }
+            if !server_hint.is_empty() {
+                p {
+                    style: "margin: 0; font-size: 11px; color: #9ca3af;",
+                    "{server_hint}"
+                }
+            }
+        }
+
+        if has_request_id {
+            div {
+                style: "
+                    display: flex;
+                    flex-direction: column;
+                    gap: 10px;
+                    padding: 14px;
+                    border: 1px solid #e5e7eb;
+                    border-radius: 12px;
+                    background: #ffffff;
+                ",
+                p {
+                    style: "margin: 0; font-weight: 600; color: #111827;",
+                    "Verification code"
+                }
+                p {
+                    style: "margin: 0; font-size: 12px; color: #6b7280; line-height: 1.4;",
+                    "Enter the 6-digit code we just emailed."
+                }
+                input {
+                    r#type: "text",
+                    inputmode: "numeric",
+                    placeholder: "123456",
+                    value: "{code_input}",
+                    disabled: busy,
+                    style: "
+                        width: 100%;
+                        padding: 10px 12px;
+                        border: 1px solid #d1d5db;
+                        border-radius: 10px;
+                        font-size: 18px;
+                        letter-spacing: 4px;
+                        text-align: center;
+                        font-family: monospace;
+                        box-sizing: border-box;
+                    ",
+                    oninput: move |event| on_code_input.call(event.value()),
+                }
+                UiButton {
+                    r#type: "button",
+                    block: true,
+                    variant: ButtonVariant::Primary,
+                    disabled: busy || code_input.len() != 6,
+                    onclick: move |event| on_verify_code.call(event),
+                    if busy { "Verifying..." } else { "Verify" }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn MessageBanner(kind: MessageKind, text: String) -> Element {
+    let (bg, fg) = match kind {
+        MessageKind::Info => ("#dbeafe", "#1d4ed8"),
+        MessageKind::Error => ("#fee2e2", "#b91c1c"),
+    };
+    rsx! {
+        div {
+            style: "
+                padding: 10px 12px;
+                background: {bg};
+                color: {fg};
+                border-radius: 10px;
+                font-size: 13px;
+                line-height: 1.4;
+            ",
+            "{text}"
+        }
+    }
+}
+
+// `AppState` is a `Copy` struct of `Signal` handles; passing by value
+// matches the rest of the mobile component tree and avoids fighting
+// the borrow checker against the `Signal::set` `&mut self` receiver
+// when called on subfields. The lint flags the raw byte count without
+// noticing that every field is a cheap `Arc`-backed handle.
+#[allow(clippy::large_types_passed_by_value)]
+async fn apply_login_outcome(
+    outcome: LoginOutcome,
+    mut state: AppState,
+    email_input: &mut Signal<String>,
+    code_input: &mut Signal<String>,
+    request_id: &mut Signal<Option<String>>,
+    message: &mut Signal<Option<(MessageKind, String)>>,
+) {
+    match outcome {
+        LoginOutcome::Success(token, session) => {
+            // Tear down the previous worker (if any — happens during
+            // re-login after a permanent failure) before starting a
+            // fresh one. The await joins the old task so two workers
+            // never run a `sync_once` against the same DB concurrently.
+            shutdown_existing_worker(state.sync_worker).await;
+
+            state.signed_in.set(Some(token));
+            state.session_client.set(Some(session.clone()));
+
+            let store = state.store.read().clone();
+            if let Some(store) = store {
+                spawn_session_worker(
+                    store,
+                    session,
+                    state.sync_worker,
+                    state.sync_status,
+                    state.sync_issue,
+                    state.last_sync_at,
+                    state.notes,
+                );
+            } else {
+                // Local DB isn't ready yet — extremely unlikely (the
+                // Settings view can't open before the DB hydrates) but
+                // worth a loud error rather than silently skipping
+                // worker startup.
+                state.sync_status.set(SyncStatus::Error);
+                state.sync_issue.set(Some(
+                    "Local database is not ready; sync worker not started.".into(),
+                ));
+            }
+
+            email_input.set(String::new());
+            code_input.set(String::new());
+            request_id.set(None);
+            message.set(Some((MessageKind::Info, "Signed in.".into())));
+        }
+        LoginOutcome::Failure(reason) => {
+            message.set(Some((MessageKind::Error, reason)));
+        }
+    }
+}
+
+// See the rationale on [`apply_login_outcome`].
+#[allow(clippy::large_types_passed_by_value)]
+async fn apply_logout_outcome(
+    outcome: LogoutOutcome,
+    mut state: AppState,
+    message: &mut Signal<Option<(MessageKind, String)>>,
+) {
+    match outcome {
+        LogoutOutcome::Success => {
+            shutdown_existing_worker(state.sync_worker).await;
+            state.signed_in.set(None);
+            state.session_client.set(None);
+            state.sync_status.set(SyncStatus::Offline);
+            state.sync_issue.set(None);
+            message.set(Some((MessageKind::Info, "Signed out.".into())));
+        }
+        LogoutOutcome::Failure(reason) => {
+            message.set(Some((MessageKind::Error, reason)));
+        }
+    }
+}
+
+/// Drop the currently-tracked worker handle and wait for the
+/// underlying tokio task to finish its in-flight `sync_once`. The
+/// await is critical — without it a fresh worker spawned right after
+/// can run a startup sync concurrently with the old worker's
+/// not-yet-cancelled push cycle, producing two simultaneous bearer
+/// tokens against the same server endpoint.
+async fn shutdown_existing_worker(mut sync_worker: Signal<Option<SyncWorkerHandle>>) {
+    let handle = sync_worker.read().clone();
+    sync_worker.set(None);
+    if let Some(handle) = handle {
+        handle.shutdown().await;
+    }
+}

--- a/crates/dirt-mobile/src/views/settings.rs
+++ b/crates/dirt-mobile/src/views/settings.rs
@@ -99,7 +99,7 @@ pub fn Settings() -> Element {
                 None => rsx! {
                     SignedOutPanel {
                         auth_available: auth_deps_snapshot.auth_client.is_some(),
-                        api_base_url: auth_deps_snapshot.api_base_url.clone(),
+                        api_base_url: auth_deps_snapshot.api_base_url,
                         email_input: email_input(),
                         on_email_input: move |value: String| email_input.set(value),
                         code_input: code_input(),


### PR DESCRIPTION
## Summary

- Wires magic-link auth into dirt-mobile, replacing `DIRT_CLIENT_TOKEN` env with OS-native storage and silent refresh on 401 (mirrors Phase 2.6 desktop).
- New `DefaultTokenStore` cfg-split: Android binds AndroidX `EncryptedSharedPreferences` via JNI (hardware-backed master key, AES-256/GCM values, AES-256/SIV keys); host build uses a file-backed mock for `cargo test`. Slot name `dev.dirt.session` / `default` matches the CLI + desktop convention so all three binaries share one logical session.
- Mobile `sync_worker` takes `Arc<SessionApiClient>`, ports the `handle_unauthorized` refresh path + async `shutdown` from desktop.
- Settings → Account view (Account-only for P2.7); `auth_flow` helpers extracted so the request → verify → logout edges run on the host.
- 49 host tests pass; clippy + fmt clean.

## Verified locally

- [x] `cargo test -p dirt-mobile` — 49 passed (3 new sync_worker wiremock tests, 8 new auth_flow tests, 6 host-store tests, 3 codec tests).
- [x] `cargo clippy -p dirt-mobile --all-targets` — clean.
- [x] `cargo fmt --all -- --check` — clean.

## Test plan

- [ ] CI: Android Mobile Check (`cargo check -p dirt-mobile --target x86_64-linux-android`) — load-bearing for the EncryptedSharedPreferences JNI signatures since the local Windows host has no Android NDK.
- [ ] CI: Format + Clippy + Test (ubuntu / macos / windows) + Security Guard + Managed Mode E2E.
- [ ] Manual on-device once an APK is built: email → code → verify, sync runs; sign out clears the slot and stops the worker; cold restart with a valid keyring slot resumes sync without prompting.

## Notes

- This PR is stacked on `feature/phase-2-6-desktop-login-screen` (PR #232). It'll need PR #232 to merge first; once that lands the base will rebase to `main` automatically.
- `androidx.security:security-crypto:1.1.0-alpha06` added to `Dioxus.toml` `[android] gradle_dependencies` — `dx 0.7.5` supports this natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)