### PR TITLE
Phase 2.8: CLI session-auth cutover + bootstrap-manifest cleanup

### DIFF
--- a/.env.client.example
+++ b/.env.client.example
@@ -5,19 +5,18 @@
 # Copy to .env.client and fill in your values:
 #   cp .env.client.example .env.client
 
-# API server base URL (used to derive bootstrap manifest URL)
+# API server base URL — baked into the desktop/mobile binary at build
+# time. Clients hit `/v1/auth/*` and `/v1/notes/*` here directly; there
+# is no longer a runtime bootstrap-manifest fetch.
 DIRT_API_BASE_URL=
 
-# Override bootstrap manifest URL directly (optional)
-DIRT_BOOTSTRAP_URL=
-
 # Optional platform-specific overrides (preferred when desktop + emulator
-# are used together and require different hostnames)
+# are used together and require different hostnames — desktop normalizes
+# 10.0.2.2 → 127.0.0.1, mobile normalizes the reverse).
 DIRT_DESKTOP_API_BASE_URL=
-DIRT_DESKTOP_BOOTSTRAP_URL=
 DIRT_MOBILE_API_BASE_URL=
-DIRT_MOBILE_BOOTSTRAP_URL=
 
-# Bearer token for the dirt-api backend (must match DIRT_SERVER_TOKEN
-# on the server). Read at runtime by the sync worker, not at build time.
-DIRT_CLIENT_TOKEN=
+# Note: clients no longer use a shared bearer token. Authentication is
+# magic-link based — run `dirt auth login` (CLI) or sign in from the
+# desktop / mobile Account settings to write a session token to the
+# OS keychain. There is no `DIRT_CLIENT_TOKEN` to set here anymore.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus"
-version = "0.7.5"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44c550c06b6785e16258ad620d5b559f5bbcbcc50e3c18c08aa6af2604a4c32"
+checksum = "7c01ecf7ddbae18a419ad3d83c486101a85ffc5740ea09cdd0f09a30dc12170d"
 dependencies = [
  "dioxus-asset-resolver",
  "dioxus-cli-config",
@@ -1373,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-asset-resolver"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b546050ecfc7fcd310be344b2f3a2a79f21554c5a9e8df28e7a07e9b36009b"
+checksum = "69387edbbc60c7cb93ad96d8cc7a22b49a76e21643380b89b1c49a78d347ff60"
 dependencies = [
  "dioxus-cli-config",
  "http 1.4.0",
@@ -1391,18 +1391,18 @@ dependencies = [
 
 [[package]]
 name = "dioxus-cli-config"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ad73f0ff638cd27466d389cd57f0975f909b66130dc1c25d5212d4041e5352"
+checksum = "c000f584ddf608e2b272b3074bf11512a474eeeb2eb85a1915f276ce5c4a8615"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "dioxus-config-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004bc8b958031117d373db2b5e0ab9d7e763751de129dd36f00ef7e318333cd"
+checksum = "7637091592978fbfdb45a16b26bd99fd97fb1bd7e31c6a963530e00c022af321"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1410,15 +1410,15 @@ dependencies = [
 
 [[package]]
 name = "dioxus-config-macros"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808a9994a9a2623e6b6890b6cc68def24bd669177ec4713684447fb46418c256"
+checksum = "54f9ed8fc1a215ad34bb8dbae42a4ea54efbcd26ca9006bbe5cca78e511bf25f"
 
 [[package]]
 name = "dioxus-core"
-version = "0.7.4"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3dd61889e6a09daec93d44db86047fb8e6603beedcf9351b8528582254e075"
+checksum = "45887100ff0cf89abeb8b659808294fda48cd53f3b424e36407dedffcfea830b"
 dependencies = [
  "anyhow",
  "const_format",
@@ -1438,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75fbe64029b90144041f8521300c7b3508e6c48caea3244de2ff5d1ade15390c"
+checksum = "370c63663dff0f24df5dfea643ca239283542c6b228a302f69b32e1d36762b7f"
 dependencies = [
  "convert_case 0.8.0",
  "dioxus-rsx",
@@ -1451,16 +1451,17 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core-types"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbfea5c8946e0745b254b5c33c515d81b3ba638f33c2a532ed06730392394d4d"
+checksum = "36963eab106b169737762f9cd5ee5fd97f585989dcb2d8e30a596e97a6999009"
 
 [[package]]
 name = "dioxus-desktop"
-version = "0.7.4"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df90224b51e0246bedeffe166e8ae782440dfaf45e329532a1d71afc79e0732"
+checksum = "662cd78c73ca3f17346adbf2d64757df40dd0ce20536c05123097fd31828d2bd"
 dependencies = [
+ "anyhow",
  "async-trait",
  "base64 0.22.1",
  "bytes",
@@ -1481,9 +1482,10 @@ dependencies = [
  "futures-util",
  "generational-box",
  "global-hotkey 0.7.0",
+ "image",
  "infer",
  "jni",
- "lazy-js-bundle 0.7.6",
+ "lazy-js-bundle 0.7.9",
  "libc",
  "muda 0.17.1",
  "ndk",
@@ -1512,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-devtools"
-version = "0.7.4"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27e7212436a581ce058d7554f1383916bd18a68ebd6015b0b4c2e9ecb0d5535"
+checksum = "2349cedbdf1b429df1f1bea61fdee0ad3dae7b2548eedfbeca82710122a57da0"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -1530,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-devtools-types"
-version = "0.7.4"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa24ed651b97e0b423270bf07a0f1b7dc0e0fa1f1dc26407cd2a118d6bf9de5"
+checksum = "0ab9b0f7565d1916b70915f59b89ea8054ef0a9d67a364a32bbee68ef5f3818d"
 dependencies = [
  "dioxus-core",
  "serde",
@@ -1541,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-document"
-version = "0.7.4"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24685cb51cc6227ea606c49dfe531836f362c49183d3007241afcd8827498401"
+checksum = "37e3a5bec7ffc999ff23446a487eb5cd86111d1574a23533dd3f8b3c69a53a22"
 dependencies = [
  "dioxus-core",
  "dioxus-core-macro",
@@ -1552,7 +1554,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "generational-box",
- "lazy-js-bundle 0.7.6",
+ "lazy-js-bundle 0.7.9",
  "serde",
  "serde_json",
  "tracing",
@@ -1560,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-history"
-version = "0.7.4"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010b446322b3f9176476579fa61c7552f0430abbeec418cab543482da6ca4363"
+checksum = "1a15232302d1933015fcf2d6fe9e286ad36f6e9c205a546089a0f326023bb0d2"
 dependencies = [
  "dioxus-core",
  "tracing",
@@ -1570,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-hooks"
-version = "0.7.4"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e7a6ba279050cc161e1215c6db0bd15915c9314ec2916d7b22c113a3039536"
+checksum = "4534f91cf6305204b948bdec130076ac9ecc7c22faab29475b76870558bf73ea"
 dependencies = [
  "dioxus-core",
  "dioxus-signals",
@@ -1586,9 +1588,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-html"
-version = "0.7.4"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0715e38cc6537aef5b79d0ddc1f4d7a56c2f4debe46b127eee24d8aa5dafd2d"
+checksum = "e03d6ad4040b667f2b2eefcb678840e630938c09bf9ec39b04ea4d1d96d90d44"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1603,7 +1605,7 @@ dependencies = [
  "futures-util",
  "generational-box",
  "keyboard-types",
- "lazy-js-bundle 0.7.6",
+ "lazy-js-bundle 0.7.9",
  "rustversion",
  "serde",
  "serde_json",
@@ -1613,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-html-internal-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025e107e677f790f4ed648a189e36f51ae014e5341902b97313e4eae626cffa2"
+checksum = "584e2772127ab00f0d5e1d4d9795f39fecebc828ece0b7a02349d438bc1b1ce7"
 dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
@@ -1625,15 +1627,15 @@ dependencies = [
 
 [[package]]
 name = "dioxus-interpreter-js"
-version = "0.7.4"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8ce1cf487007f90d0ec4ec87dff111d74ac04fca0918f9dcc4e80dc3b0531b2"
+checksum = "11999d6eb5bb179a9512dad30e5de408aab66f2cb65de9098c9fbe02927e2978"
 dependencies = [
  "dioxus-core",
  "dioxus-core-types",
  "dioxus-html",
  "js-sys",
- "lazy-js-bundle 0.7.6",
+ "lazy-js-bundle 0.7.9",
  "rustc-hash 2.1.1",
  "serde",
  "sledgehammer_bindgen",
@@ -1645,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-logger"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cbbee192b1b12fccb444a5b04d809710cfce4d27b792129fea6c845fae7f329"
+checksum = "a28ccdfe36d2cb830a2784e40f7e6f7199805a2c6da99bd65b1ca308f11aed28"
 dependencies = [
  "dioxus-cli-config",
  "tracing",
@@ -1684,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-rsx"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fb07e40e9734946511659668ea3675ed214b60889e7aa7f0a5a85271518475"
+checksum = "2106afda239a4c7c22ffa1ca19117011225fc1c735c139c0a5b765996aa8bb1d"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
@@ -1709,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-signals"
-version = "0.7.4"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409bf65d243443416650945f22cd6caf2a6bb13ae0347a50ec5852adb1961072"
+checksum = "3705754f5e043deec9fc7af0d159f18e5b21c02c47d255c7e477f31368f0b6d2"
 dependencies = [
  "dioxus-core",
  "futures-channel",
@@ -1725,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-stores"
-version = "0.7.4"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245ec4f84348e5be77451bd204181998b8bc0995b48ff3adb2db0e0ec430dab4"
+checksum = "64bec7b21c86b1360ec965a07a53a2c96b7caee3465049e1c299a45024e87614"
 dependencies = [
  "dioxus-core",
  "dioxus-signals",
@@ -1737,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-stores-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737600865572cecf60ff934f88252bd4144f4ca189e0e570b7a780e8f0e01a1f"
+checksum = "40a5875e9f890f27b1cc3e5b56c1e23601211470315a1fb8627c4ca4f3b2be9a"
 dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
@@ -1749,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-web"
-version = "0.7.4"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac92ef863bc5333440021e8ec3e538a39598c9c960daeaab66ab10ba940b5e0"
+checksum = "bc0a0be76b404e8242a597db0fb239d05f8dee4e7856bc1fc7144f7e244822fd"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -1767,7 +1769,7 @@ dependencies = [
  "generational-box",
  "gloo-timers",
  "js-sys",
- "lazy-js-bundle 0.7.6",
+ "lazy-js-bundle 0.7.9",
  "rustc-hash 2.1.1",
  "send_wrapper",
  "serde",
@@ -2357,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -2376,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2393,15 +2395,15 @@ checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2411,7 +2413,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -2511,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "generational-box"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68d74be1fbe3bba37604bdfd61403f26af9f6324cf325053abd89d60c22e799"
+checksum = "8cd0d825b8d339701ad330dbcd6399519ced4d143484954daf6e3185dace4f77"
 dependencies = [
  "parking_lot",
  "tracing",
@@ -3479,9 +3480,9 @@ checksum = "e49596223b9d9d4947a14a25c142a6e7d8ab3f27eb3ade269d238bb8b5c267e2"
 
 [[package]]
 name = "lazy-js-bundle"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebbde2c5796719fbd82d6b8ec0be3dacf1f70c2876dee0f2c001632794d6641f"
+checksum = "ccafada6c9541db44db758619236f2748f6e1bdaa84d04ded858567cd1e89321"
 
 [[package]]
 name = "lazy_static"
@@ -3817,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "manganis"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e06225f29a781d86afdfafa562de09621f2ace377136ae2ae9ca9e72a29b920"
+checksum = "8bfcf56309de35b48b8780ea097ace5c3b773a617b52edc49dfc9a63a7d9dc43"
 dependencies = [
  "const-serialize 0.7.2",
  "const-serialize 0.8.0-alpha.0",
@@ -3833,9 +3834,9 @@ dependencies = [
 
 [[package]]
 name = "manganis-core"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ddc382b4fb30f3fdcf2418131cbac5e6111f00e6c7ddf9e598ef3b2b4cd91"
+checksum = "a24d6be68f594495aea60850a284029d585d7b7839b26096c1b6d758f8518648"
 dependencies = [
  "const-serialize 0.7.2",
  "const-serialize 0.8.0-alpha.0",
@@ -3847,9 +3848,9 @@ dependencies = [
 
 [[package]]
 name = "manganis-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731c83c89d831f341fb46eba0aefdfb3433f77a3f78a8b08d9d88746613a8f8b"
+checksum = "5e782a10318d707c0833e31876ded8acf91287eee0010af8392559af614c7226"
 dependencies = [
  "dunce",
  "macro-string",
@@ -6029,9 +6030,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subsecond"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feae81a4a7ca6d0bcf70c385a43b7dbacbff527f0805cb0a4043ce2c2c559a2c"
+checksum = "9cc79674bd55726e6b123204403389400229a95fe4a3b2c5453dada70b06ca95"
 dependencies = [
  "js-sys",
  "libc",
@@ -6048,9 +6049,9 @@ dependencies = [
 
 [[package]]
 name = "subsecond-types"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85256ee192cbdf00473e48e6133863b125dd4f772fddfbc97287ec7a61458c25"
+checksum = "e9798bfed58797aed51c672aa99810aac30a50d3120ecfdcf28c13784e9a8f1c"
 dependencies = [
  "serde",
 ]

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 | `dirt-core` | Models, SQLite repository, sync engine. Platform-agnostic. |
 | `dirt-api` | axum HTTP server. `POST /v1/notes/push`, `GET /v1/notes/pull`, `/healthz`. Bearer-authed. Backed by Turso. |
 | `dirt-desktop` | Dioxus desktop app. Auto-syncs in the background. |
-| `dirt-mobile` | Android shell (in transition — Phase 1 ships server + desktop + CLI; the mobile sync worker is the next milestone). |
-| `dirt-cli` | `dirt add`, `dirt list`, `dirt sync`, etc. Local-first; sync only runs when `DIRT_API_BASE_URL` and `DIRT_CLIENT_TOKEN` are set. |
+| `dirt-mobile` | Dioxus Android app. Magic-link login wired up; mobile sync worker mirrors desktop. |
+| `dirt-cli` | `dirt add`, `dirt list`, `dirt sync`, etc. Local-first; sync runs when `DIRT_API_BASE_URL` is configured and a session is stored via `dirt auth login`. |
 | `dirt-vercel` | Workspace-root crate that hosts the Vercel serverless entry point at `api/axum.rs`. Pulls in `dirt-api` by path. |
 
 ## Quick start
@@ -26,15 +26,17 @@ cargo run -p dirt-cli list
 ```
 
 The CLI captures locally to a SQLite file under your platform's data
-dir. Sync stays off until both `DIRT_API_BASE_URL` and
-`DIRT_CLIENT_TOKEN` are set.
+dir. Sync stays off until `DIRT_API_BASE_URL` is configured and you
+sign in with `dirt auth login` (the session lands in your OS keyring;
+the same slot is shared across `dirt-cli` and `dirt-desktop`, so a
+login from either gets you sync on both).
 
 ### Run the desktop app
 
 ```bash
 export DIRT_API_BASE_URL="https://dirt-api.vercel.app"
-export DIRT_CLIENT_TOKEN="$(cat .env.client | grep DIRT_CLIENT_TOKEN | cut -d= -f2)"
 cargo run -p dirt-desktop
+# Then sign in from Settings → Account.
 ```
 
 The window opens, the local DB initializes, and a background sync
@@ -43,8 +45,9 @@ sync runs on three triggers: app startup, a 30 s periodic timer, and
 a 1.5 s debounce after every successful local mutation. Failures back
 off exponentially (5 s → 15 s → 60 s → 300 s).
 
-If either env var is missing, the sync indicator shows red and the
-Settings → Sync tab explains which one. Local capture still works.
+If `DIRT_API_BASE_URL` is missing or the user is not signed in, the
+sync indicator shows red and the Settings → Sync / Account tab explains
+which one. Local capture still works.
 
 ### Run the API server
 
@@ -66,9 +69,12 @@ for the full API contract + 15-minute self-host recipe.
 - **Server-authoritative timestamps.** Pull ordering uses
   `server_updated_at_ms` exclusively; a misbehaving client clock can't
   poison the cursor.
-- **Single shared bearer token in Phase 1.** `DIRT_CLIENT_TOKEN` on
-  every client must equal `DIRT_SERVER_TOKEN` on the server. Per-user
-  identity comes in Phase 2 (magic-link auth).
+- **Magic-link sessions (Phase 2).** Clients sign in via
+  `/v1/auth/{request,verify}` and persist the resulting session token
+  in the OS keychain. The session middleware on `dirt-api` resolves
+  the bearer to a user id before any note-shaped handler runs. The
+  Phase-1 `DIRT_CLIENT_TOKEN` shared bearer has been retired from all
+  three clients.
 - **No silent failures.** Misconfigured env vars surface visibly
   (`SyncStatus::Error` with a populated `sync_issue`) instead of
   pretending to be offline. The "no fallback" rule is a project-wide

--- a/crates/dirt-cli/src/commands/auth_cmd.rs
+++ b/crates/dirt-cli/src/commands/auth_cmd.rs
@@ -1,14 +1,15 @@
 //! `dirt auth` — magic-link auth commands.
 //!
-//! Login / logout go through [`dirt_core::auth::AuthClient`] +
-//! [`dirt_core::auth::KeyringTokenStore`]. The `status` command stays
-//! on the Phase-1 `DIRT_CLIENT_TOKEN` connectivity probe for now —
-//! cutting `status` and `dirt sync` over to the magic-link session is
-//! tracked separately (Phase 2.5 was explicitly scoped to
-//! login/logout only).
+//! All four subcommands (`status` / `login` / `logout` and any future
+//! additions) route through [`dirt_core::auth::AuthClient`] +
+//! [`dirt_core::auth::KeyringTokenStore`]. Phase 2.8 finished the cutover:
+//! `status` now probes with the keyring-stored session token and shares
+//! the silent-refresh path with `dirt sync`, so the CLI has no remaining
+//! dependency on `DIRT_CLIENT_TOKEN`.
 
 use std::env;
 use std::io::{self, BufRead, Write};
+use std::sync::Arc;
 
 use dirt_core::auth::{AuthClient, AuthError, StoredToken, TokenStore, TokenStoreError};
 // `KeyringTokenStore` is target-gated in dirt-core to non-Android
@@ -19,7 +20,8 @@ use dirt_core::auth::{AuthClient, AuthError, StoredToken, TokenStore, TokenStore
 // from inside the dirt-core auth module.
 #[cfg(not(target_os = "android"))]
 use dirt_core::auth::KeyringTokenStore;
-use dirt_core::sync::api_client::{ApiClient, ApiClientError};
+use dirt_core::sync::api_client::ApiClientError;
+use dirt_core::sync::session_client::{SessionApiClient, SessionRefreshError};
 
 use crate::cli::AuthCommands;
 use crate::config_profiles::{normalize_text_option, CliProfilesConfig};
@@ -28,7 +30,12 @@ use crate::error::CliError;
 /// Reverse-DNS service identifier the keyring slot is filed under. Shows
 /// up verbatim in Keychain Access / Credential Manager / `seahorse` so
 /// a user looking for "where does dirt store its session" can find it.
-const KEYRING_SERVICE: &str = "dev.dirt.session";
+///
+/// Pub-in-crate so `dirt sync` and `dirt auth status` reach the same
+/// slot — the three commands MUST hit identical `(service, account)`
+/// keyring coordinates or a login from one command leaves the others
+/// stranded.
+pub const KEYRING_SERVICE: &str = "dev.dirt.session";
 
 pub async fn run_auth(command: AuthCommands) -> Result<(), CliError> {
     match command {
@@ -62,39 +69,121 @@ pub async fn run_auth(command: AuthCommands) -> Result<(), CliError> {
 
 /// Compute the user-facing status line. Returned (not printed) so tests
 /// can assert exact strings.
+///
+/// Reads the keyring-stored session token planted by `dirt auth login`
+/// and probes the API with it. Shares the silent-refresh path with
+/// `dirt sync` so a freshly rotated session keeps reporting `online`
+/// without nudging the user.
+///
+/// Output forms (exact prefixes are part of the contract — scripts grep
+/// for `^online:` to detect a healthy state):
+///
+///   - "offline: `DIRT_API_BASE_URL` not set — …"
+///   - "offline: not signed in — run `dirt auth login` to sign in"
+///   - "offline: session expired — run `dirt auth login` …"
+///   - "offline: \<cause\>; \<fix\>"
+///   - "online: signed in as \<email\>, server ok"
+///   - "online: signed in as \<email\>, server ok (session rotated)"
 pub async fn status_line() -> Result<String, CliError> {
-    let token = normalize_text_option(env::var("DIRT_CLIENT_TOKEN").ok());
-    let Some(token) = token else {
-        return Ok(
-            "offline: DIRT_CLIENT_TOKEN not set — local capture works, sync disabled".to_string(),
-        );
-    };
-
     let Some(api_base_url) = resolve_api_base_url()? else {
         return Ok(
             "offline: DIRT_API_BASE_URL not set — local capture works, sync disabled".to_string(),
         );
     };
 
-    let api = match ApiClient::new(api_base_url, token) {
-        Ok(api) => api,
+    let store: Arc<dyn TokenStore> = Arc::new(build_keyring_store()?);
+
+    // Load once to extract the email for the diagnostic line. The
+    // SessionApiClient::from_store call below performs its own
+    // store.load() — two reads against the same keyring slot are
+    // cheap on every platform we ship (Credential Manager / Secret
+    // Service / Keychain all serve the second call from in-process
+    // state once ACL has been granted in the first call).
+    let stored = match store.load() {
+        Ok(Some(stored)) => stored,
+        Ok(None) => {
+            return Ok("offline: not signed in — run `dirt auth login` to sign in".to_string())
+        }
         Err(err) => {
             return Ok(format!(
-                "offline: auth test failed — invalid configuration: {err}"
-            ));
+                "offline: auth test failed — {}",
+                describe_token_store_error(&err)
+            ))
         }
+    };
+
+    Ok(probe_session_status(api_base_url, store, &stored.email).await)
+}
+
+/// Wire the session client up against `api_base_url` and probe with
+/// `.pull(None, Some(1))`. Pulled out so it stays tractable to unit-test
+/// against a wiremock server — the surrounding `status_line` is mostly
+/// keyring-store plumbing that needs an integration test instead.
+async fn probe_session_status(
+    api_base_url: String,
+    store: Arc<dyn TokenStore>,
+    email: &str,
+) -> String {
+    let auth = match AuthClient::new(&api_base_url) {
+        Ok(auth) => auth,
+        Err(err) => {
+            return format!("offline: auth test failed — invalid configuration: {err}");
+        }
+    };
+
+    let session = match SessionApiClient::from_store(api_base_url, auth, store) {
+        Ok(Some(session)) => session,
+        // The earlier `store.load()` returned `Some`, so reaching `Ok(None)` here
+        // means the keyring slot was cleared between the load and now —
+        // treat it as a fresh not-signed-in.
+        Ok(None) => return "offline: not signed in — run `dirt auth login` to sign in".to_string(),
+        Err(err) => return format!("offline: auth test failed — {err}"),
     };
 
     // The pull endpoint is the cheapest authenticated probe — it
     // doesn't mutate anything and exercises the same bearer middleware
     // production traffic does.
-    Ok(match api.pull(None, Some(1)).await {
-        Ok(_) => "online: authenticated as solo-user, server ok".to_string(),
+    let api = session.current();
+    match api.pull(None, Some(1)).await {
+        Ok(_) => format!("online: signed in as {email}, server ok"),
+        Err(ApiClientError::Unauthorized(_)) => {
+            // The snapshot Arc isn't load-bearing for refresh — drop
+            // early to free the stale ApiClient before pulling a fresh
+            // snapshot post-refresh (mirrors desktop's pattern).
+            drop(api);
+            handle_status_unauthorized(&session, email).await
+        }
         Err(err) => {
             let (cause, fix) = describe_api_error(&err);
             format!("offline: auth test failed — {cause}; {fix}")
         }
-    })
+    }
+}
+
+/// Bearer was rejected mid-probe. Try one silent refresh and re-probe
+/// so a long-running CLI session (e.g. shell prompt integration that
+/// invokes `dirt auth status` every minute) doesn't flap to `offline:`
+/// the first time the token rotates. Matches the policy in
+/// `commands::sync::run_session_sync`.
+async fn handle_status_unauthorized(session: &SessionApiClient, email: &str) -> String {
+    match session.refresh().await {
+        Ok(()) => {
+            let api = session.current();
+            match api.pull(None, Some(1)).await {
+                Ok(_) => {
+                    format!("online: signed in as {email}, server ok (session rotated)")
+                }
+                Err(err) => {
+                    let (cause, fix) = describe_api_error(&err);
+                    format!("offline: server rejected refreshed session — {cause}; {fix}")
+                }
+            }
+        }
+        Err(SessionRefreshError::SessionExpired(_) | SessionRefreshError::NoToken) => {
+            "offline: session expired — run `dirt auth login` to sign in again".to_string()
+        }
+        Err(other) => format!("offline: session refresh failed — {other}; retry shortly"),
+    }
 }
 
 /// Orchestrate the interactive login flow.
@@ -319,6 +408,13 @@ fn auth_error_to_cli(err: &AuthError) -> CliError {
 }
 
 fn token_store_error_to_cli(err: &TokenStoreError) -> CliError {
+    CliError::Auth(describe_token_store_error(err))
+}
+
+/// Build the `cause; fix` line for a `TokenStoreError`. Pulled out of
+/// `token_store_error_to_cli` so `status_line` can fold the same copy
+/// into its `offline:` envelope without going through `CliError`.
+fn describe_token_store_error(err: &TokenStoreError) -> String {
     let (cause, fix) = match err {
         TokenStoreError::Backend(msg) => (
             format!("keyring backend error: {msg}"),
@@ -337,7 +433,7 @@ fn token_store_error_to_cli(err: &TokenStoreError) -> CliError {
              to write a fresh one",
         ),
     };
-    CliError::Auth(format!("{cause}; {fix}"))
+    format!("{cause}; {fix}")
 }
 
 fn describe_auth_error(err: &AuthError) -> (String, &'static str) {
@@ -398,9 +494,13 @@ fn describe_auth_error(err: &AuthError) -> (String, &'static str) {
 
 fn describe_api_error(err: &ApiClientError) -> (String, &'static str) {
     match err {
+        // Status's 401 branch hits this *after* one silent refresh has
+        // already been attempted, so the server actually rejected a
+        // freshly minted bearer — surface re-login as the next step
+        // rather than nudging the user at a token they cannot rotate.
         ApiClientError::Unauthorized(_) => (
             "401 unauthorized".to_string(),
-            "rotate DIRT_CLIENT_TOKEN to match the bearer token the server is configured with",
+            "run `dirt auth login` to sign in again; the server rejected the current session",
         ),
         ApiClientError::Network(msg) => (
             format!("network error: {msg}"),
@@ -424,7 +524,7 @@ fn describe_api_error(err: &ApiClientError) -> (String, &'static str) {
         ),
         ApiClientError::InvalidConfiguration(msg) => (
             format!("invalid configuration: {msg}"),
-            "check DIRT_API_BASE_URL and DIRT_CLIENT_TOKEN",
+            "check DIRT_API_BASE_URL and your CLI profile config",
         ),
     }
 }
@@ -460,18 +560,204 @@ mod tests {
         AuthClient::new(server.uri()).expect("client should build for mock server")
     }
 
+    fn seeded_store(token: &str) -> Arc<MemoryTokenStore> {
+        Arc::new(MemoryTokenStore::with_initial(StoredToken {
+            session_token: token.into(),
+            session_id: "sid-1".into(),
+            user_id: "uid-1".into(),
+            email: "user@example.com".into(),
+            expires_at_ms: 1_800_000_000_000_i64,
+        }))
+    }
+
+    /// Successful probe — pull endpoint returns 200, status line must
+    /// be the canonical `online:` form including the stored email.
     #[tokio::test(flavor = "current_thread")]
-    #[allow(unsafe_code)]
-    async fn status_offline_when_no_client_token() {
-        // SAFETY: tests run on current_thread, no concurrent reader.
-        unsafe {
-            std::env::remove_var("DIRT_CLIENT_TOKEN");
-        }
-        let line = status_line().await.unwrap();
+    async fn probe_session_status_online_when_session_valid() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/notes/pull"))
+            .and(bearer_token("tok-live"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "notes": [],
+                "server_time_ms": 1_700_000_000_000_i64,
+                "has_more": false,
+                "next_cursor": null,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let store: Arc<dyn TokenStore> = seeded_store("tok-live");
+        let line = probe_session_status(server.uri(), store, "user@example.com").await;
+        assert_eq!(line, "online: signed in as user@example.com, server ok");
+    }
+
+    /// 401 + refresh-rotates + re-probe succeeds → must surface the
+    /// `(session rotated)` suffix so a watcher can tell that the
+    /// online state involved a refresh.
+    #[tokio::test(flavor = "current_thread")]
+    async fn probe_session_status_refreshes_and_reprobes_on_401() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/notes/pull"))
+            .and(bearer_token("tok-stale"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": {
+                    "code": "SESSION_EXPIRED",
+                    "message": "session token is invalid or expired",
+                    "cause": "session token is invalid or expired",
+                    "fix": "Sign in again."
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "session_token": "tok-fresh",
+                "session_id": "sid-new",
+                "expires_at_ms": 9_999_999_999_999_i64,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/v1/notes/pull"))
+            .and(bearer_token("tok-fresh"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "notes": [],
+                "server_time_ms": 1_700_000_000_000_i64,
+                "has_more": false,
+                "next_cursor": null,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let store: Arc<dyn TokenStore> = seeded_store("tok-stale");
+        let line = probe_session_status(server.uri(), store, "user@example.com").await;
         assert_eq!(
             line,
-            "offline: DIRT_CLIENT_TOKEN not set — local capture works, sync disabled"
+            "online: signed in as user@example.com, server ok (session rotated)"
         );
+    }
+
+    /// 401 → refresh returns `SESSION_EXPIRED` → terminal `offline:`
+    /// pointing at `dirt auth login`. The keyring slot is cleared by
+    /// `SessionApiClient::refresh`; we assert that explicitly so the
+    /// next status invocation lands the "not signed in" path instead
+    /// of looping through refresh again.
+    #[tokio::test(flavor = "current_thread")]
+    async fn probe_session_status_session_expired_after_failed_refresh() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/notes/pull"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": {
+                    "code": "SESSION_EXPIRED",
+                    "message": "session token is invalid or expired",
+                    "cause": "session token is invalid or expired",
+                    "fix": "Sign in again."
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": {
+                    "code": "SESSION_EXPIRED",
+                    "message": "session token is invalid or expired",
+                    "cause": "session token is invalid or expired",
+                    "fix": "Sign in again."
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let store_concrete = seeded_store("tok-dead");
+        let store: Arc<dyn TokenStore> = store_concrete.clone();
+        let line = probe_session_status(server.uri(), store, "user@example.com").await;
+        assert_eq!(
+            line,
+            "offline: session expired — run `dirt auth login` to sign in again"
+        );
+        assert!(
+            store_concrete.load().unwrap().is_none(),
+            "keyring slot must be cleared after SESSION_EXPIRED"
+        );
+    }
+
+    /// 401 on the probe + transient 5xx on refresh → must report a
+    /// retry-shortly hint and keep the stored token intact so the next
+    /// `dirt auth status` (or `dirt sync`) can recover when the server
+    /// settles down.
+    #[tokio::test(flavor = "current_thread")]
+    async fn probe_session_status_transient_refresh_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/notes/pull"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": {
+                    "code": "SESSION_EXPIRED",
+                    "message": "session token is invalid or expired",
+                    "cause": "session token is invalid or expired",
+                    "fix": "Sign in again."
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("turso down"))
+            .mount(&server)
+            .await;
+
+        let store_concrete = seeded_store("tok-maybe-live");
+        let store: Arc<dyn TokenStore> = store_concrete.clone();
+        let line = probe_session_status(server.uri(), store, "user@example.com").await;
+        assert!(
+            line.starts_with("offline: session refresh failed"),
+            "got {line}"
+        );
+        assert!(line.contains("retry shortly"), "got {line}");
+        assert!(
+            store_concrete.load().unwrap().is_some(),
+            "transient refresh failure must NOT clear the keyring"
+        );
+    }
+
+    /// A 5xx on the probe itself (not a 401) must NOT trigger refresh
+    /// and must surface the server-side cause verbatim — separating
+    /// "server is sick" from "your credentials are sick" is what makes
+    /// `dirt auth status` actionable.
+    #[tokio::test(flavor = "current_thread")]
+    async fn probe_session_status_offline_on_server_unavailable() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/notes/pull"))
+            .respond_with(ResponseTemplate::new(503).set_body_json(json!({
+                "error": {
+                    "code": "TURSO_UNREACHABLE",
+                    "message": "turso unreachable",
+                    "cause": "turso unreachable",
+                    "fix": "Retry shortly."
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        // /v1/auth/refresh should never be reached; mounting nothing
+        // confirms that any accidental refresh would 404 here (wiremock
+        // returns 404 for unmounted routes), changing the output line
+        // and failing the assertion below.
+
+        let store: Arc<dyn TokenStore> = seeded_store("tok-live");
+        let line = probe_session_status(server.uri(), store, "user@example.com").await;
+        assert!(line.starts_with("offline: auth test failed"), "got {line}");
+        assert!(line.contains("server unavailable"), "got {line}");
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -601,7 +887,7 @@ mod tests {
             let err = login_flow(&client, &store, reader).await.unwrap_err();
             match err {
                 CliError::Auth(msg) => {
-                    assert!(msg.contains("exactly 6 digits"), "[{label}] got {msg}")
+                    assert!(msg.contains("exactly 6 digits"), "[{label}] got {msg}");
                 }
                 other => panic!("[{label}] expected Auth error, got {other:?}"),
             }

--- a/crates/dirt-cli/src/commands/auth_cmd.rs
+++ b/crates/dirt-cli/src/commands/auth_cmd.rs
@@ -37,6 +37,19 @@ use crate::error::CliError;
 /// stranded.
 pub const KEYRING_SERVICE: &str = "dev.dirt.session";
 
+/// Per-user discriminator inside the keyring service slot.
+///
+/// Fixed at `"default"` — matches the constant `dirt-desktop` and
+/// `dirt-mobile` use, so a magic-link login from any client is visible
+/// to all of them. A previous version of the CLI keyed the account by
+/// the active `CliProfilesConfig` profile name, which made
+/// `DIRT_PROFILE=foo` land in `(service, foo)` while desktop wrote to
+/// `(service, "default")` — silently breaking the shared-session story
+/// for anyone with a non-default profile. The CLI profile is for
+/// `dirt_api_base_url` selection only; session sharing belongs to the
+/// account discriminator, not to the per-endpoint profile name.
+pub const KEYRING_ACCOUNT: &str = "default";
+
 pub async fn run_auth(command: AuthCommands) -> Result<(), CliError> {
     match command {
         AuthCommands::Status => {
@@ -368,10 +381,11 @@ fn build_auth_client(base_url: &str) -> Result<AuthClient, CliError> {
 
 #[cfg(not(target_os = "android"))]
 fn build_keyring_store() -> Result<KeyringTokenStore, CliError> {
-    let profile = CliProfilesConfig::load()
-        .map_err(CliError::Config)?
-        .resolve_profile_name(None);
-    Ok(KeyringTokenStore::new(KEYRING_SERVICE, profile))
+    // Account discriminator is fixed at `KEYRING_ACCOUNT` so a login
+    // from any client (CLI / desktop / mobile) lands in the same slot.
+    // See the `KEYRING_ACCOUNT` doc-comment for why this isn't keyed
+    // off the CLI profile.
+    Ok(KeyringTokenStore::new(KEYRING_SERVICE, KEYRING_ACCOUNT))
 }
 
 fn resolve_api_base_url() -> Result<Option<String>, CliError> {

--- a/crates/dirt-cli/src/commands/config.rs
+++ b/crates/dirt-cli/src/commands/config.rs
@@ -56,7 +56,7 @@ pub fn run_config_init(
         .ok_or_else(|| CliError::Config("Failed to persist profile".to_string()))?;
     if profile.dirt_api_base_url().is_some() {
         println!(
-            "Profile '{profile_name}' is ready. Set DIRT_CLIENT_TOKEN in your environment to authorize sync."
+            "Profile '{profile_name}' is ready. Run `dirt auth login` to sign in and authorize sync."
         );
     } else {
         println!("Profile '{profile_name}' is missing: api_base_url");

--- a/crates/dirt-cli/src/commands/sync.rs
+++ b/crates/dirt-cli/src/commands/sync.rs
@@ -33,18 +33,20 @@ use dirt_core::sync::engine::{SyncEngine, SyncEngineError, SyncReport};
 use dirt_core::sync::session_client::{SessionApiClient, SessionRefreshError};
 use dirt_core::SOLO_USER_ID;
 
-use crate::commands::auth_cmd::KEYRING_SERVICE;
+use crate::commands::auth_cmd::{KEYRING_ACCOUNT, KEYRING_SERVICE};
 use crate::commands::common::open_database;
 use crate::config_profiles::{normalize_text_option, CliProfilesConfig};
 use crate::error::CliError;
 
 pub async fn run_sync(db_path: &Path) -> Result<(), CliError> {
     let api_base_url = resolve_api_base_url()?;
-    let profile_name = CliProfilesConfig::load()
-        .map_err(CliError::Config)?
-        .resolve_profile_name(None);
+    // Fixed `(service, "default")` keyring slot so a login from any
+    // client (CLI / desktop / mobile) is visible here. The previous
+    // profile-keyed account silently broke cross-client sharing under
+    // `DIRT_PROFILE=foo` — see `KEYRING_ACCOUNT` doc-comment in
+    // `commands::auth_cmd` for the full reasoning.
     let store: Arc<dyn TokenStore> =
-        Arc::new(KeyringTokenStore::new(KEYRING_SERVICE, profile_name));
+        Arc::new(KeyringTokenStore::new(KEYRING_SERVICE, KEYRING_ACCOUNT));
     let session = build_session(api_base_url, store)?;
     let db = open_database(db_path).await?;
     let report = run_session_sync(&db, &session).await?;

--- a/crates/dirt-cli/src/commands/sync.rs
+++ b/crates/dirt-cli/src/commands/sync.rs
@@ -1,39 +1,135 @@
 //! `dirt sync` — push local mutations and pull remote changes once.
 //!
-//! Resolution order for the API base URL:
+//! Phase 2.8: the bearer is the magic-link session token persisted by
+//! `dirt auth login` in the OS keychain. There is no longer a
+//! `DIRT_CLIENT_TOKEN` fallback — if no session is stored the command
+//! refuses to run and points the user at `dirt auth login`.
+//!
+//! Resolution order for the API base URL is unchanged from Phase 1:
 //!   1. `DIRT_API_BASE_URL` env var (overrides everything for ad-hoc runs).
 //!   2. Active CLI profile's `dirt_api_base_url`.
 //!
-//! The bearer token is read from `DIRT_CLIENT_TOKEN` only — it never
-//! lands in the CLI profile JSON because that file is plaintext.
+//! Silent-refresh behaviour: on a 401 from the sync engine we call
+//! [`SessionApiClient::refresh`] once and retry the cycle with the new
+//! bearer. A second 401 (or a non-`Unauthorized` failure on the retry)
+//! propagates as a normal error — the user re-runs `dirt sync` once
+//! their session is valid again. This is the one-shot CLI counterpart
+//! to the desktop worker's continuous-refresh loop in
+//! `dirt-desktop/src/services/sync_worker.rs`.
+//!
+//! The local-DB `user_id` stays [`SOLO_USER_ID`] for parity with desktop
+//! and Phase-1 client rows. Migrating local-store `user_id` to the
+//! authenticated session's `user_id` is a separate, larger piece of
+//! work — see `docs/DESIGN.md` Phase 2 notes — and is intentionally not
+//! part of Phase 2.8.
 
 use std::env;
 use std::path::Path;
+use std::sync::Arc;
 
-use dirt_core::sync::api_client::ApiClient;
-use dirt_core::sync::engine::{SyncEngine, SyncReport};
+use dirt_core::auth::{AuthClient, KeyringTokenStore, TokenStore};
+use dirt_core::sync::api_client::ApiClientError;
+use dirt_core::sync::engine::{SyncEngine, SyncEngineError, SyncReport};
+use dirt_core::sync::session_client::{SessionApiClient, SessionRefreshError};
 use dirt_core::SOLO_USER_ID;
 
+use crate::commands::auth_cmd::KEYRING_SERVICE;
 use crate::commands::common::open_database;
 use crate::config_profiles::{normalize_text_option, CliProfilesConfig};
 use crate::error::CliError;
 
 pub async fn run_sync(db_path: &Path) -> Result<(), CliError> {
     let api_base_url = resolve_api_base_url()?;
-    let token = require_env("DIRT_CLIENT_TOKEN")?;
-
-    let api = ApiClient::new(api_base_url, token)
-        .map_err(|err| CliError::Config(format!("invalid sync configuration: {err}")))?;
+    let profile_name = CliProfilesConfig::load()
+        .map_err(CliError::Config)?
+        .resolve_profile_name(None);
+    let store: Arc<dyn TokenStore> =
+        Arc::new(KeyringTokenStore::new(KEYRING_SERVICE, profile_name));
+    let session = build_session(api_base_url, store)?;
     let db = open_database(db_path).await?;
-    let engine = SyncEngine::new(&db, &api, SOLO_USER_ID);
-
-    let report = engine
-        .run_once()
-        .await
-        .map_err(|err| CliError::Config(format!("sync failed: {err}")))?;
-
+    let report = run_session_sync(&db, &session).await?;
     print_report(&report);
     Ok(())
+}
+
+/// Build the refreshing session client from the keyring slot.
+///
+/// Factored out (rather than inlined in `run_sync`) so the tests can
+/// drive the post-401 retry path against a wiremock-backed
+/// `SessionApiClient` without booting the keyring.
+fn build_session(
+    api_base_url: String,
+    store: Arc<dyn TokenStore>,
+) -> Result<SessionApiClient, CliError> {
+    let auth = AuthClient::new(&api_base_url).map_err(|err| {
+        CliError::Config(format!(
+            "invalid sync configuration: {err}; check DIRT_API_BASE_URL or `dirt config init`"
+        ))
+    })?;
+    let session = SessionApiClient::from_store(api_base_url, auth, store).map_err(|err| {
+        // `from_store` only fails in two ways: a Store error from the
+        // keyring backend, or a Rebuild error from a malformed base URL.
+        // Both are configuration-shaped: the user can fix one with
+        // `dirt config init`, the other by unlocking the keyring.
+        CliError::Config(format!("could not hydrate session: {err}"))
+    })?;
+    session.ok_or_else(|| {
+        CliError::Auth(
+            "not signed in; run `dirt auth login` to sign in, then re-run `dirt sync`".to_string(),
+        )
+    })
+}
+
+/// Run one sync cycle through `session`, with a single silent-refresh
+/// retry on 401. Public-in-module so tests can drive the cycle directly.
+async fn run_session_sync(
+    db: &dirt_core::services::DatabaseService,
+    session: &SessionApiClient,
+) -> Result<SyncReport, CliError> {
+    match sync_once(db, session).await {
+        Ok(report) => Ok(report),
+        Err(SyncEngineError::Api(ApiClientError::Unauthorized(_))) => {
+            // Bearer was rejected mid-cycle. Try a silent refresh, then
+            // exactly one retry — matches desktop's policy (a second 401
+            // means refresh-without-actually-rotating-the-token, which
+            // is a server bug and should surface, not loop).
+            refresh_then_retry(db, session).await
+        }
+        Err(other) => Err(sync_engine_error_to_cli(&other)),
+    }
+}
+
+async fn sync_once(
+    db: &dirt_core::services::DatabaseService,
+    session: &SessionApiClient,
+) -> Result<SyncReport, SyncEngineError> {
+    let api = session.current();
+    let engine = SyncEngine::new(db, &api, SOLO_USER_ID);
+    engine.run_once().await
+}
+
+async fn refresh_then_retry(
+    db: &dirt_core::services::DatabaseService,
+    session: &SessionApiClient,
+) -> Result<SyncReport, CliError> {
+    match session.refresh().await {
+        Ok(()) => {}
+        Err(SessionRefreshError::SessionExpired(_) | SessionRefreshError::NoToken) => {
+            return Err(CliError::Auth(
+                "your session has expired; run `dirt auth login` to sign in again, then re-run `dirt sync`"
+                    .to_string(),
+            ));
+        }
+        Err(other) => {
+            return Err(CliError::Config(format!(
+                "session refresh failed during sync: {other}; retry shortly"
+            )));
+        }
+    }
+
+    sync_once(db, session)
+        .await
+        .map_err(|err| sync_engine_error_to_cli(&err))
 }
 
 fn resolve_api_base_url() -> Result<String, CliError> {
@@ -51,12 +147,17 @@ fn resolve_api_base_url() -> Result<String, CliError> {
         .ok_or(CliError::SyncNotConfigured)
 }
 
-fn require_env(key: &str) -> Result<String, CliError> {
-    normalize_text_option(env::var(key).ok()).ok_or_else(|| {
-        CliError::Config(format!(
-            "{key} must be set in the environment for `dirt sync`"
-        ))
-    })
+fn sync_engine_error_to_cli(err: &SyncEngineError) -> CliError {
+    match err {
+        // A 401 reaching here means the retry-after-refresh path also
+        // got 401 — the server rejected even the freshly rotated
+        // bearer. Surface as auth-shaped so the user knows the next
+        // step is re-login, not a transient retry.
+        SyncEngineError::Api(ApiClientError::Unauthorized(msg)) => CliError::Auth(format!(
+            "server rejected the refreshed session ({msg}); run `dirt auth login` again"
+        )),
+        other => CliError::Config(format!("sync failed: {other}")),
+    }
 }
 
 fn print_report(report: &SyncReport) {
@@ -64,4 +165,252 @@ fn print_report(report: &SyncReport) {
         "Sync complete — pulled {} (skipped {}), pushed {}",
         report.pulled_applied, report.pulled_skipped, report.pushed
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use dirt_core::auth::{AuthClient, MemoryTokenStore, StoredToken, TokenStore};
+    use dirt_core::sync::session_client::SessionApiClient;
+    use serde_json::json;
+    use wiremock::matchers::{bearer_token, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    fn seeded_store(token: &str) -> Arc<MemoryTokenStore> {
+        Arc::new(MemoryTokenStore::with_initial(StoredToken {
+            session_token: token.into(),
+            session_id: "sid-1".into(),
+            user_id: "uid-1".into(),
+            email: "user@example.com".into(),
+            expires_at_ms: 1_800_000_000_000_i64,
+        }))
+    }
+
+    fn session_for(server: &MockServer, store: Arc<dyn TokenStore>) -> SessionApiClient {
+        let auth = AuthClient::new(server.uri()).expect("auth client must build for mock");
+        SessionApiClient::from_store(server.uri(), auth, store)
+            .expect("from_store must succeed for mock")
+            .expect("seeded store must hydrate a session")
+    }
+
+    async fn open_temp_db() -> dirt_core::services::DatabaseService {
+        // In-memory libsql DB is enough — `SyncEngine` only reads
+        // `sync_state` / `pending_sync` and writes the cursor, all of
+        // which sit on top of the standard migration set that
+        // `open_in_memory` runs internally.
+        dirt_core::services::DatabaseService::open_in_memory()
+            .await
+            .expect("open in-memory db")
+    }
+
+    /// Empty pull + empty push must return Ok with zeroed counts when
+    /// the session bearer is accepted. This is the happy-path smoke
+    /// that proves the [`SessionApiClient`] → [`SyncEngine`] plumbing
+    /// works with a session token (not a `DIRT_CLIENT_TOKEN`).
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_session_sync_happy_path() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/notes/pull"))
+            .and(bearer_token("tok-live"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "notes": [],
+                "server_time_ms": 1_700_000_000_000_i64,
+                "has_more": false,
+                "next_cursor": null,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let store: Arc<dyn TokenStore> = seeded_store("tok-live");
+        let session = session_for(&server, store);
+        let db = open_temp_db().await;
+
+        let report = run_session_sync(&db, &session).await.unwrap();
+        assert_eq!(report.pulled_applied, 0);
+        assert_eq!(report.pushed, 0);
+    }
+
+    /// Single 401 → silent refresh → retry with new bearer → success.
+    /// The user must NOT see the failure; the CLI prints the normal
+    /// "Sync complete" line and exits 0. The refreshed token must be
+    /// the one persisted in the store.
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_session_sync_refreshes_on_401_and_retries() {
+        let server = MockServer::start().await;
+        // First pull with the stale bearer → 401.
+        Mock::given(method("GET"))
+            .and(path("/v1/notes/pull"))
+            .and(bearer_token("tok-stale"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": {
+                    "code": "SESSION_EXPIRED",
+                    "message": "session token is invalid or expired",
+                    "cause": "session token is invalid or expired",
+                    "fix": "Sign in again."
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        // Refresh exchanges stale → fresh.
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/refresh"))
+            .and(bearer_token("tok-stale"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "session_token": "tok-fresh",
+                "session_id": "sid-new",
+                "expires_at_ms": 9_999_999_999_999_i64,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        // Retry pull with fresh bearer → empty page.
+        Mock::given(method("GET"))
+            .and(path("/v1/notes/pull"))
+            .and(bearer_token("tok-fresh"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "notes": [],
+                "server_time_ms": 1_700_000_000_000_i64,
+                "has_more": false,
+                "next_cursor": null,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let store_concrete = seeded_store("tok-stale");
+        let store: Arc<dyn TokenStore> = store_concrete.clone();
+        let session = session_for(&server, store);
+        let db = open_temp_db().await;
+
+        run_session_sync(&db, &session)
+            .await
+            .expect("retry after refresh must succeed");
+        assert_eq!(
+            store_concrete.load().unwrap().unwrap().session_token,
+            "tok-fresh",
+            "refresh must persist the new bearer"
+        );
+    }
+
+    /// 401 on pull + `SESSION_EXPIRED` on `/v1/auth/refresh` is the
+    /// terminal "the user has to log in again" path. The CLI must
+    /// surface a [`CliError::Auth`] pointing at `dirt auth login`,
+    /// and `SessionApiClient::refresh` must have cleared the keyring
+    /// slot so the next run starts from a clean "Not signed in" state.
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_session_sync_surfaces_session_expired_with_login_hint() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/notes/pull"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": {
+                    "code": "SESSION_EXPIRED",
+                    "message": "session token is invalid or expired",
+                    "cause": "session token is invalid or expired",
+                    "fix": "Sign in again."
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": {
+                    "code": "SESSION_EXPIRED",
+                    "message": "session token is invalid or expired",
+                    "cause": "session token is invalid or expired",
+                    "fix": "Sign in again."
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let store_concrete = seeded_store("tok-dead");
+        let store: Arc<dyn TokenStore> = store_concrete.clone();
+        let session = session_for(&server, store);
+        let db = open_temp_db().await;
+
+        let err = run_session_sync(&db, &session)
+            .await
+            .expect_err("must surface auth error");
+        match err {
+            CliError::Auth(msg) => {
+                assert!(msg.contains("session has expired"), "got {msg}");
+                assert!(msg.contains("dirt auth login"), "got {msg}");
+            }
+            other => panic!("expected Auth error, got {other:?}"),
+        }
+        assert!(
+            store_concrete.load().unwrap().is_none(),
+            "SessionApiClient::refresh must clear the keyring on SESSION_EXPIRED"
+        );
+    }
+
+    /// 401 on pull + a transient 503 on refresh: the local credential
+    /// is potentially still valid, so we must NOT clear the keyring and
+    /// the CLI surfaces a `Config`-shaped (transient) error so the user
+    /// knows to retry shortly — distinct from the "log in again" copy.
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_session_sync_propagates_transient_refresh_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/notes/pull"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": {
+                    "code": "SESSION_EXPIRED",
+                    "message": "session token is invalid or expired",
+                    "cause": "session token is invalid or expired",
+                    "fix": "Sign in again."
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("turso down"))
+            .mount(&server)
+            .await;
+
+        let store_concrete = seeded_store("tok-maybe-live");
+        let store: Arc<dyn TokenStore> = store_concrete.clone();
+        let session = session_for(&server, store);
+        let db = open_temp_db().await;
+
+        let err = run_session_sync(&db, &session)
+            .await
+            .expect_err("must surface config error");
+        match err {
+            CliError::Config(msg) => {
+                assert!(msg.contains("session refresh failed"), "got {msg}");
+                assert!(msg.contains("retry shortly"), "got {msg}");
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+        assert!(
+            store_concrete.load().unwrap().is_some(),
+            "transient refresh failure must NOT clear the keyring"
+        );
+    }
+
+    /// `build_session` returns Ok(None) → Auth error pointing at login
+    /// when the keyring slot is empty. Exercises the "first-time user
+    /// runs `dirt sync` without logging in" path.
+    #[test]
+    fn build_session_surfaces_not_signed_in_message() {
+        let store: Arc<dyn TokenStore> = Arc::new(MemoryTokenStore::new());
+        let err = build_session("https://example.invalid".into(), store).unwrap_err();
+        match err {
+            CliError::Auth(msg) => {
+                assert!(msg.contains("not signed in"), "got {msg}");
+                assert!(msg.contains("dirt auth login"), "got {msg}");
+            }
+            other => panic!("expected Auth error, got {other:?}"),
+        }
+    }
 }

--- a/crates/dirt-cli/src/error.rs
+++ b/crates/dirt-cli/src/error.rs
@@ -39,9 +39,8 @@ pub enum CliError {
     #[error("auth error: {0}")]
     Auth(String),
     #[error(
-        "Sync via the new dirt-api backend is not yet wired into the CLI. \
-         Run `dirt config init --api-base-url <URL>` and watch for the \
-         follow-up commit that adds the ApiClient-driven sync worker."
+        "Sync is not configured. Run `dirt config init --api-base-url <URL>` to point \
+         the CLI at a dirt-api endpoint, then `dirt auth login` to sign in."
     )]
     SyncNotConfigured,
 }

--- a/crates/dirt-cli/src/tests.rs
+++ b/crates/dirt-cli/src/tests.rs
@@ -275,20 +275,21 @@ async fn run_delete_soft_deletes_note_by_exact_and_prefix_id() {
 async fn run_sync_requires_sync_configuration() {
     let db_path = unique_test_db_path();
 
-    // Force the unconfigured paths so the test doesn't accidentally pick
-    // up a developer's real DIRT_API_BASE_URL or DIRT_CLIENT_TOKEN.
+    // Force the unconfigured path so the test doesn't accidentally pick
+    // up a developer's real DIRT_API_BASE_URL. Post-2.8 there is no
+    // client-side bearer env var to clear — auth flows through the
+    // keyring, which the CLI guards against silently in
+    // `commands::sync::build_session` (Auth error if empty).
     // SAFETY: tests in this module run on a current_thread runtime, so
     // there's no concurrent reader of these vars within the process.
     unsafe {
         std::env::remove_var("DIRT_API_BASE_URL");
-        std::env::remove_var("DIRT_CLIENT_TOKEN");
         std::env::set_var("DIRT_PROFILE", "this-profile-does-not-exist");
     }
 
     let error = run_sync(&db_path).await.unwrap_err();
-    // Either "no api_base_url configured" or "no DIRT_CLIENT_TOKEN" —
-    // the contract is that `dirt sync` refuses to run rather than
-    // silently no-oping.
+    // No api_base_url is `SyncNotConfigured`. The contract is that
+    // `dirt sync` refuses to run rather than silently no-oping.
     assert!(
         matches!(error, CliError::SyncNotConfigured | CliError::Config(_)),
         "unexpected error variant: {error:?}",

--- a/crates/dirt-core/src/config/mod.rs
+++ b/crates/dirt-core/src/config/mod.rs
@@ -1,18 +1,16 @@
 //! Bootstrap configuration for client apps.
 //!
-//! `BootstrapConfig` carries the safe-to-ship public endpoints clients
-//! need at startup. Post-Supabase the only meaningful field is
-//! `dirt_api_base_url`; bearer-token secrets live in the OS keychain
-//! (clients) or in `DIRT_SERVER_TOKEN` (server), never here.
-
-use std::time::Duration;
+//! `BootstrapConfig` carries the build-baked API base URL clients need
+//! at startup. Phase-1's runtime "bootstrap manifest" (`/v1/bootstrap`
+//! endpoint, [`ManagedBootstrapManifest`], runtime fetch) was deleted
+//! when the server-side route was removed; clients now read the
+//! embedded JSON straight from `build.rs` and never hit the network at
+//! startup. Bearer-token secrets live in the OS keychain (clients)
+//! or in `DIRT_SERVER_TOKEN` (server), never here.
 
 use serde::{Deserialize, Serialize};
 
-use crate::util::{compact_text, is_http_url, normalize_text_option};
-
-const BOOTSTRAP_SCHEMA_VERSION: u32 = 2;
-const BOOTSTRAP_HTTP_TIMEOUT_SECS: u64 = 4;
+use crate::util::normalize_text_option;
 
 /// Build-provisioned client configuration.
 ///
@@ -21,8 +19,6 @@ const BOOTSTRAP_HTTP_TIMEOUT_SECS: u64 = 4;
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct BootstrapConfig {
-    #[serde(default)]
-    pub bootstrap_manifest_url: Option<String>,
     #[serde(default)]
     pub dirt_api_base_url: Option<String>,
 }
@@ -34,112 +30,6 @@ impl BootstrapConfig {
     }
 }
 
-/// Resolve runtime bootstrap config by fetching the manifest URL.
-///
-/// If `bootstrap_manifest_url` is set, fetch/parse/validation failures are
-/// returned as errors instead of falling back to embedded values.
-pub async fn resolve_bootstrap_config(
-    fallback: BootstrapConfig,
-) -> Result<BootstrapConfig, String> {
-    let Some(manifest_url) = normalize_text_option(fallback.bootstrap_manifest_url.clone()) else {
-        return Ok(fallback);
-    };
-
-    fetch_bootstrap_manifest(&manifest_url).await
-}
-
-/// Parse a bootstrap manifest from a raw JSON payload.
-///
-/// Public for testability — callers can exercise parsing without network access.
-pub fn parse_bootstrap_manifest(
-    payload: &str,
-    manifest_url: &str,
-) -> Result<BootstrapConfig, String> {
-    let manifest: ManagedBootstrapManifest = serde_json::from_str(payload)
-        .map_err(|error| format!("invalid bootstrap manifest JSON: {error}"))?;
-    manifest.into_runtime_config(manifest_url)
-}
-
-// ---------------------------------------------------------------------------
-// Private
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct ManagedBootstrapManifest {
-    schema_version: u32,
-    manifest_version: String,
-    api_base_url: String,
-}
-
-impl ManagedBootstrapManifest {
-    fn into_runtime_config(self, manifest_url: &str) -> Result<BootstrapConfig, String> {
-        if self.schema_version != BOOTSTRAP_SCHEMA_VERSION {
-            return Err(format!(
-                "unsupported bootstrap schema_version {} (expected {})",
-                self.schema_version, BOOTSTRAP_SCHEMA_VERSION
-            ));
-        }
-        if self.manifest_version.trim().is_empty() {
-            return Err("bootstrap manifest_version must not be empty".to_string());
-        }
-
-        let api_base_url = normalize_required_http_url(self.api_base_url, "api_base_url")?;
-
-        Ok(BootstrapConfig {
-            bootstrap_manifest_url: Some(manifest_url.to_string()),
-            dirt_api_base_url: Some(api_base_url),
-        })
-    }
-}
-
-async fn fetch_bootstrap_manifest(url: &str) -> Result<BootstrapConfig, String> {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(BOOTSTRAP_HTTP_TIMEOUT_SECS))
-        .build()
-        .map_err(|error| format!("failed to build bootstrap HTTP client: {error}"))?;
-
-    let response = client
-        .get(url)
-        .header(reqwest::header::ACCEPT, "application/json")
-        .send()
-        .await
-        .map_err(|error| format!("bootstrap request failed: {error}"))?;
-
-    if !response.status().is_success() {
-        let status = response.status().as_u16();
-        let body = response
-            .text()
-            .await
-            .map_err(|error| format!("failed to read bootstrap error response body: {error}"))?;
-        return Err(format!(
-            "bootstrap endpoint returned HTTP {status}: {}",
-            compact_text(&body)
-        ));
-    }
-
-    let body = response
-        .text()
-        .await
-        .map_err(|error| format!("failed to read bootstrap response body: {error}"))?;
-    parse_bootstrap_manifest(&body, url)
-}
-
-fn normalize_required_value(raw: String, field: &str) -> Result<String, String> {
-    normalize_text_option(Some(raw)).ok_or_else(|| format!("bootstrap field '{field}' is required"))
-}
-
-fn normalize_required_http_url(raw: String, field: &str) -> Result<String, String> {
-    let value = normalize_required_value(raw, field)?;
-    if is_http_url(&value) {
-        Ok(value.trim_end_matches('/').to_string())
-    } else {
-        Err(format!(
-            "bootstrap field '{field}' must include http:// or https://"
-        ))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -148,7 +38,6 @@ mod tests {
     fn managed_api_base_url_returns_configured_value() {
         let config = BootstrapConfig {
             dirt_api_base_url: Some("https://api.example.com".to_string()),
-            ..Default::default()
         };
         assert_eq!(
             config.managed_api_base_url().as_deref(),
@@ -157,51 +46,10 @@ mod tests {
     }
 
     #[test]
-    fn parse_manifest_rejects_unknown_fields() {
-        let payload = r#"
-        {
-          "schema_version": 2,
-          "manifest_version": "v1",
-          "api_base_url": "https://api.example.com",
-          "supabase_url": "https://leftover.example.com"
-        }
-        "#;
-
-        let error =
-            parse_bootstrap_manifest(payload, "https://api.example.com/v1/bootstrap").unwrap_err();
-        assert!(error.contains("unknown field"));
-    }
-
-    #[test]
-    fn parse_manifest_rejects_invalid_schema_version() {
-        let payload = r#"
-        {
-          "schema_version": 9,
-          "manifest_version": "v1",
-          "api_base_url": "https://api.example.com"
-        }
-        "#;
-
-        let error =
-            parse_bootstrap_manifest(payload, "https://api.example.com/v1/bootstrap").unwrap_err();
-        assert!(error.contains("schema_version"));
-    }
-
-    #[test]
-    fn parse_manifest_returns_api_base_url() {
-        let payload = r#"
-        {
-          "schema_version": 2,
-          "manifest_version": "v2",
-          "api_base_url": "https://api.example.com"
-        }
-        "#;
-
-        let parsed = parse_bootstrap_manifest(payload, "https://api.example.com/v1/bootstrap")
-            .expect("manifest should parse");
-        assert_eq!(
-            parsed.dirt_api_base_url.as_deref(),
-            Some("https://api.example.com")
-        );
+    fn managed_api_base_url_normalizes_empty() {
+        let config = BootstrapConfig {
+            dirt_api_base_url: Some("   ".to_string()),
+        };
+        assert!(config.managed_api_base_url().is_none());
     }
 }

--- a/crates/dirt-core/src/sync/session_client.rs
+++ b/crates/dirt-core/src/sync/session_client.rs
@@ -148,13 +148,25 @@ impl SessionApiClient {
         let resp = match self.auth.refresh_session(&stored.session_token).await {
             Ok(resp) => resp,
             Err(AuthError::SessionExpired(msg)) => {
-                // Bearer is dead and there's no path back via refresh —
-                // wipe the slot so the next login starts clean and a
-                // background refresh-loop bug can't keep retrying a
-                // known-bad credential.
-                if let Err(err) = self.store.clear() {
-                    tracing::warn!("Failed to clear stale token after SessionExpired: {err}");
-                }
+                // Compare-and-swap: only clear the slot if it still
+                // holds the very token whose refresh just failed.
+                //
+                // Phase 2.8 made this slot shared across CLI + desktop
+                // + mobile, so two clients can hit a 401 at roughly the
+                // same time, both read `tok-A`, and race into refresh.
+                // The first refresh succeeds and writes `tok-B`; the
+                // second arrives at the server with `tok-A` (now
+                // rotated) and gets `SESSION_EXPIRED`. Unconditionally
+                // clearing in that arm would wipe the winner's
+                // `tok-B`, putting every client back at "Sign in
+                // again" despite a perfectly valid token sitting on
+                // disk a moment ago.
+                //
+                // Surfacing `SessionExpired` to *this* caller is still
+                // correct — its in-flight bearer is dead and the
+                // worker should park. The slot's contents belong to
+                // whoever wrote last.
+                clear_if_still_stale(self.store.as_ref(), &stored.session_token);
                 return Err(SessionRefreshError::SessionExpired(msg));
             }
             Err(other) => return Err(SessionRefreshError::Other(other.to_string())),
@@ -171,6 +183,45 @@ impl SessionApiClient {
             .write()
             .expect("SessionApiClient inner lock poisoned") = Arc::new(new_api);
         Ok(())
+    }
+}
+
+/// Clear the keyring slot only if it still holds `stale_token`.
+///
+/// Pulled out of [`SessionApiClient::refresh`] so the compare-and-swap
+/// stays scrutable: a peer process on the same keyring slot may have
+/// rotated the token between our `load` and the server's
+/// `SESSION_EXPIRED` reply, and clearing the peer's freshly-rotated
+/// token would put every client back at "Sign in again."
+///
+/// Reading the store twice (once at the top of `refresh` and again
+/// here) is a deliberate cost: it bounds the window in which a peer's
+/// write can clobber ours to "between our load and our clear" rather
+/// than the full duration of the network round-trip. The platform
+/// keyring serializes individual reads/writes inside the OS, so the
+/// load↔clear is the smallest atomic unit we can build without
+/// reaching for an out-of-process lock.
+fn clear_if_still_stale(store: &dyn TokenStore, stale_token: &str) {
+    match store.load() {
+        Ok(Some(current)) if current.session_token == stale_token => {
+            if let Err(err) = store.clear() {
+                tracing::warn!("Failed to clear stale token after SessionExpired: {err}");
+            }
+        }
+        Ok(Some(_)) => {
+            // Slot was rotated by a peer between our load and the
+            // SESSION_EXPIRED reply — preserve the peer's token.
+            tracing::info!(
+                "Keyring slot rotated by a peer during refresh; preserving the peer's token after SessionExpired"
+            );
+        }
+        Ok(None) => {
+            // Slot already empty — nothing to do; another path cleared
+            // it (logout, manual delete, etc.).
+        }
+        Err(err) => {
+            tracing::warn!("Failed to inspect keyring during SessionExpired: {err}");
+        }
     }
 }
 
@@ -293,6 +344,126 @@ mod tests {
         assert!(
             store_concrete.load().unwrap().is_some(),
             "store must NOT be cleared on transient refresh failure"
+        );
+    }
+
+    /// Phase 2.8 made the keyring slot shared across CLI / desktop /
+    /// mobile, which opens a refresh race: two clients hit a 401 on
+    /// the *same* stale token, both enter `refresh`, the first
+    /// succeeds and writes a fresh token, the second arrives at the
+    /// server with the now-rotated token and gets `SESSION_EXPIRED`.
+    /// The old behaviour cleared the slot unconditionally on
+    /// `SESSION_EXPIRED`, wiping the winner's fresh token and putting
+    /// every client back at "Sign in again."
+    ///
+    /// This regression test models the race precisely. `refresh()`
+    /// reads the store twice: once at the top to pick the bearer to
+    /// send, and once inside the CAS in `clear_if_still_stale` to
+    /// decide whether the slot still holds the bearer that just
+    /// failed. A peer's write lands between those two loads. The
+    /// `LoadSwapStore` wrapper returns `tok-stale` on the first load
+    /// (so refresh POSTs the stale bearer the server then rejects)
+    /// and `tok-fresh` on every subsequent load (so the CAS sees the
+    /// peer's freshly-rotated token and skips the clear).
+    #[tokio::test(flavor = "current_thread")]
+    async fn refresh_preserves_peer_rotated_token_during_concurrent_session_expired() {
+        use std::sync::Mutex;
+
+        use crate::auth::{StoredToken, TokenStore, TokenStoreError, TokenStoreResult};
+
+        /// The first two `load()` calls (from `SessionApiClient::from_store`
+        /// at construction, and the top of `refresh()` for the bearer
+        /// it sends) return `tok-stale`. Every subsequent load returns
+        /// `tok-fresh`, modeling a peer that won the refresh race
+        /// between the top-of-refresh load and the CAS recheck.
+        struct LoadSwapStore {
+            load_count: Mutex<usize>,
+            clear_count: Mutex<usize>,
+            stale: StoredToken,
+            fresh: StoredToken,
+        }
+
+        impl TokenStore for LoadSwapStore {
+            fn load(&self) -> TokenStoreResult<Option<StoredToken>> {
+                let mut n = self.load_count.lock().unwrap();
+                *n += 1;
+                if *n <= 2 {
+                    Ok(Some(self.stale.clone()))
+                } else {
+                    Ok(Some(self.fresh.clone()))
+                }
+            }
+            fn save(&self, _token: &StoredToken) -> TokenStoreResult<()> {
+                Err(TokenStoreError::Backend(
+                    "save() should never run on the SessionExpired path".into(),
+                ))
+            }
+            fn clear(&self) -> TokenStoreResult<()> {
+                *self.clear_count.lock().unwrap() += 1;
+                Ok(())
+            }
+        }
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(REFRESH_PATH))
+            .and(bearer_token("tok-stale"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": {
+                    "code": "SESSION_EXPIRED",
+                    "message": "session token is invalid or expired",
+                    "cause": "session token is invalid or expired",
+                    "fix": "Sign in again to obtain a fresh session token.",
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let auth = AuthClient::new(server.uri()).unwrap();
+        let store_concrete = Arc::new(LoadSwapStore {
+            load_count: Mutex::new(0),
+            clear_count: Mutex::new(0),
+            stale: StoredToken {
+                session_token: "tok-stale".into(),
+                session_id: "sid-old".into(),
+                user_id: "uid-1".into(),
+                email: "user@example.com".into(),
+                expires_at_ms: 1,
+            },
+            fresh: StoredToken {
+                session_token: "tok-fresh".into(),
+                session_id: "sid-new".into(),
+                user_id: "uid-1".into(),
+                email: "user@example.com".into(),
+                expires_at_ms: 9_999_999_999_999,
+            },
+        });
+        let store: Arc<dyn TokenStore> = store_concrete.clone();
+        let session = SessionApiClient::from_store(server.uri(), auth, store)
+            .unwrap()
+            .unwrap();
+
+        let err = session.refresh().await.unwrap_err();
+        assert!(matches!(err, SessionRefreshError::SessionExpired(_)));
+
+        // The whole point of the CAS: the peer's `tok-fresh` was
+        // already in the slot at clear-decision time, so `clear()`
+        // must NOT have fired. Pre-fix this counter would be 1.
+        assert_eq!(
+            *store_concrete.clear_count.lock().unwrap(),
+            0,
+            "compare-and-swap must skip clear() when the slot holds a peer's freshly rotated token"
+        );
+
+        // Sanity: at least three loads must have happened — one each
+        // from `from_store`, the top of `refresh()`, and the CAS
+        // recheck inside `clear_if_still_stale`. Anything less proves
+        // the CAS branch never ran and the clear-skipped assertion
+        // above is hollow.
+        assert!(
+            *store_concrete.load_count.lock().unwrap() >= 3,
+            "expected at least three store.load() calls (from_store + refresh + CAS recheck)"
         );
     }
 

--- a/crates/dirt-core/src/util.rs
+++ b/crates/dirt-core/src/util.rs
@@ -18,11 +18,6 @@ pub fn is_http_url(value: &str) -> bool {
     value.starts_with("http://") || value.starts_with("https://")
 }
 
-/// Truncate text to at most 180 characters for error messages.
-pub fn compact_text(value: &str) -> String {
-    value.trim().chars().take(180).collect()
-}
-
 /// Current Unix timestamp in seconds.
 pub fn unix_timestamp_now() -> i64 {
     chrono::Utc::now().timestamp()

--- a/crates/dirt-desktop/build.rs
+++ b/crates/dirt-desktop/build.rs
@@ -7,7 +7,6 @@ use serde::Serialize;
 
 #[derive(Debug, Default, Serialize)]
 struct DesktopBootstrapConfig {
-    bootstrap_manifest_url: Option<String>,
     dirt_api_base_url: Option<String>,
 }
 
@@ -15,9 +14,7 @@ fn main() {
     configure_windows_stack_size();
 
     println!("cargo:rerun-if-env-changed=DIRT_DESKTOP_API_BASE_URL");
-    println!("cargo:rerun-if-env-changed=DIRT_DESKTOP_BOOTSTRAP_URL");
     println!("cargo:rerun-if-env-changed=DIRT_API_BASE_URL");
-    println!("cargo:rerun-if-env-changed=DIRT_BOOTSTRAP_URL");
     println!("cargo:rerun-if-changed=../../.env.client");
     println!("cargo:rerun-if-changed=../../.env.client.example");
 
@@ -56,24 +53,8 @@ fn write_desktop_bootstrap_config() -> io::Result<()> {
                 .as_deref()
                 .map(normalize_desktop_local_base_url)
         });
-    let bootstrap_manifest_url = env_var_trimmed("DIRT_DESKTOP_BOOTSTRAP_URL")
-        .as_deref()
-        .map(normalize_desktop_local_base_url)
-        .or_else(|| {
-            env_var_trimmed("DIRT_BOOTSTRAP_URL")
-                .as_deref()
-                .map(normalize_desktop_local_base_url)
-        })
-        .or_else(|| {
-            dirt_api_base_url
-                .as_deref()
-                .map(|value| format!("{}/v1/bootstrap", value.trim_end_matches('/')))
-        });
 
-    let config = DesktopBootstrapConfig {
-        bootstrap_manifest_url,
-        dirt_api_base_url,
-    };
+    let config = DesktopBootstrapConfig { dirt_api_base_url };
 
     let content = serde_json::to_string_pretty(&config)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;

--- a/crates/dirt-desktop/src/app.rs
+++ b/crates/dirt-desktop/src/app.rs
@@ -20,7 +20,7 @@ use dirt_core::auth::{AuthClient, KeyringTokenStore};
 use dirt_core::models::Note;
 use dirt_core::sync::session_client::SessionApiClient;
 
-use crate::bootstrap_config::{load_bootstrap_config, resolve_bootstrap_config, BootstrapConfig};
+use crate::bootstrap_config::{load_bootstrap_config, BootstrapConfig};
 use crate::components::{QuickCapture, SettingsPanel};
 use crate::queries::use_notes_query;
 use crate::services::{
@@ -69,38 +69,17 @@ pub fn App() -> Element {
                 None
             }
         });
-    let mut bootstrap_ready = use_signal(|| false);
-    let mut bootstrap_config: Signal<Option<BootstrapConfig>> = use_signal(|| None);
+    // Bootstrap is build-baked (see `bootstrap_config::load_bootstrap_config`),
+    // so it's available synchronously at component init. The Phase-1
+    // managed-architecture's runtime `/v1/bootstrap` fetch was removed
+    // when the server-side route was deleted; clients now read straight
+    // from the embedded JSON.
+    let bootstrap_config: Signal<BootstrapConfig> = use_signal(load_bootstrap_config);
     let sync_status = use_signal(|| SyncStatus::Offline);
     let sync_issue = use_signal(|| None::<String>);
     let last_sync_at = use_signal(|| None::<i64>);
     let pending_sync_count = use_signal(|| 0usize);
     let pending_sync_note_ids = use_signal(Vec::new);
-    let embedded_bootstrap_config = load_bootstrap_config();
-
-    // Resolve runtime bootstrap manifest. The auto-sync worker reads
-    // the resolved config (or the embedded fallback) below.
-    use_effect(move || {
-        if bootstrap_ready() {
-            return;
-        }
-        let fallback_bootstrap = embedded_bootstrap_config.clone();
-
-        spawn(async move {
-            let resolved = match resolve_bootstrap_config(fallback_bootstrap.clone()).await {
-                Ok(config) => config,
-                Err(error) => {
-                    tracing::warn!(
-                        "Failed to resolve runtime bootstrap manifest ({}). Falling back to embedded desktop bootstrap values.",
-                        error
-                    );
-                    fallback_bootstrap
-                }
-            };
-            bootstrap_config.set(Some(resolved));
-            bootstrap_ready.set(true);
-        });
-    });
 
     let mut sync_status_signal = sync_status;
     let mut sync_issue_signal = sync_issue;
@@ -117,9 +96,7 @@ pub fn App() -> Element {
     });
 
     use_effect(move || {
-        let Some(bootstrap) = bootstrap_config() else {
-            return;
-        };
+        let bootstrap = bootstrap_config();
         let api_base_url = bootstrap
             .dirt_api_base_url
             .as_deref()
@@ -146,10 +123,6 @@ pub fn App() -> Element {
     // present) spawn the auto-sync worker. A missing token leaves
     // sync_status at Offline — sync is opt-in.
     let _db_init_task = use_resource(move || async move {
-        if !bootstrap_ready() {
-            return;
-        }
-
         match DatabaseService::new().await {
             Ok(db) => {
                 let db = Arc::new(db);

--- a/crates/dirt-desktop/src/app.rs
+++ b/crates/dirt-desktop/src/app.rs
@@ -69,12 +69,17 @@ pub fn App() -> Element {
                 None
             }
         });
-    // Bootstrap is build-baked (see `bootstrap_config::load_bootstrap_config`),
-    // so it's available synchronously at component init. The Phase-1
-    // managed-architecture's runtime `/v1/bootstrap` fetch was removed
-    // when the server-side route was deleted; clients now read straight
-    // from the embedded JSON.
-    let bootstrap_config: Signal<BootstrapConfig> = use_signal(load_bootstrap_config);
+    // Bootstrap is build-baked (see `bootstrap_config::load_bootstrap_config`)
+    // and never changes at runtime — the Phase-1 managed-architecture's
+    // `/v1/bootstrap` fetch was removed when the server-side route was
+    // deleted. Loading it into a local rather than a `Signal` lets us
+    // build `auth_deps` synchronously below: critical because the
+    // `_db_init_task` `use_resource` reads `auth_deps` early to decide
+    // whether to spawn the sync worker, and a `use_effect`-based
+    // population (the previous shape) could race ahead and leave the
+    // user offline on every startup despite a valid keyring entry.
+    let bootstrap = load_bootstrap_config();
+
     let sync_status = use_signal(|| SyncStatus::Offline);
     let sync_issue = use_signal(|| None::<String>);
     let last_sync_at = use_signal(|| None::<i64>);
@@ -85,38 +90,13 @@ pub fn App() -> Element {
     let mut sync_issue_signal = sync_issue;
     let last_sync_at_signal = last_sync_at;
 
-    // Auth dependencies live in a signal so they can be reactively
-    // populated once `bootstrap_config` resolves. Initial value carries
-    // the always-present keyring store; the `auth_client` /
-    // `api_base_url` fields fill in after bootstrap.
-    let mut auth_deps: Signal<AuthDeps> = use_signal(|| AuthDeps {
-        auth_client: None,
-        token_store: Arc::new(KeyringTokenStore::new(KEYRING_SERVICE, KEYRING_ACCOUNT)),
-        api_base_url: None,
-    });
-
-    use_effect(move || {
-        let bootstrap = bootstrap_config();
-        let api_base_url = bootstrap
-            .dirt_api_base_url
-            .as_deref()
-            .filter(|value| !value.trim().is_empty());
-        let (client_arc, normalized_url) =
-            api_base_url.map_or((None, None), |url| match AuthClient::new(url) {
-                Ok(client) => {
-                    let normalized = client.base_url().to_string();
-                    (Some(Arc::new(client)), Some(normalized))
-                }
-                Err(err) => {
-                    tracing::error!("AuthClient build failed for `{url}`: {err}");
-                    (None, None)
-                }
-            });
-        auth_deps.with_mut(|deps| {
-            deps.auth_client = client_arc;
-            deps.api_base_url = normalized_url;
-        });
-    });
+    // Build the auth deps once from `bootstrap`. Same pattern as
+    // `dirt-mobile::app_shell::build_auth_deps`: every field is
+    // populated synchronously so any downstream `use_resource` /
+    // `use_effect` reading the signal sees a final value on first
+    // render. The signal is never mutated after init — it stays in a
+    // `Signal` only so it can be shared via `use_context_provider`.
+    let auth_deps: Signal<AuthDeps> = use_signal(|| build_auth_deps(&bootstrap));
 
     // Initialize the local database; once it's ready, hydrate any
     // pre-existing session from the keyring and (only if a token is
@@ -371,6 +351,40 @@ pub fn App() -> Element {
 /// the keyring slot is empty (user hasn't logged in yet). `Err(msg)`
 /// is reserved for real misconfigurations the user should see in the
 /// UI (malformed base URL, keyring backend failure).
+/// Build the per-process auth dependencies from the build-baked
+/// bootstrap.
+///
+/// Synchronous on purpose: the previous shape — initialize with
+/// `None`/`None` then populate via `use_effect(bootstrap_config)` —
+/// raced the `_db_init_task` `use_resource` and could leave a
+/// signed-in user offline on every launch, because the resource read
+/// `auth_deps` before the effect fired (#235 review). Building
+/// everything here at signal init eliminates the race entirely;
+/// `bootstrap` is constant for the lifetime of the process so there
+/// is nothing for the reactive layer to react to anyway.
+fn build_auth_deps(bootstrap: &BootstrapConfig) -> AuthDeps {
+    let api_base_url = bootstrap
+        .dirt_api_base_url
+        .as_deref()
+        .filter(|value| !value.trim().is_empty());
+    let (auth_client, normalized_url) =
+        api_base_url.map_or((None, None), |url| match AuthClient::new(url) {
+            Ok(client) => {
+                let normalized = client.base_url().to_string();
+                (Some(Arc::new(client)), Some(normalized))
+            }
+            Err(err) => {
+                tracing::error!("AuthClient build failed for `{url}`: {err}");
+                (None, None)
+            }
+        });
+    AuthDeps {
+        auth_client,
+        token_store: Arc::new(KeyringTokenStore::new(KEYRING_SERVICE, KEYRING_ACCOUNT)),
+        api_base_url: normalized_url,
+    }
+}
+
 fn hydrate_session(deps: &AuthDeps) -> Result<Option<SessionApiClient>, String> {
     let Some(auth_client) = deps.auth_client.as_ref() else {
         // No base URL configured — sync just isn't available. Not an

--- a/crates/dirt-desktop/src/bootstrap_config.rs
+++ b/crates/dirt-desktop/src/bootstrap_config.rs
@@ -18,7 +18,10 @@ pub fn load_bootstrap_config() -> BootstrapConfig {
 }
 
 fn normalize_desktop_bootstrap(mut config: BootstrapConfig) -> BootstrapConfig {
-    config.dirt_api_base_url = config.dirt_api_base_url.as_deref().map(normalize_desktop_url);
+    config.dirt_api_base_url = config
+        .dirt_api_base_url
+        .as_deref()
+        .map(normalize_desktop_url);
     config
 }
 

--- a/crates/dirt-desktop/src/bootstrap_config.rs
+++ b/crates/dirt-desktop/src/bootstrap_config.rs
@@ -2,9 +2,12 @@
 //!
 //! Re-exports the shared `BootstrapConfig` from dirt-core and provides
 //! the desktop-specific `load_bootstrap_config` function that reads the
-//! embedded build-time JSON.
+//! embedded build-time JSON. After the Phase-1 Supabase-removal
+//! rewrite there is no runtime manifest fetch — `build.rs` writes the
+//! `DIRT_API_BASE_URL` directly into `desktop-bootstrap.json` and we
+//! `include_str!` it here.
 
-pub use dirt_core::config::{resolve_bootstrap_config, BootstrapConfig};
+pub use dirt_core::config::BootstrapConfig;
 
 /// Loads the generated desktop bootstrap JSON from `OUT_DIR`.
 pub fn load_bootstrap_config() -> BootstrapConfig {
@@ -15,14 +18,7 @@ pub fn load_bootstrap_config() -> BootstrapConfig {
 }
 
 fn normalize_desktop_bootstrap(mut config: BootstrapConfig) -> BootstrapConfig {
-    config.bootstrap_manifest_url = config
-        .bootstrap_manifest_url
-        .as_deref()
-        .map(normalize_desktop_url);
-    config.dirt_api_base_url = config
-        .dirt_api_base_url
-        .as_deref()
-        .map(normalize_desktop_url);
+    config.dirt_api_base_url = config.dirt_api_base_url.as_deref().map(normalize_desktop_url);
     config
 }
 
@@ -40,15 +36,10 @@ mod tests {
     #[test]
     fn normalize_desktop_bootstrap_rewrites_emulator_hosts() {
         let config = BootstrapConfig {
-            bootstrap_manifest_url: Some("http://10.0.2.2:8080/v1/bootstrap".to_string()),
             dirt_api_base_url: Some("http://10.0.2.2:8080".to_string()),
         };
 
         let normalized = normalize_desktop_bootstrap(config);
-        assert_eq!(
-            normalized.bootstrap_manifest_url.as_deref(),
-            Some("http://127.0.0.1:8080/v1/bootstrap")
-        );
         assert_eq!(
             normalized.dirt_api_base_url.as_deref(),
             Some("http://127.0.0.1:8080")

--- a/crates/dirt-mobile/build.rs
+++ b/crates/dirt-mobile/build.rs
@@ -18,16 +18,13 @@ const QUICK_CAPTURE_WIDGET_XML: &str = r#"<?xml version="1.0" encoding="utf-8"?>
 
 #[derive(Debug, Default, Serialize)]
 struct MobileBootstrapConfig {
-    bootstrap_manifest_url: Option<String>,
     dirt_api_base_url: Option<String>,
 }
 
 fn main() {
     println!("cargo:rerun-if-env-changed=WRY_ANDROID_KOTLIN_FILES_OUT_DIR");
     println!("cargo:rerun-if-env-changed=DIRT_MOBILE_API_BASE_URL");
-    println!("cargo:rerun-if-env-changed=DIRT_MOBILE_BOOTSTRAP_URL");
     println!("cargo:rerun-if-env-changed=DIRT_API_BASE_URL");
-    println!("cargo:rerun-if-env-changed=DIRT_BOOTSTRAP_URL");
     println!("cargo:rerun-if-changed=../../.env.client");
     println!("cargo:rerun-if-changed=../../.env.client.example");
 
@@ -88,24 +85,8 @@ fn write_mobile_bootstrap_config() -> io::Result<()> {
                 .as_deref()
                 .map(normalize_android_emulator_base_url)
         });
-    let bootstrap_manifest_url = env_var_trimmed("DIRT_MOBILE_BOOTSTRAP_URL")
-        .as_deref()
-        .map(normalize_android_emulator_base_url)
-        .or_else(|| {
-            env_var_trimmed("DIRT_BOOTSTRAP_URL")
-                .as_deref()
-                .map(normalize_android_emulator_base_url)
-        })
-        .or_else(|| {
-            dirt_api_base_url
-                .as_deref()
-                .map(|value| format!("{}/v1/bootstrap", value.trim_end_matches('/')))
-        });
 
-    let config = MobileBootstrapConfig {
-        bootstrap_manifest_url,
-        dirt_api_base_url,
-    };
+    let config = MobileBootstrapConfig { dirt_api_base_url };
 
     let content = serde_json::to_string_pretty(&config)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;


### PR DESCRIPTION
## Summary

- **CLI session-auth cutover.** `dirt sync` and `dirt auth status` now read the magic-link session token from the OS keyring slot `(dev.dirt.session, default)` — the same slot `dirt-desktop` plants on login and `dirt-mobile` (Phase 2.7) plants via Android KeyStore. The Phase-1 `DIRT_CLIENT_TOKEN` code path is gone from the CLI entirely.
- **Bootstrap-manifest legacy cleanup.** `/v1/bootstrap` was deleted server-side during the Supabase-removal era (`cato-feature-remove-supabase-auth-design`), but the client-side resolver code lingered and produced a startup 404 warning on every desktop launch. Stripped `resolve_bootstrap_config` / `ManagedBootstrapManifest` / `parse_bootstrap_manifest` from `dirt-core`, dropped the manifest URL field + env reads from desktop/mobile `build.rs`, removed `DIRT_BOOTSTRAP_URL`/`DIRT_DESKTOP_BOOTSTRAP_URL`/`DIRT_MOBILE_BOOTSTRAP_URL` from `.env.client.example`.
- **`Cargo.lock` dioxus 0.7.5 → 0.7.9.** Aligns the workspace with the scoop-installed `dx` CLI 0.7.9; patch-line bump, no breaking changes expected. Folded in because the desktop wouldn't compile against an updated `dx` without it.

## Sync code paths

`dirt sync` (one-shot CLI):
1. Resolve `DIRT_API_BASE_URL` (env > CLI profile).
2. Load `StoredToken` from the keyring; if empty → `CliError::Auth("not signed in; run \`dirt auth login\`...")`.
3. `SessionApiClient::from_store` wraps a refreshing `ApiClient` over the bearer.
4. Run `SyncEngine::run_once(db, session.current(), SOLO_USER_ID)`. On 401, call `session.refresh()` exactly once and retry. A second 401 surfaces as `Auth` ("server rejected the refreshed session; run \`dirt auth login\`"); a transient refresh failure surfaces as `Config` ("retry shortly").
5. Local DB `user_id` stays `SOLO_USER_ID` to match the v3 rows desktop already runs against — the session-uid migration is filed separately (#234).

`dirt auth status`:
1. Resolve API base URL.
2. Single keyring load to extract `email` for the diagnostic line.
3. `SessionApiClient::from_store` + probe via `api.pull(None, Some(1))`.
4. On 401, refresh-and-reprobe once. Output forms (grep-stable contracts):
   - `online: signed in as <email>, server ok`
   - `online: signed in as <email>, server ok (session rotated)`
   - `offline: DIRT_API_BASE_URL not set — local capture works, sync disabled`
   - `offline: not signed in — run \`dirt auth login\` to sign in`
   - `offline: session expired — run \`dirt auth login\` to sign in again`
   - `offline: <cause>; <fix>`

## Tests (10 new)

`sync.rs`:
- `run_session_sync_happy_path`
- `run_session_sync_refreshes_on_401_and_retries`
- `run_session_sync_surfaces_session_expired_with_login_hint`
- `run_session_sync_propagates_transient_refresh_error`
- `build_session_surfaces_not_signed_in_message`

`auth_cmd.rs`:
- `probe_session_status_online_when_session_valid`
- `probe_session_status_refreshes_and_reprobes_on_401`
- `probe_session_status_session_expired_after_failed_refresh`
- `probe_session_status_transient_refresh_error`
- `probe_session_status_offline_on_server_unavailable`

The stale `status_offline_when_no_client_token` test is gone with the `DIRT_CLIENT_TOKEN` code path.

## End-to-end verification (against `https://dirt-api.vercel.app`)

- Desktop magic-link login lands a session at `(dev.dirt.session, default)` in Windows Credential Manager.
- `DIRT_API_BASE_URL=https://dirt-api.vercel.app ./target/debug/dirt.exe auth status` → `online: signed in as catol@abacus.tw, server ok`, exit 0.
- `dirt sync` → `Sync complete — pulled 0 (skipped 0), pushed 0`, exit 0.
- Same keyring slot serves CLI + desktop; login from either gets you sync on both.

## Out of scope (deliberate)

- **Local DB partitioning by `user_id`.** Filed as #234. The shared `dirs::data_dir()/dirt/dirt.db` across CLI/desktop/mobile pre-dates magic-link auth; a multi-account flow would currently leak across sessions on the same machine. Separate scope; substantial enough to deserve a focused PR with a data-migration path.
- **Server-side `DIRT_SERVER_TOKEN` removal.** Phase-1 shared bearer still works on the server for legacy paths. Future cleanup once all clients have ridden the session-token train for a few weeks without complaints.

## Test plan

- [ ] CI green on Linux (cargo fmt, clippy --all-targets --all-features -D warnings, test --workspace, android cross-compile)
- [ ] `gh pr view --json statusCheckRollup` shows all checks pass
- [ ] Manual smoke: `dirt auth login` flow + `dirt sync` against the deployed server (already verified locally during PR prep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)